### PR TITLE
fix: branch regex doesn't capture current branch names

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -8,7 +8,7 @@ const K8S_VERSION = `1.${SPEC_VERSION}.0`;
 
 function k8sVersion() {
   const branch = child.execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-  const match = branch.match(/k8s-(\d\d)-/);
+  const match = branch.match(/k8s-(\d\d)/);
   if (!match) {
     // if we cannot determine the spec version from the branch name, we're probably targetting
     // the default spec version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,9 +157,9 @@ targeting an older kubernetes version. For example, `IngressV1Beta` is not
 available in cdk8s-plus-22, so changing it would require making a change to
 cdk8s-plus-21 and cdk8s-plus-20. If you need to make a pull request to a version
 of cdk8s-plus that isn't the latest version, then **the branch name of your pull
-request must contain `k8s-XX-`** where XX is the version number. For example,
+request must contain `k8s-XX`** where XX is the version number. For example,
 to make a pull request to cdk8s-plus-21, you could name the branch
-`k8s-21-bug-fix`. When you submit the pull request on GitHub, make sure the
+`k8s-21/bug-fix`. When you submit the pull request on GitHub, make sure the
 target branch matches your branch name (in this example, it would be
 `k8s-21/main`). The pull request should target the latest branch that your fix
 applies for - so in the example above, only a PR to `k8s-21/main` is required,


### PR DESCRIPTION
Backport of https://github.com/cdk8s-team/cdk8s-plus/pull/48 to `k8s-21/main`