### PR TITLE
feat: default port when exposing deployment

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -2,16 +2,16 @@
 
 ## Constructs <a name="Constructs"></a>
 
-### ConfigMap <a name="org.cdk8s.plus22.ConfigMap"></a>
+### ConfigMap <a name="org.cdk8s.plus21.ConfigMap"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap)
+- *Implements:* [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
 
 ConfigMap holds configuration data for pods to consume.
 
-#### Initializers <a name="org.cdk8s.plus22.ConfigMap.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.ConfigMap.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ConfigMap;
+import org.cdk8s.plus21.ConfigMap;
 
 ConfigMap.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -20,19 +20,19 @@ ConfigMap.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -40,7 +40,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binaryData`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.parameter.binaryData"></a>
+##### `binaryData`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.parameter.binaryData"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.String`>
 
@@ -56,7 +56,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.parameter.data"></a>
+##### `data`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.parameter.data"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.String`>
 
@@ -73,13 +73,13 @@ You can also add data using `configMap.addData()`.
 
 #### Methods <a name="Methods"></a>
 
-##### `addBinaryData` <a name="org.cdk8s.plus22.ConfigMap.addBinaryData"></a>
+##### `addBinaryData` <a name="org.cdk8s.plus21.ConfigMap.addBinaryData"></a>
 
 ```java
 public addBinaryData(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -87,7 +87,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -95,13 +95,13 @@ The value.
 
 ---
 
-##### `addData` <a name="org.cdk8s.plus22.ConfigMap.addData"></a>
+##### `addData` <a name="org.cdk8s.plus21.ConfigMap.addData"></a>
 
 ```java
 public addData(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -109,7 +109,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -117,14 +117,14 @@ The value.
 
 ---
 
-##### `addDirectory` <a name="org.cdk8s.plus22.ConfigMap.addDirectory"></a>
+##### `addDirectory` <a name="org.cdk8s.plus21.ConfigMap.addDirectory"></a>
 
 ```java
 public addDirectory(java.lang.String localDir)
 public addDirectory(java.lang.String localDir, AddDirectoryOptions options)
 ```
 
-###### `localDir`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.localDir"></a>
+###### `localDir`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.localDir"></a>
 
 - *Type:* `java.lang.String`
 
@@ -132,22 +132,22 @@ A path to a local directory.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.AddDirectoryOptions`](#org.cdk8s.plus22.AddDirectoryOptions)
+- *Type:* [`org.cdk8s.plus21.AddDirectoryOptions`](#org.cdk8s.plus21.AddDirectoryOptions)
 
 Options.
 
 ---
 
-##### `addFile` <a name="org.cdk8s.plus22.ConfigMap.addFile"></a>
+##### `addFile` <a name="org.cdk8s.plus21.ConfigMap.addFile"></a>
 
 ```java
 public addFile(java.lang.String localFile)
 public addFile(java.lang.String localFile, java.lang.String key)
 ```
 
-###### `localFile`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.localFile"></a>
+###### `localFile`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.localFile"></a>
 
 - *Type:* `java.lang.String`
 
@@ -155,7 +155,7 @@ The path to the local file.
 
 ---
 
-###### `key`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -165,15 +165,15 @@ The ConfigMap key (default to the file name).
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMapName` <a name="org.cdk8s.plus22.ConfigMap.fromConfigMapName"></a>
+##### `fromConfigMapName` <a name="org.cdk8s.plus21.ConfigMap.fromConfigMapName"></a>
 
 ```java
-import org.cdk8s.plus22.ConfigMap;
+import org.cdk8s.plus21.ConfigMap;
 
 ConfigMap.fromConfigMapName(java.lang.String name)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
@@ -183,7 +183,7 @@ The name of the config map to import.
 
 #### Properties <a name="Properties"></a>
 
-##### `binaryData`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.property.binaryData"></a>
+##### `binaryData`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.property.binaryData"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getBinaryData();
@@ -197,7 +197,7 @@ Returns a copy. To add data records, use `addBinaryData()` or `addData()`.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.property.data"></a>
+##### `data`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.property.data"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getData();
@@ -212,9 +212,9 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 ---
 
 
-### Deployment <a name="org.cdk8s.plus22.Deployment"></a>
+### Deployment <a name="org.cdk8s.plus21.Deployment"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
+- *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
 
 A Deployment provides declarative updates for Pods and ReplicaSets.
 
@@ -241,10 +241,10 @@ The following are typical use cases for Deployments:
 - Use the status of the Deployment as an indicator that a rollout has stuck.
 - Clean up older ReplicaSets that you don't need anymore.
 
-#### Initializers <a name="org.cdk8s.plus22.Deployment.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Deployment.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Deployment;
+import org.cdk8s.plus21.Deployment;
 
 Deployment.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -258,19 +258,19 @@ Deployment.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -278,9 +278,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -292,9 +292,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -303,9 +303,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -321,9 +321,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -334,7 +334,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.podMetadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -342,7 +342,7 @@ The pod metadata.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.defaultSelector"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* true
@@ -354,7 +354,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.replicas"></a>
 
 - *Type:* `java.lang.Number`
 - *Default:* 1
@@ -365,52 +365,52 @@ Number of desired pods.
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus22.Deployment.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus21.Deployment.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
+- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus22.Deployment.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus21.Deployment.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
+- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
 
 ---
 
-##### `expose` <a name="org.cdk8s.plus22.Deployment.expose"></a>
+##### `expose` <a name="org.cdk8s.plus21.Deployment.expose"></a>
 
 ```java
 public expose()
 public expose(ExposeOptions options)
 ```
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Deployment.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Deployment.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.ExposeOptions`](#org.cdk8s.plus22.ExposeOptions)
+- *Type:* [`org.cdk8s.plus21.ExposeOptions`](#org.cdk8s.plus21.ExposeOptions)
 
 Options to determine details of the service and port exposed.
 
 ---
 
-##### `selectByLabel` <a name="org.cdk8s.plus22.Deployment.selectByLabel"></a>
+##### `selectByLabel` <a name="org.cdk8s.plus21.Deployment.selectByLabel"></a>
 
 ```java
 public selectByLabel(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -418,7 +418,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -429,13 +429,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
 
 The containers belonging to the pod.
 
@@ -443,7 +443,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `labelSelector`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.labelSelector"></a>
+##### `labelSelector`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.labelSelector"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getLabelSelector();
@@ -457,7 +457,7 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -469,7 +469,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.replicas"></a>
 
 ```java
 public java.lang.Number getReplicas();
@@ -481,13 +481,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 
 The volumes associated with this pod.
 
@@ -495,32 +495,32 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.Deployment.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.Deployment.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.Deployment.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.Deployment.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Ingress <a name="org.cdk8s.plus22.Ingress"></a>
+### IngressV1Beta1 <a name="org.cdk8s.plus21.IngressV1Beta1"></a>
 
 Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend.
 
@@ -528,32 +528,32 @@ An Ingress can be configured to give services
 externally-reachable urls, load balance traffic, terminate SSL, offer name
 based virtual hosting etc.
 
-#### Initializers <a name="org.cdk8s.plus22.Ingress.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.IngressV1Beta1.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Ingress;
+import org.cdk8s.plus21.IngressV1Beta1;
 
-Ingress.Builder.create(Construct scope, java.lang.String id)
+IngressV1Beta1.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
-//  .defaultBackend(IngressBackend)
-//  .rules(java.util.List<IngressRule>)
-//  .tls(java.util.List<IngressTls>)
+//  .defaultBackend(IngressV1Beta1Backend)
+//  .rules(java.util.List<IngressV1Beta1Rule>)
+//  .tls(java.util.List<IngressV1Beta1Tls>)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -561,9 +561,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `defaultBackend`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.parameter.defaultBackend"></a>
+##### `defaultBackend`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.parameter.defaultBackend"></a>
 
-- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
+- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
 
 The default backend services requests that do not match any rule.
 
@@ -572,9 +572,9 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.parameter.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.parameter.rules"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.IngressRule`](#org.cdk8s.plus22.IngressRule)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Rule`](#org.cdk8s.plus21.IngressV1Beta1Rule)>
 
 Routing rules for this ingress.
 
@@ -587,9 +587,9 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.parameter.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.parameter.tls"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.IngressTls`](#org.cdk8s.plus22.IngressTls)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Tls`](#org.cdk8s.plus21.IngressV1Beta1Tls)>
 
 TLS settings for this ingress.
 
@@ -603,27 +603,27 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 #### Methods <a name="Methods"></a>
 
-##### `addDefaultBackend` <a name="org.cdk8s.plus22.Ingress.addDefaultBackend"></a>
+##### `addDefaultBackend` <a name="org.cdk8s.plus21.IngressV1Beta1.addDefaultBackend"></a>
 
 ```java
-public addDefaultBackend(IngressBackend backend)
+public addDefaultBackend(IngressV1Beta1Backend backend)
 ```
 
-###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
+- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
 
 The backend to use for requests that do not match any rule.
 
 ---
 
-##### `addHostDefaultBackend` <a name="org.cdk8s.plus22.Ingress.addHostDefaultBackend"></a>
+##### `addHostDefaultBackend` <a name="org.cdk8s.plus21.IngressV1Beta1.addHostDefaultBackend"></a>
 
 ```java
-public addHostDefaultBackend(java.lang.String host, IngressBackend backend)
+public addHostDefaultBackend(java.lang.String host, IngressV1Beta1Backend backend)
 ```
 
-###### `host`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.host"></a>
 
 - *Type:* `java.lang.String`
 
@@ -631,22 +631,21 @@ The host name to match.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
+- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
 
 The backend to route to.
 
 ---
 
-##### `addHostRule` <a name="org.cdk8s.plus22.Ingress.addHostRule"></a>
+##### `addHostRule` <a name="org.cdk8s.plus21.IngressV1Beta1.addHostRule"></a>
 
 ```java
-public addHostRule(java.lang.String host, java.lang.String path, IngressBackend backend)
-public addHostRule(java.lang.String host, java.lang.String path, IngressBackend backend, HttpIngressPathType pathType)
+public addHostRule(java.lang.String host, java.lang.String path, IngressV1Beta1Backend backend)
 ```
 
-###### `host`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.host"></a>
 
 - *Type:* `java.lang.String`
 
@@ -654,7 +653,7 @@ The host name.
 
 ---
 
-###### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.path"></a>
 
 - *Type:* `java.lang.String`
 
@@ -662,30 +661,21 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
+- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
 
 The backend to route requests to.
 
 ---
 
-###### `pathType`<sup>Optional</sup> <a name="org.cdk8s.plus22.Ingress.parameter.pathType"></a>
-
-- *Type:* [`org.cdk8s.plus22.HttpIngressPathType`](#org.cdk8s.plus22.HttpIngressPathType)
-
-How the path is matched against request paths.
-
----
-
-##### `addRule` <a name="org.cdk8s.plus22.Ingress.addRule"></a>
+##### `addRule` <a name="org.cdk8s.plus21.IngressV1Beta1.addRule"></a>
 
 ```java
-public addRule(java.lang.String path, IngressBackend backend)
-public addRule(java.lang.String path, IngressBackend backend, HttpIngressPathType pathType)
+public addRule(java.lang.String path, IngressV1Beta1Backend backend)
 ```
 
-###### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.path"></a>
 
 - *Type:* `java.lang.String`
 
@@ -693,54 +683,46 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
+- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
 
 The backend to route requests to.
 
 ---
 
-###### `pathType`<sup>Optional</sup> <a name="org.cdk8s.plus22.Ingress.parameter.pathType"></a>
-
-- *Type:* [`org.cdk8s.plus22.HttpIngressPathType`](#org.cdk8s.plus22.HttpIngressPathType)
-
-How the path is matched against request paths.
-
----
-
-##### `addRules` <a name="org.cdk8s.plus22.Ingress.addRules"></a>
+##### `addRules` <a name="org.cdk8s.plus21.IngressV1Beta1.addRules"></a>
 
 ```java
-public addRules(IngressRule rules)
+public addRules(IngressV1Beta1Rule rules)
 ```
 
-###### `rules`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.rules"></a>
+###### `rules`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.rules"></a>
 
-- *Type:* [`org.cdk8s.plus22.IngressRule`](#org.cdk8s.plus22.IngressRule)
+- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Rule`](#org.cdk8s.plus21.IngressV1Beta1Rule)
 
 The rules to add.
 
 ---
 
-##### `addTls` <a name="org.cdk8s.plus22.Ingress.addTls"></a>
+##### `addTls` <a name="org.cdk8s.plus21.IngressV1Beta1.addTls"></a>
 
 ```java
-public addTls(java.util.List<IngressTls> tls)
+public addTls(java.util.List<IngressV1Beta1Tls> tls)
 ```
 
-###### `tls`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.tls"></a>
+###### `tls`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.tls"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.IngressTls`](#org.cdk8s.plus22.IngressTls)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Tls`](#org.cdk8s.plus21.IngressV1Beta1Tls)>
 
 ---
 
 
 
 
-### Job <a name="org.cdk8s.plus22.Job"></a>
+### Job <a name="org.cdk8s.plus21.Job"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
+- *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
 
 A Job creates one or more Pods and ensures that a specified number of them successfully terminate.
 
@@ -750,10 +732,10 @@ Deleting a Job will clean up the Pods it created. A simple case is to create one
 The Job object will start a new Pod if the first Pod fails or is deleted (for example due to a node hardware failure or a node reboot).
 You can also use a Job to run multiple Pods in parallel.
 
-#### Initializers <a name="org.cdk8s.plus22.Job.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Job.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Job;
+import org.cdk8s.plus21.Job;
 
 Job.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -768,19 +750,19 @@ Job.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -788,9 +770,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -802,9 +784,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -813,9 +795,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -831,9 +813,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -844,7 +826,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.podMetadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -852,7 +834,7 @@ The pod metadata.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.activeDeadline"></a>
 
 - *Type:* [`org.cdk8s.Duration`](#org.cdk8s.Duration)
 - *Default:* If unset, then there is no deadline.
@@ -861,7 +843,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.backoffLimit"></a>
 
 - *Type:* `java.lang.Number`
 - *Default:* If not set, system defaults to 6.
@@ -870,7 +852,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.ttlAfterFinished"></a>
 
 - *Type:* [`org.cdk8s.Duration`](#org.cdk8s.Duration)
 - *Default:* If this field is unset, the Job won't be automatically deleted.
@@ -888,40 +870,40 @@ field is alpha-level and is only honored by servers that enable the
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus22.Job.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus21.Job.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
+- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus22.Job.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus21.Job.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
+- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
 
 The containers belonging to the pod.
 
@@ -929,7 +911,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -941,13 +923,13 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 
 The volumes associated with this pod.
 
@@ -955,7 +937,7 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.activeDeadline"></a>
 
 ```java
 public Duration getActiveDeadline();
@@ -969,7 +951,7 @@ If undefined, there is no deadline.
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.backoffLimit"></a>
 
 ```java
 public java.lang.Number getBackoffLimit();
@@ -981,31 +963,31 @@ Number of retries before marking failed.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.ttlAfterFinished"></a>
 
 ```java
 public Duration getTtlAfterFinished();
@@ -1018,19 +1000,19 @@ TTL before the job is deleted after it is finished.
 ---
 
 
-### Pod <a name="org.cdk8s.plus22.Pod"></a>
+### Pod <a name="org.cdk8s.plus21.Pod"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IPodSpec`](#org.cdk8s.plus22.IPodSpec)
+- *Implements:* [`org.cdk8s.plus21.IPodSpec`](#org.cdk8s.plus21.IPodSpec)
 
 Pod is a collection of containers that can run on a host.
 
 This resource is
 created by clients and scheduled onto hosts.
 
-#### Initializers <a name="org.cdk8s.plus22.Pod.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Pod.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Pod;
+import org.cdk8s.plus21.Pod;
 
 Pod.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1041,19 +1023,19 @@ Pod.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1061,9 +1043,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1075,9 +1057,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -1086,9 +1068,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -1104,9 +1086,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -1119,40 +1101,40 @@ You can also add volumes later using `podSpec.addVolume()`
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus22.Pod.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus21.Pod.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
+- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus22.Pod.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus21.Pod.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
+- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
 
 The containers belonging to the pod.
 
@@ -1160,13 +1142,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 
 The volumes associated with this pod.
 
@@ -1174,51 +1156,51 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.Pod.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.Pod.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.Pod.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.Pod.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Resource <a name="org.cdk8s.plus22.Resource"></a>
+### Resource <a name="org.cdk8s.plus21.Resource"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource)
+- *Implements:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
 
 Base class for all Kubernetes objects in stdk8s.
 
 Represents a single
 resource.
 
-#### Initializers <a name="org.cdk8s.plus22.Resource.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Resource.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Resource;
+import org.cdk8s.plus21.Resource;
 
 Resource.Builder.create(Construct scope, java.lang.String id)
 //  .nodeFactory(INodeFactory)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Resource.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Resource.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
@@ -1226,7 +1208,7 @@ The scope in which to define this construct.
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Resource.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Resource.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1251,7 +1233,7 @@ A factory for attaching `Node`s to the construct.
 
 #### Properties <a name="Properties"></a>
 
-##### `metadata`<sup>Required</sup> <a name="org.cdk8s.plus22.Resource.property.metadata"></a>
+##### `metadata`<sup>Required</sup> <a name="org.cdk8s.plus21.Resource.property.metadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getMetadata();
@@ -1261,7 +1243,7 @@ public ApiObjectMetadataDefinition getMetadata();
 
 ---
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Resource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Resource.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -1274,9 +1256,9 @@ The name of this API object.
 ---
 
 
-### Secret <a name="org.cdk8s.plus22.Secret"></a>
+### Secret <a name="org.cdk8s.plus21.Secret"></a>
 
-- *Implements:* [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
+- *Implements:* [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
 
 Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 
@@ -1286,10 +1268,10 @@ definition or in a container image.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
 
-#### Initializers <a name="org.cdk8s.plus22.Secret.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Secret.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Secret;
+import org.cdk8s.plus21.Secret;
 
 Secret.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1298,19 +1280,19 @@ Secret.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1318,7 +1300,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.stringData"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.String`>
 
@@ -1331,7 +1313,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.type"></a>
+##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.type"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* undefined - Don't set a type.
@@ -1345,13 +1327,13 @@ handling of secret data by various controllers.
 
 #### Methods <a name="Methods"></a>
 
-##### `addStringData` <a name="org.cdk8s.plus22.Secret.addStringData"></a>
+##### `addStringData` <a name="org.cdk8s.plus21.Secret.addStringData"></a>
 
 ```java
 public addStringData(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1359,7 +1341,7 @@ Key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1367,13 +1349,13 @@ Value.
 
 ---
 
-##### `getStringData` <a name="org.cdk8s.plus22.Secret.getStringData"></a>
+##### `getStringData` <a name="org.cdk8s.plus21.Secret.getStringData"></a>
 
 ```java
 public getStringData(java.lang.String key)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1383,15 +1365,15 @@ Key.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromSecretName` <a name="org.cdk8s.plus22.Secret.fromSecretName"></a>
+##### `fromSecretName` <a name="org.cdk8s.plus21.Secret.fromSecretName"></a>
 
 ```java
-import org.cdk8s.plus22.Secret;
+import org.cdk8s.plus21.Secret;
 
 Secret.fromSecretName(java.lang.String name)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1401,7 +1383,7 @@ The name of the secret to reference.
 
 
 
-### Service <a name="org.cdk8s.plus22.Service"></a>
+### Service <a name="org.cdk8s.plus21.Service"></a>
 
 An abstract way to expose an application running on a set of Pods as a network service.
 
@@ -1417,10 +1399,10 @@ If you're able to use Kubernetes APIs for service discovery in your application,
 that get updated whenever the set of Pods in a Service changes. For non-native applications, Kubernetes offers ways to place a network port
 or load balancer in between your application and the backend Pods.
 
-#### Initializers <a name="org.cdk8s.plus22.Service.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Service.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Service;
+import org.cdk8s.plus21.Service;
 
 Service.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1433,19 +1415,19 @@ Service.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1453,7 +1435,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.clusterIP"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* Automatically assigned.
@@ -1471,7 +1453,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `externalIPs`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.externalIPs"></a>
+##### `externalIPs`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.externalIPs"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 - *Default:* No external IPs.
@@ -1485,7 +1467,7 @@ Kubernetes system.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.externalName"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* No external name.
@@ -1494,7 +1476,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.loadBalancerSourceRanges"></a>
+##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.loadBalancerSourceRanges"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 
@@ -1504,9 +1486,9 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.ports"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ServicePort`](#org.cdk8s.plus22.ServicePort)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ServicePort`](#org.cdk8s.plus21.ServicePort)>
 
 The port exposed by this service.
 
@@ -1514,9 +1496,9 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.type"></a>
+##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.type"></a>
 
-- *Type:* [`org.cdk8s.plus22.ServiceType`](#org.cdk8s.plus22.ServiceType)
+- *Type:* [`org.cdk8s.plus21.ServiceType`](#org.cdk8s.plus21.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -1527,36 +1509,36 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 #### Methods <a name="Methods"></a>
 
-##### `addDeployment` <a name="org.cdk8s.plus22.Service.addDeployment"></a>
+##### `addDeployment` <a name="org.cdk8s.plus21.Service.addDeployment"></a>
 
 ```java
 public addDeployment(Deployment deployment)
 public addDeployment(Deployment deployment, AddDeploymentOptions options)
 ```
 
-###### `deployment`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.deployment"></a>
+###### `deployment`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.deployment"></a>
 
-- *Type:* [`org.cdk8s.plus22.Deployment`](#org.cdk8s.plus22.Deployment)
+- *Type:* [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment)
 
 The deployment to expose.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Service.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Service.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.AddDeploymentOptions`](#org.cdk8s.plus22.AddDeploymentOptions)
+- *Type:* [`org.cdk8s.plus21.AddDeploymentOptions`](#org.cdk8s.plus21.AddDeploymentOptions)
 
 Optional settings for the port.
 
 ---
 
-##### `addSelector` <a name="org.cdk8s.plus22.Service.addSelector"></a>
+##### `addSelector` <a name="org.cdk8s.plus21.Service.addSelector"></a>
 
 ```java
 public addSelector(java.lang.String label, java.lang.String value)
 ```
 
-###### `label`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.label"></a>
+###### `label`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.label"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1564,7 +1546,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1572,14 +1554,14 @@ The label value.
 
 ---
 
-##### `serve` <a name="org.cdk8s.plus22.Service.serve"></a>
+##### `serve` <a name="org.cdk8s.plus21.Service.serve"></a>
 
 ```java
 public serve(java.lang.Number port)
 public serve(java.lang.Number port, ServicePortOptions options)
 ```
 
-###### `port`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.port"></a>
+###### `port`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.port"></a>
 
 - *Type:* `java.lang.Number`
 
@@ -1587,22 +1569,22 @@ The port definition.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Service.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Service.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.ServicePortOptions`](#org.cdk8s.plus22.ServicePortOptions)
+- *Type:* [`org.cdk8s.plus21.ServicePortOptions`](#org.cdk8s.plus21.ServicePortOptions)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `ports`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.property.ports"></a>
+##### `ports`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.property.ports"></a>
 
 ```java
 public java.util.List<ServicePort> getPorts();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ServicePort`](#org.cdk8s.plus22.ServicePort)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ServicePort`](#org.cdk8s.plus21.ServicePort)>
 
 Ports for this service.
 
@@ -1610,7 +1592,7 @@ Use `serve()` to expose additional service ports.
 
 ---
 
-##### `selector`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.property.selector"></a>
+##### `selector`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.property.selector"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getSelector();
@@ -1622,19 +1604,19 @@ Returns the labels which are used to select pods for this service.
 
 ---
 
-##### `type`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.property.type"></a>
+##### `type`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.property.type"></a>
 
 ```java
 public ServiceType getType();
 ```
 
-- *Type:* [`org.cdk8s.plus22.ServiceType`](#org.cdk8s.plus22.ServiceType)
+- *Type:* [`org.cdk8s.plus21.ServiceType`](#org.cdk8s.plus21.ServiceType)
 
 Determines how the Service is exposed.
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus22.Service.property.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus21.Service.property.clusterIP"></a>
 
 ```java
 public java.lang.String getClusterIP();
@@ -1646,7 +1628,7 @@ The IP address of the service and is usually assigned randomly by the master.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus22.Service.property.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus21.Service.property.externalName"></a>
 
 ```java
 public java.lang.String getExternalName();
@@ -1659,9 +1641,9 @@ The externalName to be used for EXTERNAL_NAME types.
 ---
 
 
-### ServiceAccount <a name="org.cdk8s.plus22.ServiceAccount"></a>
+### ServiceAccount <a name="org.cdk8s.plus21.ServiceAccount"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Implements:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 A service account provides an identity for processes that run in a Pod.
 
@@ -1674,10 +1656,10 @@ example, default).
 
 > https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account
 
-#### Initializers <a name="org.cdk8s.plus22.ServiceAccount.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.ServiceAccount.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ServiceAccount;
+import org.cdk8s.plus21.ServiceAccount;
 
 ServiceAccount.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1685,19 +1667,19 @@ ServiceAccount.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1705,9 +1687,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountProps.parameter.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountProps.parameter.secrets"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)>
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -1717,15 +1699,15 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 #### Methods <a name="Methods"></a>
 
-##### `addSecret` <a name="org.cdk8s.plus22.ServiceAccount.addSecret"></a>
+##### `addSecret` <a name="org.cdk8s.plus21.ServiceAccount.addSecret"></a>
 
 ```java
 public addSecret(ISecret secret)
 ```
 
-###### `secret`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.parameter.secret"></a>
+###### `secret`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.parameter.secret"></a>
 
-- *Type:* [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
+- *Type:* [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
 
 The secret.
 
@@ -1733,15 +1715,15 @@ The secret.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromServiceAccountName` <a name="org.cdk8s.plus22.ServiceAccount.fromServiceAccountName"></a>
+##### `fromServiceAccountName` <a name="org.cdk8s.plus21.ServiceAccount.fromServiceAccountName"></a>
 
 ```java
-import org.cdk8s.plus22.ServiceAccount;
+import org.cdk8s.plus21.ServiceAccount;
 
 ServiceAccount.fromServiceAccountName(java.lang.String name)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1751,13 +1733,13 @@ The name of the service account resource.
 
 #### Properties <a name="Properties"></a>
 
-##### `secrets`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.property.secrets"></a>
+##### `secrets`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.property.secrets"></a>
 
 ```java
 public java.util.List<ISecret> getSecrets();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)>
 
 List of secrets allowed to be used by pods running using this service account.
 
@@ -1766,9 +1748,9 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
-### StatefulSet <a name="org.cdk8s.plus22.StatefulSet"></a>
+### StatefulSet <a name="org.cdk8s.plus21.StatefulSet"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
+- *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
 
 StatefulSet is the workload API object used to manage stateful applications.
 
@@ -1795,10 +1777,10 @@ StatefulSets are valuable for applications that require one or more of the follo
 - Ordered, graceful deployment and scaling.
 - Ordered, automated rolling updates.
 
-#### Initializers <a name="org.cdk8s.plus22.StatefulSet.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.StatefulSet.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.StatefulSet;
+import org.cdk8s.plus21.StatefulSet;
 
 StatefulSet.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1814,19 +1796,19 @@ StatefulSet.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1834,9 +1816,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1848,9 +1830,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -1859,9 +1841,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -1877,9 +1859,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -1890,7 +1872,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.podMetadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1898,15 +1880,15 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.service"></a>
+##### `service`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.service"></a>
 
-- *Type:* [`org.cdk8s.plus22.Service`](#org.cdk8s.plus22.Service)
+- *Type:* [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.defaultSelector"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* true
@@ -1918,16 +1900,16 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `podManagementPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.podManagementPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus22.PodManagementPolicy`](#org.cdk8s.plus22.PodManagementPolicy)
+- *Type:* [`org.cdk8s.plus21.PodManagementPolicy`](#org.cdk8s.plus21.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.replicas"></a>
 
 - *Type:* `java.lang.Number`
 - *Default:* 1
@@ -1938,37 +1920,37 @@ Number of desired pods.
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus22.StatefulSet.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus21.StatefulSet.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
+- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus22.StatefulSet.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus21.StatefulSet.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
+- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
 
 ---
 
-##### `selectByLabel` <a name="org.cdk8s.plus22.StatefulSet.selectByLabel"></a>
+##### `selectByLabel` <a name="org.cdk8s.plus21.StatefulSet.selectByLabel"></a>
 
 ```java
 public selectByLabel(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1976,7 +1958,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1987,13 +1969,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
 
 The containers belonging to the pod.
 
@@ -2001,7 +1983,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `labelSelector`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.labelSelector"></a>
+##### `labelSelector`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.labelSelector"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getLabelSelector();
@@ -2015,19 +1997,19 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `podManagementPolicy`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.podManagementPolicy"></a>
 
 ```java
 public PodManagementPolicy getPodManagementPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.PodManagementPolicy`](#org.cdk8s.plus22.PodManagementPolicy)
+- *Type:* [`org.cdk8s.plus21.PodManagementPolicy`](#org.cdk8s.plus21.PodManagementPolicy)
 
 Management policy to use for the set.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -2039,7 +2021,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.replicas"></a>
 
 ```java
 public java.lang.Number getReplicas();
@@ -2051,13 +2033,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 
 The volumes associated with this pod.
 
@@ -2065,25 +2047,25 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSet.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSet.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSet.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSet.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 The service account used to run this pod.
 
@@ -2092,14 +2074,14 @@ The service account used to run this pod.
 
 ## Structs <a name="Structs"></a>
 
-### AddDeploymentOptions <a name="org.cdk8s.plus22.AddDeploymentOptions"></a>
+### AddDeploymentOptions <a name="org.cdk8s.plus21.AddDeploymentOptions"></a>
 
 Options to add a deployment to a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.AddDeploymentOptions;
+import org.cdk8s.plus21.AddDeploymentOptions;
 
 AddDeploymentOptions.builder()
 //  .name(java.lang.String)
@@ -2110,7 +2092,7 @@ AddDeploymentOptions.builder()
     .build();
 ```
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDeploymentOptions.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -2127,7 +2109,7 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDeploymentOptions.property.nodePort"></a>
 
 ```java
 public java.lang.Number getNodePort();
@@ -2147,13 +2129,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDeploymentOptions.property.protocol"></a>
 
 ```java
 public Protocol getProtocol();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Protocol`](#org.cdk8s.plus22.Protocol)
+- *Type:* [`org.cdk8s.plus21.Protocol`](#org.cdk8s.plus21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -2162,7 +2144,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDeploymentOptions.property.targetPort"></a>
 
 ```java
 public java.lang.Number getTargetPort();
@@ -2175,7 +2157,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDeploymentOptions.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -2188,14 +2170,14 @@ The port number the service will bind to.
 
 ---
 
-### AddDirectoryOptions <a name="org.cdk8s.plus22.AddDirectoryOptions"></a>
+### AddDirectoryOptions <a name="org.cdk8s.plus21.AddDirectoryOptions"></a>
 
 Options for `configmap.addDirectory()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.AddDirectoryOptions;
+import org.cdk8s.plus21.AddDirectoryOptions;
 
 AddDirectoryOptions.builder()
 //  .exclude(java.util.List<java.lang.String>)
@@ -2203,7 +2185,7 @@ AddDirectoryOptions.builder()
     .build();
 ```
 
-##### `exclude`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDirectoryOptions.property.exclude"></a>
+##### `exclude`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDirectoryOptions.property.exclude"></a>
 
 ```java
 public java.util.List<java.lang.String> getExclude();
@@ -2216,7 +2198,7 @@ Glob patterns to exclude when adding files.
 
 ---
 
-##### `keyPrefix`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDirectoryOptions.property.keyPrefix"></a>
+##### `keyPrefix`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDirectoryOptions.property.keyPrefix"></a>
 
 ```java
 public java.lang.String getKeyPrefix();
@@ -2229,14 +2211,14 @@ A prefix to add to all keys in the config map.
 
 ---
 
-### CommandProbeOptions <a name="org.cdk8s.plus22.CommandProbeOptions"></a>
+### CommandProbeOptions <a name="org.cdk8s.plus21.CommandProbeOptions"></a>
 
 Options for `Probe.fromCommand()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.CommandProbeOptions;
+import org.cdk8s.plus21.CommandProbeOptions;
 
 CommandProbeOptions.builder()
 //  .failureThreshold(java.lang.Number)
@@ -2247,7 +2229,7 @@ CommandProbeOptions.builder()
     .build();
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.failureThreshold"></a>
 
 ```java
 public java.lang.Number getFailureThreshold();
@@ -2262,7 +2244,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.initialDelaySeconds"></a>
 
 ```java
 public Duration getInitialDelaySeconds();
@@ -2277,7 +2259,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.periodSeconds"></a>
 
 ```java
 public Duration getPeriodSeconds();
@@ -2292,7 +2274,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.successThreshold"></a>
 
 ```java
 public java.lang.Number getSuccessThreshold();
@@ -2307,7 +2289,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.timeoutSeconds"></a>
 
 ```java
 public Duration getTimeoutSeconds();
@@ -2324,14 +2306,14 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="org.cdk8s.plus22.ConfigMapProps"></a>
+### ConfigMapProps <a name="org.cdk8s.plus21.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ConfigMapProps;
+import org.cdk8s.plus21.ConfigMapProps;
 
 ConfigMapProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -2340,7 +2322,7 @@ ConfigMapProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -2352,7 +2334,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binaryData`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.property.binaryData"></a>
+##### `binaryData`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.property.binaryData"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getBinaryData();
@@ -2372,7 +2354,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.property.data"></a>
+##### `data`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.property.data"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getData();
@@ -2391,14 +2373,14 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="org.cdk8s.plus22.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="org.cdk8s.plus21.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ConfigMapVolumeOptions;
+import org.cdk8s.plus21.ConfigMapVolumeOptions;
 
 ConfigMapVolumeOptions.builder()
 //  .defaultMode(java.lang.Number)
@@ -2408,7 +2390,7 @@ ConfigMapVolumeOptions.builder()
     .build();
 ```
 
-##### `defaultMode`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapVolumeOptions.property.defaultMode"></a>
+##### `defaultMode`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapVolumeOptions.property.defaultMode"></a>
 
 ```java
 public java.lang.Number getDefaultMode();
@@ -2428,13 +2410,13 @@ file mode, like fsGroup, and the result can be other mode bits set.
 
 ---
 
-##### `items`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapVolumeOptions.property.items"></a>
+##### `items`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapVolumeOptions.property.items"></a>
 
 ```java
 public java.util.Map<java.lang.String, PathMapping> getItems();
 ```
 
-- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus22.PathMapping`](#org.cdk8s.plus22.PathMapping)>
+- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus21.PathMapping`](#org.cdk8s.plus21.PathMapping)>
 - *Default:* no mapping
 
 If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value.
@@ -2447,7 +2429,7 @@ contain the '..' path or start with '..'.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapVolumeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapVolumeOptions.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -2460,7 +2442,7 @@ The volume name.
 
 ---
 
-##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapVolumeOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapVolumeOptions.property.optional"></a>
 
 ```java
 public java.lang.Boolean getOptional();
@@ -2473,14 +2455,14 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
-### ContainerProps <a name="org.cdk8s.plus22.ContainerProps"></a>
+### ContainerProps <a name="org.cdk8s.plus21.ContainerProps"></a>
 
 Properties for creating a container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ContainerProps;
+import org.cdk8s.plus21.ContainerProps;
 
 ContainerProps.builder()
     .image(java.lang.String)
@@ -2498,7 +2480,7 @@ ContainerProps.builder()
     .build();
 ```
 
-##### `image`<sup>Required</sup> <a name="org.cdk8s.plus22.ContainerProps.property.image"></a>
+##### `image`<sup>Required</sup> <a name="org.cdk8s.plus21.ContainerProps.property.image"></a>
 
 ```java
 public java.lang.String getImage();
@@ -2510,7 +2492,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.args"></a>
 
 ```java
 public java.util.List<java.lang.String> getArgs();
@@ -2533,7 +2515,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.command"></a>
 
 ```java
 public java.util.List<java.lang.String> getCommand();
@@ -2551,13 +2533,13 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.env"></a>
+##### `env`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.env"></a>
 
 ```java
 public java.util.Map<java.lang.String, EnvValue> getEnv();
 ```
 
-- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus22.EnvValue`](#org.cdk8s.plus22.EnvValue)>
+- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus21.EnvValue`](#org.cdk8s.plus21.EnvValue)>
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -2566,26 +2548,26 @@ Cannot be updated.
 
 ---
 
-##### `imagePullPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.imagePullPolicy"></a>
 
 ```java
 public ImagePullPolicy getImagePullPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.ImagePullPolicy`](#org.cdk8s.plus22.ImagePullPolicy)
+- *Type:* [`org.cdk8s.plus21.ImagePullPolicy`](#org.cdk8s.plus21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.liveness"></a>
 
 ```java
 public Probe getLiveness();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
+- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -2594,7 +2576,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -2609,7 +2591,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -2624,26 +2606,26 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.readiness"></a>
 
 ```java
 public Probe getReadiness();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
+- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.startup"></a>
 
 ```java
 public Probe getStartup();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
+- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -2652,13 +2634,13 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volumeMounts`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.volumeMounts"></a>
+##### `volumeMounts`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.volumeMounts"></a>
 
 ```java
 public java.util.List<VolumeMount> getVolumeMounts();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.VolumeMount`](#org.cdk8s.plus22.VolumeMount)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.VolumeMount`](#org.cdk8s.plus21.VolumeMount)>
 
 Pod volumes to mount into the container's filesystem.
 
@@ -2666,7 +2648,7 @@ Cannot be updated.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.workingDir"></a>
 
 ```java
 public java.lang.String getWorkingDir();
@@ -2681,14 +2663,14 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-### DeploymentProps <a name="org.cdk8s.plus22.DeploymentProps"></a>
+### DeploymentProps <a name="org.cdk8s.plus21.DeploymentProps"></a>
 
 Properties for initialization of `Deployment`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.DeploymentProps;
+import org.cdk8s.plus21.DeploymentProps;
 
 DeploymentProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -2702,7 +2684,7 @@ DeploymentProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -2714,13 +2696,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2732,13 +2714,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2747,13 +2729,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2769,13 +2751,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2786,7 +2768,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadata getPodMetadata();
@@ -2798,7 +2780,7 @@ The pod metadata.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.defaultSelector"></a>
 
 ```java
 public java.lang.Boolean getDefaultSelector();
@@ -2814,7 +2796,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.replicas"></a>
 
 ```java
 public java.lang.Number getReplicas();
@@ -2827,14 +2809,14 @@ Number of desired pods.
 
 ---
 
-### EmptyDirVolumeOptions <a name="org.cdk8s.plus22.EmptyDirVolumeOptions"></a>
+### EmptyDirVolumeOptions <a name="org.cdk8s.plus21.EmptyDirVolumeOptions"></a>
 
 Options for volumes populated with an empty directory.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.EmptyDirVolumeOptions;
+import org.cdk8s.plus21.EmptyDirVolumeOptions;
 
 EmptyDirVolumeOptions.builder()
 //  .medium(EmptyDirMedium)
@@ -2842,13 +2824,13 @@ EmptyDirVolumeOptions.builder()
     .build();
 ```
 
-##### `medium`<sup>Optional</sup> <a name="org.cdk8s.plus22.EmptyDirVolumeOptions.property.medium"></a>
+##### `medium`<sup>Optional</sup> <a name="org.cdk8s.plus21.EmptyDirVolumeOptions.property.medium"></a>
 
 ```java
 public EmptyDirMedium getMedium();
 ```
 
-- *Type:* [`org.cdk8s.plus22.EmptyDirMedium`](#org.cdk8s.plus22.EmptyDirMedium)
+- *Type:* [`org.cdk8s.plus21.EmptyDirMedium`](#org.cdk8s.plus21.EmptyDirMedium)
 - *Default:* EmptyDirMedium.DEFAULT
 
 By default, emptyDir volumes are stored on whatever medium is backing the node - that might be disk or SSD or network storage, depending on your environment.
@@ -2861,7 +2843,7 @@ against your Container's memory limit.
 
 ---
 
-##### `sizeLimit`<sup>Optional</sup> <a name="org.cdk8s.plus22.EmptyDirVolumeOptions.property.sizeLimit"></a>
+##### `sizeLimit`<sup>Optional</sup> <a name="org.cdk8s.plus21.EmptyDirVolumeOptions.property.sizeLimit"></a>
 
 ```java
 public Size getSizeLimit();
@@ -2879,21 +2861,21 @@ here and the sum of memory limits of all containers in a pod.
 
 ---
 
-### EnvValueFromConfigMapOptions <a name="org.cdk8s.plus22.EnvValueFromConfigMapOptions"></a>
+### EnvValueFromConfigMapOptions <a name="org.cdk8s.plus21.EnvValueFromConfigMapOptions"></a>
 
 Options to specify an envionment variable value from a ConfigMap key.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.EnvValueFromConfigMapOptions;
+import org.cdk8s.plus21.EnvValueFromConfigMapOptions;
 
 EnvValueFromConfigMapOptions.builder()
 //  .optional(java.lang.Boolean)
     .build();
 ```
 
-##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValueFromConfigMapOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValueFromConfigMapOptions.property.optional"></a>
 
 ```java
 public java.lang.Boolean getOptional();
@@ -2906,21 +2888,21 @@ Specify whether the ConfigMap or its key must be defined.
 
 ---
 
-### EnvValueFromProcessOptions <a name="org.cdk8s.plus22.EnvValueFromProcessOptions"></a>
+### EnvValueFromProcessOptions <a name="org.cdk8s.plus21.EnvValueFromProcessOptions"></a>
 
 Options to specify an environment variable value from the process environment.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.EnvValueFromProcessOptions;
+import org.cdk8s.plus21.EnvValueFromProcessOptions;
 
 EnvValueFromProcessOptions.builder()
 //  .required(java.lang.Boolean)
     .build();
 ```
 
-##### `required`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValueFromProcessOptions.property.required"></a>
+##### `required`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValueFromProcessOptions.property.required"></a>
 
 ```java
 public java.lang.Boolean getRequired();
@@ -2935,21 +2917,21 @@ If this is set to true, and the key does not exist, an error will thrown.
 
 ---
 
-### EnvValueFromSecretOptions <a name="org.cdk8s.plus22.EnvValueFromSecretOptions"></a>
+### EnvValueFromSecretOptions <a name="org.cdk8s.plus21.EnvValueFromSecretOptions"></a>
 
 Options to specify an environment variable value from a Secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.EnvValueFromSecretOptions;
+import org.cdk8s.plus21.EnvValueFromSecretOptions;
 
 EnvValueFromSecretOptions.builder()
 //  .optional(java.lang.Boolean)
     .build();
 ```
 
-##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValueFromSecretOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValueFromSecretOptions.property.optional"></a>
 
 ```java
 public java.lang.Boolean getOptional();
@@ -2962,14 +2944,14 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="org.cdk8s.plus22.ExposeOptions"></a>
+### ExposeOptions <a name="org.cdk8s.plus21.ExposeOptions"></a>
 
 Options for exposing a deployment via a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ExposeOptions;
+import org.cdk8s.plus21.ExposeOptions;
 
 ExposeOptions.builder()
 //  .name(java.lang.String)
@@ -2980,7 +2962,7 @@ ExposeOptions.builder()
     .build();
 ```
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -2995,7 +2977,7 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -3008,13 +2990,13 @@ The port that the service should serve on.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.protocol"></a>
 
 ```java
 public Protocol getProtocol();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Protocol`](#org.cdk8s.plus22.Protocol)
+- *Type:* [`org.cdk8s.plus21.Protocol`](#org.cdk8s.plus21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -3023,20 +3005,20 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `serviceType`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.serviceType"></a>
+##### `serviceType`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.serviceType"></a>
 
 ```java
 public ServiceType getServiceType();
 ```
 
-- *Type:* [`org.cdk8s.plus22.ServiceType`](#org.cdk8s.plus22.ServiceType)
+- *Type:* [`org.cdk8s.plus21.ServiceType`](#org.cdk8s.plus21.ServiceType)
 - *Default:* ClusterIP.
 
 The type of the exposed service.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.targetPort"></a>
 
 ```java
 public java.lang.Number getTargetPort();
@@ -3049,14 +3031,14 @@ The port number the service will redirect to.
 
 ---
 
-### HttpGetProbeOptions <a name="org.cdk8s.plus22.HttpGetProbeOptions"></a>
+### HttpGetProbeOptions <a name="org.cdk8s.plus21.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.HttpGetProbeOptions;
+import org.cdk8s.plus21.HttpGetProbeOptions;
 
 HttpGetProbeOptions.builder()
 //  .failureThreshold(java.lang.Number)
@@ -3068,7 +3050,7 @@ HttpGetProbeOptions.builder()
     .build();
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.failureThreshold"></a>
 
 ```java
 public java.lang.Number getFailureThreshold();
@@ -3083,7 +3065,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.initialDelaySeconds"></a>
 
 ```java
 public Duration getInitialDelaySeconds();
@@ -3098,7 +3080,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.periodSeconds"></a>
 
 ```java
 public Duration getPeriodSeconds();
@@ -3113,7 +3095,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.successThreshold"></a>
 
 ```java
 public java.lang.Number getSuccessThreshold();
@@ -3128,7 +3110,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.timeoutSeconds"></a>
 
 ```java
 public Duration getTimeoutSeconds();
@@ -3145,7 +3127,7 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -3158,24 +3140,24 @@ The TCP port to use when sending the GET request.
 
 ---
 
-### IngressProps <a name="org.cdk8s.plus22.IngressProps"></a>
+### IngressV1Beta1Props <a name="org.cdk8s.plus21.IngressV1Beta1Props"></a>
 
 Properties for `Ingress`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.IngressProps;
+import org.cdk8s.plus21.IngressV1Beta1Props;
 
-IngressProps.builder()
+IngressV1Beta1Props.builder()
 //  .metadata(ApiObjectMetadata)
-//  .defaultBackend(IngressBackend)
-//  .rules(java.util.List<IngressRule>)
-//  .tls(java.util.List<IngressTls>)
+//  .defaultBackend(IngressV1Beta1Backend)
+//  .rules(java.util.List<IngressV1Beta1Rule>)
+//  .tls(java.util.List<IngressV1Beta1Tls>)
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -3187,13 +3169,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `defaultBackend`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.property.defaultBackend"></a>
+##### `defaultBackend`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.property.defaultBackend"></a>
 
 ```java
-public IngressBackend getDefaultBackend();
+public IngressV1Beta1Backend getDefaultBackend();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
+- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
 
 The default backend services requests that do not match any rule.
 
@@ -3202,13 +3184,13 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.property.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.property.rules"></a>
 
 ```java
-public java.util.List<IngressRule> getRules();
+public java.util.List<IngressV1Beta1Rule> getRules();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.IngressRule`](#org.cdk8s.plus22.IngressRule)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Rule`](#org.cdk8s.plus21.IngressV1Beta1Rule)>
 
 Routing rules for this ingress.
 
@@ -3221,13 +3203,13 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.property.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.property.tls"></a>
 
 ```java
-public java.util.List<IngressTls> getTls();
+public java.util.List<IngressV1Beta1Tls> getTls();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.IngressTls`](#org.cdk8s.plus22.IngressTls)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Tls`](#org.cdk8s.plus21.IngressV1Beta1Tls)>
 
 TLS settings for this ingress.
 
@@ -3239,7 +3221,7 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 ---
 
-### IngressRule <a name="org.cdk8s.plus22.IngressRule"></a>
+### IngressV1Beta1Rule <a name="org.cdk8s.plus21.IngressV1Beta1Rule"></a>
 
 Represents the rules mapping the paths under a specified host to the related backend services.
 
@@ -3249,29 +3231,28 @@ then routed to the backend associated with the matching path.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.IngressRule;
+import org.cdk8s.plus21.IngressV1Beta1Rule;
 
-IngressRule.builder()
-    .backend(IngressBackend)
+IngressV1Beta1Rule.builder()
+    .backend(IngressV1Beta1Backend)
 //  .host(java.lang.String)
 //  .path(java.lang.String)
-//  .pathType(HttpIngressPathType)
     .build();
 ```
 
-##### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.IngressRule.property.backend"></a>
+##### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Rule.property.backend"></a>
 
 ```java
-public IngressBackend getBackend();
+public IngressV1Beta1Backend getBackend();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
+- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
 
 Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ---
 
-##### `host`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressRule.property.host"></a>
+##### `host`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Rule.property.host"></a>
 
 ```java
 public java.lang.String getHost();
@@ -3293,7 +3274,7 @@ host before the IngressRuleValue.
 
 ---
 
-##### `path`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressRule.property.path"></a>
+##### `path`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Rule.property.path"></a>
 
 ```java
 public java.lang.String getPath();
@@ -3307,39 +3288,22 @@ Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows
 
 ---
 
-##### `pathType`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressRule.property.pathType"></a>
-
-```java
-public HttpIngressPathType getPathType();
-```
-
-- *Type:* [`org.cdk8s.plus22.HttpIngressPathType`](#org.cdk8s.plus22.HttpIngressPathType)
-
-Specify how the path is matched against request paths.
-
-By default, path
-types will be matched by prefix.
-
-> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-
----
-
-### IngressTls <a name="org.cdk8s.plus22.IngressTls"></a>
+### IngressV1Beta1Tls <a name="org.cdk8s.plus21.IngressV1Beta1Tls"></a>
 
 Represents the TLS configuration mapping that is passed to the ingress controller for SSL termination.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.IngressTls;
+import org.cdk8s.plus21.IngressV1Beta1Tls;
 
-IngressTls.builder()
+IngressV1Beta1Tls.builder()
 //  .hosts(java.util.List<java.lang.String>)
 //  .secret(ISecret)
     .build();
 ```
 
-##### `hosts`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressTls.property.hosts"></a>
+##### `hosts`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Tls.property.hosts"></a>
 
 ```java
 public java.util.List<java.lang.String> getHosts();
@@ -3356,13 +3320,13 @@ this list must match the name/s used in the TLS Secret.
 
 ---
 
-##### `secret`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressTls.property.secret"></a>
+##### `secret`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Tls.property.secret"></a>
 
 ```java
 public ISecret getSecret();
 ```
 
-- *Type:* [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
+- *Type:* [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
 - *Default:* If unspecified, it allows SSL routing based on SNI hostname.
 
 Secret is the secret that contains the certificate and key used to terminate SSL traffic on 443.
@@ -3373,14 +3337,14 @@ termination and value of the Host header is used for routing.
 
 ---
 
-### JobProps <a name="org.cdk8s.plus22.JobProps"></a>
+### JobProps <a name="org.cdk8s.plus21.JobProps"></a>
 
 Properties for initialization of `Job`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.JobProps;
+import org.cdk8s.plus21.JobProps;
 
 JobProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -3395,7 +3359,7 @@ JobProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -3407,13 +3371,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3425,13 +3389,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3440,13 +3404,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3462,13 +3426,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3479,7 +3443,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadata getPodMetadata();
@@ -3491,7 +3455,7 @@ The pod metadata.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.activeDeadline"></a>
 
 ```java
 public Duration getActiveDeadline();
@@ -3504,7 +3468,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.backoffLimit"></a>
 
 ```java
 public java.lang.Number getBackoffLimit();
@@ -3517,7 +3481,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.ttlAfterFinished"></a>
 
 ```java
 public Duration getTtlAfterFinished();
@@ -3537,14 +3501,14 @@ field is alpha-level and is only honored by servers that enable the
 
 ---
 
-### MountOptions <a name="org.cdk8s.plus22.MountOptions"></a>
+### MountOptions <a name="org.cdk8s.plus21.MountOptions"></a>
 
 Options for mounts.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.MountOptions;
+import org.cdk8s.plus21.MountOptions;
 
 MountOptions.builder()
 //  .propagation(MountPropagation)
@@ -3554,13 +3518,13 @@ MountOptions.builder()
     .build();
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.propagation"></a>
 
 ```java
 public MountPropagation getPropagation();
 ```
 
-- *Type:* [`org.cdk8s.plus22.MountPropagation`](#org.cdk8s.plus22.MountPropagation)
+- *Type:* [`org.cdk8s.plus21.MountPropagation`](#org.cdk8s.plus21.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -3574,7 +3538,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.readOnly"></a>
+##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.readOnly"></a>
 
 ```java
 public java.lang.Boolean getReadOnly();
@@ -3589,7 +3553,7 @@ Defaults to false.
 
 ---
 
-##### `subPath`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.subPath"></a>
+##### `subPath`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.subPath"></a>
 
 ```java
 public java.lang.String getSubPath();
@@ -3602,7 +3566,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `subPathExpr`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.subPathExpr"></a>
+##### `subPathExpr`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.subPathExpr"></a>
 
 ```java
 public java.lang.String getSubPathExpr();
@@ -3623,14 +3587,14 @@ is beta in 1.15.
 
 ---
 
-### PathMapping <a name="org.cdk8s.plus22.PathMapping"></a>
+### PathMapping <a name="org.cdk8s.plus21.PathMapping"></a>
 
 Maps a string key to a path within a volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.PathMapping;
+import org.cdk8s.plus21.PathMapping;
 
 PathMapping.builder()
     .path(java.lang.String)
@@ -3638,7 +3602,7 @@ PathMapping.builder()
     .build();
 ```
 
-##### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.PathMapping.property.path"></a>
+##### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.PathMapping.property.path"></a>
 
 ```java
 public java.lang.String getPath();
@@ -3654,7 +3618,7 @@ path. May not contain the path element '..'. May not start with the string
 
 ---
 
-##### `mode`<sup>Optional</sup> <a name="org.cdk8s.plus22.PathMapping.property.mode"></a>
+##### `mode`<sup>Optional</sup> <a name="org.cdk8s.plus21.PathMapping.property.mode"></a>
 
 ```java
 public java.lang.Number getMode();
@@ -3670,14 +3634,14 @@ the result can be other mode bits set.
 
 ---
 
-### PodProps <a name="org.cdk8s.plus22.PodProps"></a>
+### PodProps <a name="org.cdk8s.plus21.PodProps"></a>
 
 Properties for initialization of `Pod`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.PodProps;
+import org.cdk8s.plus21.PodProps;
 
 PodProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -3688,7 +3652,7 @@ PodProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -3700,13 +3664,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3718,13 +3682,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3733,13 +3697,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3755,13 +3719,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3772,14 +3736,14 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodSpecProps <a name="org.cdk8s.plus22.PodSpecProps"></a>
+### PodSpecProps <a name="org.cdk8s.plus21.PodSpecProps"></a>
 
 Properties of a `PodSpec`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.PodSpecProps;
+import org.cdk8s.plus21.PodSpecProps;
 
 PodSpecProps.builder()
 //  .containers(java.util.List<ContainerProps>)
@@ -3789,13 +3753,13 @@ PodSpecProps.builder()
     .build();
 ```
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3807,13 +3771,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3822,13 +3786,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3844,13 +3808,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3861,7 +3825,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodTemplateProps <a name="org.cdk8s.plus22.PodTemplateProps"></a>
+### PodTemplateProps <a name="org.cdk8s.plus21.PodTemplateProps"></a>
 
 Properties of a `PodTemplate`.
 
@@ -3870,7 +3834,7 @@ Adds metadata information on top of the spec.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.PodTemplateProps;
+import org.cdk8s.plus21.PodTemplateProps;
 
 PodTemplateProps.builder()
 //  .containers(java.util.List<ContainerProps>)
@@ -3881,13 +3845,13 @@ PodTemplateProps.builder()
     .build();
 ```
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3899,13 +3863,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3914,13 +3878,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3936,13 +3900,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3953,7 +3917,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadata getPodMetadata();
@@ -3965,14 +3929,14 @@ The pod metadata.
 
 ---
 
-### ProbeOptions <a name="org.cdk8s.plus22.ProbeOptions"></a>
+### ProbeOptions <a name="org.cdk8s.plus21.ProbeOptions"></a>
 
 Probe options.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ProbeOptions;
+import org.cdk8s.plus21.ProbeOptions;
 
 ProbeOptions.builder()
 //  .failureThreshold(java.lang.Number)
@@ -3983,7 +3947,7 @@ ProbeOptions.builder()
     .build();
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.failureThreshold"></a>
 
 ```java
 public java.lang.Number getFailureThreshold();
@@ -3998,7 +3962,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.initialDelaySeconds"></a>
 
 ```java
 public Duration getInitialDelaySeconds();
@@ -4013,7 +3977,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.periodSeconds"></a>
 
 ```java
 public Duration getPeriodSeconds();
@@ -4028,7 +3992,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.successThreshold"></a>
 
 ```java
 public java.lang.Number getSuccessThreshold();
@@ -4043,7 +4007,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.timeoutSeconds"></a>
 
 ```java
 public Duration getTimeoutSeconds();
@@ -4060,21 +4024,21 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ResourceProps <a name="org.cdk8s.plus22.ResourceProps"></a>
+### ResourceProps <a name="org.cdk8s.plus21.ResourceProps"></a>
 
 Initialization properties for resources.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ResourceProps;
+import org.cdk8s.plus21.ResourceProps;
 
 ResourceProps.builder()
 //  .metadata(ApiObjectMetadata)
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ResourceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ResourceProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -4086,12 +4050,12 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-### SecretProps <a name="org.cdk8s.plus22.SecretProps"></a>
+### SecretProps <a name="org.cdk8s.plus21.SecretProps"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.SecretProps;
+import org.cdk8s.plus21.SecretProps;
 
 SecretProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -4100,7 +4064,7 @@ SecretProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -4112,7 +4076,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.stringData"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getStringData();
@@ -4129,7 +4093,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.type"></a>
 
 ```java
 public java.lang.String getType();
@@ -4145,14 +4109,14 @@ handling of secret data by various controllers.
 
 ---
 
-### SecretValue <a name="org.cdk8s.plus22.SecretValue"></a>
+### SecretValue <a name="org.cdk8s.plus21.SecretValue"></a>
 
 Represents a specific value in JSON secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.SecretValue;
+import org.cdk8s.plus21.SecretValue;
 
 SecretValue.builder()
     .key(java.lang.String)
@@ -4160,7 +4124,7 @@ SecretValue.builder()
     .build();
 ```
 
-##### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.SecretValue.property.key"></a>
+##### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.SecretValue.property.key"></a>
 
 ```java
 public java.lang.String getKey();
@@ -4172,19 +4136,19 @@ The JSON key.
 
 ---
 
-##### `secret`<sup>Required</sup> <a name="org.cdk8s.plus22.SecretValue.property.secret"></a>
+##### `secret`<sup>Required</sup> <a name="org.cdk8s.plus21.SecretValue.property.secret"></a>
 
 ```java
 public ISecret getSecret();
 ```
 
-- *Type:* [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
+- *Type:* [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
 
 The secret.
 
 ---
 
-### ServiceAccountProps <a name="org.cdk8s.plus22.ServiceAccountProps"></a>
+### ServiceAccountProps <a name="org.cdk8s.plus21.ServiceAccountProps"></a>
 
 Properties for initialization of `ServiceAccount`.
 
@@ -4193,7 +4157,7 @@ Properties for initialization of `ServiceAccount`.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ServiceAccountProps;
+import org.cdk8s.plus21.ServiceAccountProps;
 
 ServiceAccountProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -4201,7 +4165,7 @@ ServiceAccountProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -4213,13 +4177,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountProps.property.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountProps.property.secrets"></a>
 
 ```java
 public java.util.List<ISecret> getSecrets();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)>
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -4227,21 +4191,21 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 ---
 
-### ServiceIngressBackendOptions <a name="org.cdk8s.plus22.ServiceIngressBackendOptions"></a>
+### ServiceIngressV1BetaBackendOptions <a name="org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions"></a>
 
 Options for setting up backends for ingress rules.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ServiceIngressBackendOptions;
+import org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions;
 
-ServiceIngressBackendOptions.builder()
+ServiceIngressV1BetaBackendOptions.builder()
 //  .port(java.lang.Number)
     .build();
 ```
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceIngressBackendOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -4259,14 +4223,14 @@ This option will fail if the service does not expose any ports.
 
 ---
 
-### ServicePort <a name="org.cdk8s.plus22.ServicePort"></a>
+### ServicePort <a name="org.cdk8s.plus21.ServicePort"></a>
 
 Definition of a service port.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ServicePort;
+import org.cdk8s.plus21.ServicePort;
 
 ServicePort.builder()
 //  .name(java.lang.String)
@@ -4277,7 +4241,7 @@ ServicePort.builder()
     .build();
 ```
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePort.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePort.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -4294,7 +4258,7 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePort.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePort.property.nodePort"></a>
 
 ```java
 public java.lang.Number getNodePort();
@@ -4314,13 +4278,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePort.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePort.property.protocol"></a>
 
 ```java
 public Protocol getProtocol();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Protocol`](#org.cdk8s.plus22.Protocol)
+- *Type:* [`org.cdk8s.plus21.Protocol`](#org.cdk8s.plus21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -4329,7 +4293,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePort.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePort.property.targetPort"></a>
 
 ```java
 public java.lang.Number getTargetPort();
@@ -4342,7 +4306,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Required</sup> <a name="org.cdk8s.plus22.ServicePort.property.port"></a>
+##### `port`<sup>Required</sup> <a name="org.cdk8s.plus21.ServicePort.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -4354,12 +4318,12 @@ The port number the service will bind to.
 
 ---
 
-### ServicePortOptions <a name="org.cdk8s.plus22.ServicePortOptions"></a>
+### ServicePortOptions <a name="org.cdk8s.plus21.ServicePortOptions"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ServicePortOptions;
+import org.cdk8s.plus21.ServicePortOptions;
 
 ServicePortOptions.builder()
 //  .name(java.lang.String)
@@ -4369,7 +4333,7 @@ ServicePortOptions.builder()
     .build();
 ```
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePortOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePortOptions.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -4386,7 +4350,7 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePortOptions.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePortOptions.property.nodePort"></a>
 
 ```java
 public java.lang.Number getNodePort();
@@ -4406,13 +4370,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePortOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePortOptions.property.protocol"></a>
 
 ```java
 public Protocol getProtocol();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Protocol`](#org.cdk8s.plus22.Protocol)
+- *Type:* [`org.cdk8s.plus21.Protocol`](#org.cdk8s.plus21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -4421,7 +4385,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePortOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePortOptions.property.targetPort"></a>
 
 ```java
 public java.lang.Number getTargetPort();
@@ -4434,14 +4398,14 @@ The port number the service will redirect to.
 
 ---
 
-### ServiceProps <a name="org.cdk8s.plus22.ServiceProps"></a>
+### ServiceProps <a name="org.cdk8s.plus21.ServiceProps"></a>
 
 Properties for initialization of `Service`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.ServiceProps;
+import org.cdk8s.plus21.ServiceProps;
 
 ServiceProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -4454,7 +4418,7 @@ ServiceProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -4466,7 +4430,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.clusterIP"></a>
 
 ```java
 public java.lang.String getClusterIP();
@@ -4488,7 +4452,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `externalIPs`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.externalIPs"></a>
+##### `externalIPs`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.externalIPs"></a>
 
 ```java
 public java.util.List<java.lang.String> getExternalIPs();
@@ -4506,7 +4470,7 @@ Kubernetes system.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.externalName"></a>
 
 ```java
 public java.lang.String getExternalName();
@@ -4519,7 +4483,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.loadBalancerSourceRanges"></a>
+##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.loadBalancerSourceRanges"></a>
 
 ```java
 public java.util.List<java.lang.String> getLoadBalancerSourceRanges();
@@ -4533,13 +4497,13 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.ports"></a>
 
 ```java
 public java.util.List<ServicePort> getPorts();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ServicePort`](#org.cdk8s.plus22.ServicePort)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ServicePort`](#org.cdk8s.plus21.ServicePort)>
 
 The port exposed by this service.
 
@@ -4547,13 +4511,13 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.type"></a>
 
 ```java
 public ServiceType getType();
 ```
 
-- *Type:* [`org.cdk8s.plus22.ServiceType`](#org.cdk8s.plus22.ServiceType)
+- *Type:* [`org.cdk8s.plus21.ServiceType`](#org.cdk8s.plus21.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -4562,14 +4526,14 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 ---
 
-### StatefulSetProps <a name="org.cdk8s.plus22.StatefulSetProps"></a>
+### StatefulSetProps <a name="org.cdk8s.plus21.StatefulSetProps"></a>
 
 Properties for initialization of `StatefulSet`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.StatefulSetProps;
+import org.cdk8s.plus21.StatefulSetProps;
 
 StatefulSetProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -4585,7 +4549,7 @@ StatefulSetProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -4597,13 +4561,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4615,13 +4579,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4630,13 +4594,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4652,13 +4616,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4669,7 +4633,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadata getPodMetadata();
@@ -4681,19 +4645,19 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.service"></a>
+##### `service`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.service"></a>
 
 ```java
 public Service getService();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Service`](#org.cdk8s.plus22.Service)
+- *Type:* [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.defaultSelector"></a>
 
 ```java
 public java.lang.Boolean getDefaultSelector();
@@ -4709,20 +4673,20 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `podManagementPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.podManagementPolicy"></a>
 
 ```java
 public PodManagementPolicy getPodManagementPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.PodManagementPolicy`](#org.cdk8s.plus22.PodManagementPolicy)
+- *Type:* [`org.cdk8s.plus21.PodManagementPolicy`](#org.cdk8s.plus21.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.replicas"></a>
 
 ```java
 public java.lang.Number getReplicas();
@@ -4735,14 +4699,14 @@ Number of desired pods.
 
 ---
 
-### VolumeMount <a name="org.cdk8s.plus22.VolumeMount"></a>
+### VolumeMount <a name="org.cdk8s.plus21.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.VolumeMount;
+import org.cdk8s.plus21.VolumeMount;
 
 VolumeMount.builder()
 //  .propagation(MountPropagation)
@@ -4754,13 +4718,13 @@ VolumeMount.builder()
     .build();
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.propagation"></a>
 
 ```java
 public MountPropagation getPropagation();
 ```
 
-- *Type:* [`org.cdk8s.plus22.MountPropagation`](#org.cdk8s.plus22.MountPropagation)
+- *Type:* [`org.cdk8s.plus21.MountPropagation`](#org.cdk8s.plus21.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -4774,7 +4738,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.readOnly"></a>
+##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.readOnly"></a>
 
 ```java
 public java.lang.Boolean getReadOnly();
@@ -4789,7 +4753,7 @@ Defaults to false.
 
 ---
 
-##### `subPath`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.subPath"></a>
+##### `subPath`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.subPath"></a>
 
 ```java
 public java.lang.String getSubPath();
@@ -4802,7 +4766,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `subPathExpr`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.subPathExpr"></a>
+##### `subPathExpr`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.subPathExpr"></a>
 
 ```java
 public java.lang.String getSubPathExpr();
@@ -4823,7 +4787,7 @@ is beta in 1.15.
 
 ---
 
-##### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.VolumeMount.property.path"></a>
+##### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.VolumeMount.property.path"></a>
 
 ```java
 public java.lang.String getPath();
@@ -4838,13 +4802,13 @@ contain ':'.
 
 ---
 
-##### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.VolumeMount.property.volume"></a>
+##### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.VolumeMount.property.volume"></a>
 
 ```java
 public Volume getVolume();
 ```
 
-- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
+- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
 
 The volume to mount.
 
@@ -4852,14 +4816,14 @@ The volume to mount.
 
 ## Classes <a name="Classes"></a>
 
-### Container <a name="org.cdk8s.plus22.Container"></a>
+### Container <a name="org.cdk8s.plus21.Container"></a>
 
 A single application container that you want to run within a pod.
 
-#### Initializers <a name="org.cdk8s.plus22.Container.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Container.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Container;
+import org.cdk8s.plus21.Container;
 
 Container.Builder.create()
     .image(java.lang.String)
@@ -4877,7 +4841,7 @@ Container.Builder.create()
     .build();
 ```
 
-##### `image`<sup>Required</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.image"></a>
+##### `image`<sup>Required</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.image"></a>
 
 - *Type:* `java.lang.String`
 
@@ -4885,7 +4849,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.args"></a>
+##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.args"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 - *Default:* []
@@ -4904,7 +4868,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.command"></a>
+##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.command"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 - *Default:* The docker image's ENTRYPOINT.
@@ -4918,9 +4882,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.env"></a>
+##### `env`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.env"></a>
 
-- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus22.EnvValue`](#org.cdk8s.plus22.EnvValue)>
+- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus21.EnvValue`](#org.cdk8s.plus21.EnvValue)>
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -4929,18 +4893,18 @@ Cannot be updated.
 
 ---
 
-##### `imagePullPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.imagePullPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus22.ImagePullPolicy`](#org.cdk8s.plus22.ImagePullPolicy)
+- *Type:* [`org.cdk8s.plus21.ImagePullPolicy`](#org.cdk8s.plus21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
+- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -4949,7 +4913,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* 'main'
@@ -4960,7 +4924,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.port"></a>
 
 - *Type:* `java.lang.Number`
 - *Default:* No port is exposed.
@@ -4971,18 +4935,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
+- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
+- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -4991,9 +4955,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volumeMounts`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.volumeMounts"></a>
+##### `volumeMounts`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.volumeMounts"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.VolumeMount`](#org.cdk8s.plus22.VolumeMount)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.VolumeMount`](#org.cdk8s.plus21.VolumeMount)>
 
 Pod volumes to mount into the container's filesystem.
 
@@ -5001,7 +4965,7 @@ Cannot be updated.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.workingDir"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* The container runtime's default.
@@ -5014,13 +4978,13 @@ If not specified, the container runtime's default will be used, which might be c
 
 #### Methods <a name="Methods"></a>
 
-##### `addEnv` <a name="org.cdk8s.plus22.Container.addEnv"></a>
+##### `addEnv` <a name="org.cdk8s.plus21.Container.addEnv"></a>
 
 ```java
 public addEnv(java.lang.String name, EnvValue value)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5028,22 +4992,22 @@ The variable name.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.value"></a>
 
-- *Type:* [`org.cdk8s.plus22.EnvValue`](#org.cdk8s.plus22.EnvValue)
+- *Type:* [`org.cdk8s.plus21.EnvValue`](#org.cdk8s.plus21.EnvValue)
 
 The variable value.
 
 ---
 
-##### `mount` <a name="org.cdk8s.plus22.Container.mount"></a>
+##### `mount` <a name="org.cdk8s.plus21.Container.mount"></a>
 
 ```java
 public mount(java.lang.String path, Volume volume)
 public mount(java.lang.String path, Volume volume, MountOptions options)
 ```
 
-###### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.path"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5051,30 +5015,30 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
+- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
 
 The volume to mount.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.MountOptions`](#org.cdk8s.plus22.MountOptions)
+- *Type:* [`org.cdk8s.plus21.MountOptions`](#org.cdk8s.plus21.MountOptions)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `env`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.env"></a>
+##### `env`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.env"></a>
 
 ```java
 public java.util.Map<java.lang.String, EnvValue> getEnv();
 ```
 
-- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus22.EnvValue`](#org.cdk8s.plus22.EnvValue)>
+- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus21.EnvValue`](#org.cdk8s.plus21.EnvValue)>
 
 The environment variables for this container.
 
@@ -5082,7 +5046,7 @@ Returns a copy. To add environment variables use `addEnv()`.
 
 ---
 
-##### `image`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.image"></a>
+##### `image`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.image"></a>
 
 ```java
 public java.lang.String getImage();
@@ -5094,31 +5058,31 @@ The container image.
 
 ---
 
-##### `imagePullPolicy`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.imagePullPolicy"></a>
 
 ```java
 public ImagePullPolicy getImagePullPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.ImagePullPolicy`](#org.cdk8s.plus22.ImagePullPolicy)
+- *Type:* [`org.cdk8s.plus21.ImagePullPolicy`](#org.cdk8s.plus21.ImagePullPolicy)
 
 Image pull policy for this container.
 
 ---
 
-##### `mounts`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.mounts"></a>
+##### `mounts`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.mounts"></a>
 
 ```java
 public java.util.List<VolumeMount> getMounts();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.VolumeMount`](#org.cdk8s.plus22.VolumeMount)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.VolumeMount`](#org.cdk8s.plus21.VolumeMount)>
 
 Volume mounts configured for this container.
 
 ---
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5130,7 +5094,7 @@ The name of the container.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.property.args"></a>
 
 ```java
 public java.util.List<java.lang.String> getArgs();
@@ -5142,7 +5106,7 @@ Arguments to the entrypoint.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.property.command"></a>
 
 ```java
 public java.util.List<java.lang.String> getCommand();
@@ -5154,7 +5118,7 @@ Entrypoint array (the command to execute when the container starts).
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -5166,7 +5130,7 @@ The port this container exposes.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.property.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.property.workingDir"></a>
 
 ```java
 public java.lang.String getWorkingDir();
@@ -5179,31 +5143,31 @@ The working directory inside the container.
 ---
 
 
-### EnvValue <a name="org.cdk8s.plus22.EnvValue"></a>
+### EnvValue <a name="org.cdk8s.plus21.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMap` <a name="org.cdk8s.plus22.EnvValue.fromConfigMap"></a>
+##### `fromConfigMap` <a name="org.cdk8s.plus21.EnvValue.fromConfigMap"></a>
 
 ```java
-import org.cdk8s.plus22.EnvValue;
+import org.cdk8s.plus21.EnvValue;
 
 EnvValue.fromConfigMap(IConfigMap configMap, java.lang.String key)
 EnvValue.fromConfigMap(IConfigMap configMap, java.lang.String key, EnvValueFromConfigMapOptions options)
 ```
 
-###### `configMap`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.configMap"></a>
+###### `configMap`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.configMap"></a>
 
-- *Type:* [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap)
+- *Type:* [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
 
 The config map.
 
 ---
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5211,24 +5175,24 @@ The key to extract the value from.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.EnvValueFromConfigMapOptions`](#org.cdk8s.plus22.EnvValueFromConfigMapOptions)
+- *Type:* [`org.cdk8s.plus21.EnvValueFromConfigMapOptions`](#org.cdk8s.plus21.EnvValueFromConfigMapOptions)
 
 Additional options.
 
 ---
 
-##### `fromProcess` <a name="org.cdk8s.plus22.EnvValue.fromProcess"></a>
+##### `fromProcess` <a name="org.cdk8s.plus21.EnvValue.fromProcess"></a>
 
 ```java
-import org.cdk8s.plus22.EnvValue;
+import org.cdk8s.plus21.EnvValue;
 
 EnvValue.fromProcess(java.lang.String key)
 EnvValue.fromProcess(java.lang.String key, EnvValueFromProcessOptions options)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5236,48 +5200,48 @@ The key to read.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.EnvValueFromProcessOptions`](#org.cdk8s.plus22.EnvValueFromProcessOptions)
+- *Type:* [`org.cdk8s.plus21.EnvValueFromProcessOptions`](#org.cdk8s.plus21.EnvValueFromProcessOptions)
 
 Additional options.
 
 ---
 
-##### `fromSecretValue` <a name="org.cdk8s.plus22.EnvValue.fromSecretValue"></a>
+##### `fromSecretValue` <a name="org.cdk8s.plus21.EnvValue.fromSecretValue"></a>
 
 ```java
-import org.cdk8s.plus22.EnvValue;
+import org.cdk8s.plus21.EnvValue;
 
 EnvValue.fromSecretValue(SecretValue secretValue)
 EnvValue.fromSecretValue(SecretValue secretValue, EnvValueFromSecretOptions options)
 ```
 
-###### `secretValue`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.secretValue"></a>
+###### `secretValue`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.secretValue"></a>
 
-- *Type:* [`org.cdk8s.plus22.SecretValue`](#org.cdk8s.plus22.SecretValue)
+- *Type:* [`org.cdk8s.plus21.SecretValue`](#org.cdk8s.plus21.SecretValue)
 
 The secret value (secrent + key).
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.EnvValueFromSecretOptions`](#org.cdk8s.plus22.EnvValueFromSecretOptions)
+- *Type:* [`org.cdk8s.plus21.EnvValueFromSecretOptions`](#org.cdk8s.plus21.EnvValueFromSecretOptions)
 
 Additional options.
 
 ---
 
-##### `fromValue` <a name="org.cdk8s.plus22.EnvValue.fromValue"></a>
+##### `fromValue` <a name="org.cdk8s.plus21.EnvValue.fromValue"></a>
 
 ```java
-import org.cdk8s.plus22.EnvValue;
+import org.cdk8s.plus21.EnvValue;
 
 EnvValue.fromValue(java.lang.String value)
 ```
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5287,7 +5251,7 @@ The value.
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.property.value"></a>
+##### `value`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.property.value"></a>
 
 ```java
 public java.lang.Object getValue();
@@ -5297,7 +5261,7 @@ public java.lang.Object getValue();
 
 ---
 
-##### `valueFrom`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.property.valueFrom"></a>
+##### `valueFrom`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.property.valueFrom"></a>
 
 ```java
 public java.lang.Object getValueFrom();
@@ -5308,48 +5272,48 @@ public java.lang.Object getValueFrom();
 ---
 
 
-### IngressBackend <a name="org.cdk8s.plus22.IngressBackend"></a>
+### IngressV1Beta1Backend <a name="org.cdk8s.plus21.IngressV1Beta1Backend"></a>
 
 The backend for an ingress path.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromService` <a name="org.cdk8s.plus22.IngressBackend.fromService"></a>
+##### `fromService` <a name="org.cdk8s.plus21.IngressV1Beta1Backend.fromService"></a>
 
 ```java
-import org.cdk8s.plus22.IngressBackend;
+import org.cdk8s.plus21.IngressV1Beta1Backend;
 
-IngressBackend.fromService(Service service)
-IngressBackend.fromService(Service service, ServiceIngressBackendOptions options)
+IngressV1Beta1Backend.fromService(Service service)
+IngressV1Beta1Backend.fromService(Service service, ServiceIngressV1BetaBackendOptions options)
 ```
 
-###### `service`<sup>Required</sup> <a name="org.cdk8s.plus22.IngressBackend.parameter.service"></a>
+###### `service`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Backend.parameter.service"></a>
 
-- *Type:* [`org.cdk8s.plus22.Service`](#org.cdk8s.plus22.Service)
+- *Type:* [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service)
 
 The service object.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressBackend.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Backend.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.ServiceIngressBackendOptions`](#org.cdk8s.plus22.ServiceIngressBackendOptions)
+- *Type:* [`org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions`](#org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions)
 
 ---
 
 
 
-### PodSpec <a name="org.cdk8s.plus22.PodSpec"></a>
+### PodSpec <a name="org.cdk8s.plus21.PodSpec"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IPodSpec`](#org.cdk8s.plus22.IPodSpec)
+- *Implements:* [`org.cdk8s.plus21.IPodSpec`](#org.cdk8s.plus21.IPodSpec)
 
 Provides read/write capabilities ontop of a `PodSpecProps`.
 
-#### Initializers <a name="org.cdk8s.plus22.PodSpec.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.PodSpec.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.PodSpec;
+import org.cdk8s.plus21.PodSpec;
 
 PodSpec.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
@@ -5359,9 +5323,9 @@ PodSpec.Builder.create()
     .build();
 ```
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -5373,9 +5337,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -5384,9 +5348,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -5402,9 +5366,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -5417,40 +5381,40 @@ You can also add volumes later using `podSpec.addVolume()`
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus22.PodSpec.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus21.PodSpec.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.PodSpec.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
+- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus22.PodSpec.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus21.PodSpec.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.PodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
+- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.PodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
 
 The containers belonging to the pod.
 
@@ -5458,13 +5422,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.PodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 
 The volumes associated with this pod.
 
@@ -5472,41 +5436,41 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpec.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpec.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpec.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### PodTemplate <a name="org.cdk8s.plus22.PodTemplate"></a>
+### PodTemplate <a name="org.cdk8s.plus21.PodTemplate"></a>
 
-- *Implements:* [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
+- *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
 
 Provides read/write capabilities ontop of a `PodTemplateProps`.
 
-#### Initializers <a name="org.cdk8s.plus22.PodTemplate.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.PodTemplate.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.PodTemplate;
+import org.cdk8s.plus21.PodTemplate;
 
 PodTemplate.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
@@ -5517,9 +5481,9 @@ PodTemplate.Builder.create()
     .build();
 ```
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -5531,9 +5495,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -5542,9 +5506,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -5560,9 +5524,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -5573,7 +5537,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.podMetadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -5585,7 +5549,7 @@ The pod metadata.
 
 #### Properties <a name="Properties"></a>
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.PodTemplate.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.PodTemplate.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -5598,14 +5562,14 @@ Provides read/write access to the underlying pod metadata of the resource.
 ---
 
 
-### Probe <a name="org.cdk8s.plus22.Probe"></a>
+### Probe <a name="org.cdk8s.plus21.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 
-#### Initializers <a name="org.cdk8s.plus22.Probe.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Probe.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Probe;
+import org.cdk8s.plus21.Probe;
 
 new Probe();
 ```
@@ -5613,16 +5577,16 @@ new Probe();
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromCommand` <a name="org.cdk8s.plus22.Probe.fromCommand"></a>
+##### `fromCommand` <a name="org.cdk8s.plus21.Probe.fromCommand"></a>
 
 ```java
-import org.cdk8s.plus22.Probe;
+import org.cdk8s.plus21.Probe;
 
 Probe.fromCommand(java.util.List<java.lang.String> command)
 Probe.fromCommand(java.util.List<java.lang.String> command, CommandProbeOptions options)
 ```
 
-###### `command`<sup>Required</sup> <a name="org.cdk8s.plus22.Probe.parameter.command"></a>
+###### `command`<sup>Required</sup> <a name="org.cdk8s.plus21.Probe.parameter.command"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 
@@ -5630,24 +5594,24 @@ The command to execute.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Probe.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Probe.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.CommandProbeOptions`](#org.cdk8s.plus22.CommandProbeOptions)
+- *Type:* [`org.cdk8s.plus21.CommandProbeOptions`](#org.cdk8s.plus21.CommandProbeOptions)
 
 Options.
 
 ---
 
-##### `fromHttpGet` <a name="org.cdk8s.plus22.Probe.fromHttpGet"></a>
+##### `fromHttpGet` <a name="org.cdk8s.plus21.Probe.fromHttpGet"></a>
 
 ```java
-import org.cdk8s.plus22.Probe;
+import org.cdk8s.plus21.Probe;
 
 Probe.fromHttpGet(java.lang.String path)
 Probe.fromHttpGet(java.lang.String path, HttpGetProbeOptions options)
 ```
 
-###### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.Probe.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.Probe.parameter.path"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5655,9 +5619,9 @@ The URL path to hit.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Probe.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Probe.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.HttpGetProbeOptions`](#org.cdk8s.plus22.HttpGetProbeOptions)
+- *Type:* [`org.cdk8s.plus21.HttpGetProbeOptions`](#org.cdk8s.plus21.HttpGetProbeOptions)
 
 Options.
 
@@ -5665,7 +5629,7 @@ Options.
 
 
 
-### Volume <a name="org.cdk8s.plus22.Volume"></a>
+### Volume <a name="org.cdk8s.plus21.Volume"></a>
 
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
@@ -5698,21 +5662,21 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
-#### Initializers <a name="org.cdk8s.plus22.Volume.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus21.Volume.Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.Volume;
+import org.cdk8s.plus21.Volume;
 
 new Volume(java.lang.String name, java.lang.Object config);
 ```
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.parameter.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `config`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.parameter.config"></a>
+##### `config`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.config"></a>
 
 - *Type:* `java.lang.Object`
 
@@ -5721,49 +5685,49 @@ new Volume(java.lang.String name, java.lang.Object config);
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMap` <a name="org.cdk8s.plus22.Volume.fromConfigMap"></a>
+##### `fromConfigMap` <a name="org.cdk8s.plus21.Volume.fromConfigMap"></a>
 
 ```java
-import org.cdk8s.plus22.Volume;
+import org.cdk8s.plus21.Volume;
 
 Volume.fromConfigMap(IConfigMap configMap)
 Volume.fromConfigMap(IConfigMap configMap, ConfigMapVolumeOptions options)
 ```
 
-###### `configMap`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.parameter.configMap"></a>
+###### `configMap`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.configMap"></a>
 
-- *Type:* [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap)
+- *Type:* [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
 
 The config map to use to populate the volume.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Volume.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Volume.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.ConfigMapVolumeOptions`](#org.cdk8s.plus22.ConfigMapVolumeOptions)
+- *Type:* [`org.cdk8s.plus21.ConfigMapVolumeOptions`](#org.cdk8s.plus21.ConfigMapVolumeOptions)
 
 Options.
 
 ---
 
-##### `fromEmptyDir` <a name="org.cdk8s.plus22.Volume.fromEmptyDir"></a>
+##### `fromEmptyDir` <a name="org.cdk8s.plus21.Volume.fromEmptyDir"></a>
 
 ```java
-import org.cdk8s.plus22.Volume;
+import org.cdk8s.plus21.Volume;
 
 Volume.fromEmptyDir(java.lang.String name)
 Volume.fromEmptyDir(java.lang.String name, EmptyDirVolumeOptions options)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Volume.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Volume.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.EmptyDirVolumeOptions`](#org.cdk8s.plus22.EmptyDirVolumeOptions)
+- *Type:* [`org.cdk8s.plus21.EmptyDirVolumeOptions`](#org.cdk8s.plus21.EmptyDirVolumeOptions)
 
 Additional options.
 
@@ -5771,7 +5735,7 @@ Additional options.
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5784,18 +5748,18 @@ public java.lang.String getName();
 
 ## Protocols <a name="Protocols"></a>
 
-### IConfigMap <a name="org.cdk8s.plus22.IConfigMap"></a>
+### IConfigMap <a name="org.cdk8s.plus21.IConfigMap"></a>
 
-- *Extends:* [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource)
+- *Extends:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
 
-- *Implemented By:* [`org.cdk8s.plus22.ConfigMap`](#org.cdk8s.plus22.ConfigMap), [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap)
+- *Implemented By:* [`org.cdk8s.plus21.ConfigMap`](#org.cdk8s.plus21.ConfigMap), [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
 
 Represents a config map.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.IConfigMap.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.IConfigMap.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5807,9 +5771,9 @@ The Kubernetes name of this resource.
 
 ---
 
-### IPodSpec <a name="org.cdk8s.plus22.IPodSpec"></a>
+### IPodSpec <a name="org.cdk8s.plus21.IPodSpec"></a>
 
-- *Implemented By:* [`org.cdk8s.plus22.Deployment`](#org.cdk8s.plus22.Deployment), [`org.cdk8s.plus22.Job`](#org.cdk8s.plus22.Job), [`org.cdk8s.plus22.Pod`](#org.cdk8s.plus22.Pod), [`org.cdk8s.plus22.PodSpec`](#org.cdk8s.plus22.PodSpec), [`org.cdk8s.plus22.PodTemplate`](#org.cdk8s.plus22.PodTemplate), [`org.cdk8s.plus22.StatefulSet`](#org.cdk8s.plus22.StatefulSet), [`org.cdk8s.plus22.IPodSpec`](#org.cdk8s.plus22.IPodSpec), [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
+- *Implemented By:* [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment), [`org.cdk8s.plus21.Job`](#org.cdk8s.plus21.Job), [`org.cdk8s.plus21.Pod`](#org.cdk8s.plus21.Pod), [`org.cdk8s.plus21.PodSpec`](#org.cdk8s.plus21.PodSpec), [`org.cdk8s.plus21.PodTemplate`](#org.cdk8s.plus21.PodTemplate), [`org.cdk8s.plus21.StatefulSet`](#org.cdk8s.plus21.StatefulSet), [`org.cdk8s.plus21.IPodSpec`](#org.cdk8s.plus21.IPodSpec), [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod spec. (e.g `Deployment`, `Job`, `Pod`, ...).
 
@@ -5817,29 +5781,29 @@ Use the `PodSpec` class as an implementation helper.
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus22.IPodSpec.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus21.IPodSpec.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodSpec.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
+- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
 
 The container.
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus22.IPodSpec.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus21.IPodSpec.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
+- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
 
 The volume.
 
@@ -5847,13 +5811,13 @@ The volume.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
 
 The containers belonging to the pod.
 
@@ -5861,13 +5825,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 
 The volumes associated with this pod.
 
@@ -5875,35 +5839,35 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.IPodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.IPodSpec.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.IPodSpec.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.IPodSpec.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-### IPodTemplate <a name="org.cdk8s.plus22.IPodTemplate"></a>
+### IPodTemplate <a name="org.cdk8s.plus21.IPodTemplate"></a>
 
-- *Extends:* [`org.cdk8s.plus22.IPodSpec`](#org.cdk8s.plus22.IPodSpec)
+- *Extends:* [`org.cdk8s.plus21.IPodSpec`](#org.cdk8s.plus21.IPodSpec)
 
-- *Implemented By:* [`org.cdk8s.plus22.Deployment`](#org.cdk8s.plus22.Deployment), [`org.cdk8s.plus22.Job`](#org.cdk8s.plus22.Job), [`org.cdk8s.plus22.PodTemplate`](#org.cdk8s.plus22.PodTemplate), [`org.cdk8s.plus22.StatefulSet`](#org.cdk8s.plus22.StatefulSet), [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
+- *Implemented By:* [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment), [`org.cdk8s.plus21.Job`](#org.cdk8s.plus21.Job), [`org.cdk8s.plus21.PodTemplate`](#org.cdk8s.plus21.PodTemplate), [`org.cdk8s.plus21.StatefulSet`](#org.cdk8s.plus21.StatefulSet), [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod template. (e.g `Deployment`, `Job`, ...).
 
@@ -5912,13 +5876,13 @@ Use the `PodTemplate` class as an implementation helper.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
 
 The containers belonging to the pod.
 
@@ -5926,13 +5890,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
 
 The volumes associated with this pod.
 
@@ -5940,31 +5904,31 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
+- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -5976,16 +5940,16 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-### IResource <a name="org.cdk8s.plus22.IResource"></a>
+### IResource <a name="org.cdk8s.plus21.IResource"></a>
 
-- *Implemented By:* [`org.cdk8s.plus22.ConfigMap`](#org.cdk8s.plus22.ConfigMap), [`org.cdk8s.plus22.Deployment`](#org.cdk8s.plus22.Deployment), [`org.cdk8s.plus22.Ingress`](#org.cdk8s.plus22.Ingress), [`org.cdk8s.plus22.Job`](#org.cdk8s.plus22.Job), [`org.cdk8s.plus22.Pod`](#org.cdk8s.plus22.Pod), [`org.cdk8s.plus22.Resource`](#org.cdk8s.plus22.Resource), [`org.cdk8s.plus22.Secret`](#org.cdk8s.plus22.Secret), [`org.cdk8s.plus22.Service`](#org.cdk8s.plus22.Service), [`org.cdk8s.plus22.ServiceAccount`](#org.cdk8s.plus22.ServiceAccount), [`org.cdk8s.plus22.StatefulSet`](#org.cdk8s.plus22.StatefulSet), [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap), [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource), [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret), [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Implemented By:* [`org.cdk8s.plus21.ConfigMap`](#org.cdk8s.plus21.ConfigMap), [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment), [`org.cdk8s.plus21.IngressV1Beta1`](#org.cdk8s.plus21.IngressV1Beta1), [`org.cdk8s.plus21.Job`](#org.cdk8s.plus21.Job), [`org.cdk8s.plus21.Pod`](#org.cdk8s.plus21.Pod), [`org.cdk8s.plus21.Resource`](#org.cdk8s.plus21.Resource), [`org.cdk8s.plus21.Secret`](#org.cdk8s.plus21.Secret), [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service), [`org.cdk8s.plus21.ServiceAccount`](#org.cdk8s.plus21.ServiceAccount), [`org.cdk8s.plus21.StatefulSet`](#org.cdk8s.plus21.StatefulSet), [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap), [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource), [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret), [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 Represents a resource.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.IResource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.IResource.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5997,16 +5961,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### ISecret <a name="org.cdk8s.plus22.ISecret"></a>
+### ISecret <a name="org.cdk8s.plus21.ISecret"></a>
 
-- *Extends:* [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource)
+- *Extends:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
 
-- *Implemented By:* [`org.cdk8s.plus22.Secret`](#org.cdk8s.plus22.Secret), [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
+- *Implemented By:* [`org.cdk8s.plus21.Secret`](#org.cdk8s.plus21.Secret), [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.ISecret.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.ISecret.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -6018,16 +5982,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### IServiceAccount <a name="org.cdk8s.plus22.IServiceAccount"></a>
+### IServiceAccount <a name="org.cdk8s.plus21.IServiceAccount"></a>
 
-- *Extends:* [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource)
+- *Extends:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
 
-- *Implemented By:* [`org.cdk8s.plus22.ServiceAccount`](#org.cdk8s.plus22.ServiceAccount), [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
+- *Implemented By:* [`org.cdk8s.plus21.ServiceAccount`](#org.cdk8s.plus21.ServiceAccount), [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.IServiceAccount.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.IServiceAccount.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -6045,14 +6009,14 @@ The Kubernetes name of this resource.
 
 The medium on which to store the volume.
 
-#### `DEFAULT` <a name="org.cdk8s.plus22.EmptyDirMedium.DEFAULT"></a>
+#### `DEFAULT` <a name="org.cdk8s.plus21.EmptyDirMedium.DEFAULT"></a>
 
 The default volume of the backing node.
 
 ---
 
 
-#### `MEMORY` <a name="org.cdk8s.plus22.EmptyDirMedium.MEMORY"></a>
+#### `MEMORY` <a name="org.cdk8s.plus21.EmptyDirMedium.MEMORY"></a>
 
 Mount a tmpfs (RAM-backed filesystem) for you instead.
 
@@ -6063,36 +6027,9 @@ files you write will count against your Container's memory limit.
 ---
 
 
-### HttpIngressPathType <a name="HttpIngressPathType"></a>
-
-Specify how the path is matched against request paths.
-
-> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-
-#### `PREFIX` <a name="org.cdk8s.plus22.HttpIngressPathType.PREFIX"></a>
-
-Matches the URL path exactly.
-
----
-
-
-#### `EXACT` <a name="org.cdk8s.plus22.HttpIngressPathType.EXACT"></a>
-
-Matches based on a URL path prefix split by '/'.
-
----
-
-
-#### `IMPLEMENTATION_SPECIFIC` <a name="org.cdk8s.plus22.HttpIngressPathType.IMPLEMENTATION_SPECIFIC"></a>
-
-Matching is specified by the underlying IngressClass.
-
----
-
-
 ### ImagePullPolicy <a name="ImagePullPolicy"></a>
 
-#### `ALWAYS` <a name="org.cdk8s.plus22.ImagePullPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="org.cdk8s.plus21.ImagePullPolicy.ALWAYS"></a>
 
 Every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest.
 
@@ -6106,7 +6043,7 @@ the image tag is omitted.
 ---
 
 
-#### `IF_NOT_PRESENT` <a name="org.cdk8s.plus22.ImagePullPolicy.IF_NOT_PRESENT"></a>
+#### `IF_NOT_PRESENT` <a name="org.cdk8s.plus21.ImagePullPolicy.IF_NOT_PRESENT"></a>
 
 The image is pulled only if it is not already present locally.
 
@@ -6116,7 +6053,7 @@ not :latest
 ---
 
 
-#### `NEVER` <a name="org.cdk8s.plus22.ImagePullPolicy.NEVER"></a>
+#### `NEVER` <a name="org.cdk8s.plus21.ImagePullPolicy.NEVER"></a>
 
 The image is assumed to exist locally.
 
@@ -6127,7 +6064,7 @@ No attempt is made to pull the image.
 
 ### MountPropagation <a name="MountPropagation"></a>
 
-#### `NONE` <a name="org.cdk8s.plus22.MountPropagation.NONE"></a>
+#### `NONE` <a name="org.cdk8s.plus21.MountPropagation.NONE"></a>
 
 This volume mount will not receive any subsequent mounts that are mounted to this volume or any of its subdirectories by the host.
 
@@ -6142,7 +6079,7 @@ kernel documentation
 ---
 
 
-#### `HOST_TO_CONTAINER` <a name="org.cdk8s.plus22.MountPropagation.HOST_TO_CONTAINER"></a>
+#### `HOST_TO_CONTAINER` <a name="org.cdk8s.plus21.MountPropagation.HOST_TO_CONTAINER"></a>
 
 This volume mount will receive all subsequent mounts that are mounted to this volume or any of its subdirectories.
 
@@ -6159,7 +6096,7 @@ kernel documentation
 ---
 
 
-#### `BIDIRECTIONAL` <a name="org.cdk8s.plus22.MountPropagation.BIDIRECTIONAL"></a>
+#### `BIDIRECTIONAL` <a name="org.cdk8s.plus21.MountPropagation.BIDIRECTIONAL"></a>
 
 This volume mount behaves the same the HostToContainer mount.
 
@@ -6193,29 +6130,29 @@ continuing. When scaling down, the pods are removed in the opposite order.
 The alternative policy is `Parallel` which will create pods in parallel to match the
 desired scale without waiting, and on scale down will delete all pods at once.
 
-#### `ORDERED_READY` <a name="org.cdk8s.plus22.PodManagementPolicy.ORDERED_READY"></a>
+#### `ORDERED_READY` <a name="org.cdk8s.plus21.PodManagementPolicy.ORDERED_READY"></a>
 
 ---
 
 
-#### `PARALLEL` <a name="org.cdk8s.plus22.PodManagementPolicy.PARALLEL"></a>
+#### `PARALLEL` <a name="org.cdk8s.plus21.PodManagementPolicy.PARALLEL"></a>
 
 ---
 
 
 ### Protocol <a name="Protocol"></a>
 
-#### `TCP` <a name="org.cdk8s.plus22.Protocol.TCP"></a>
+#### `TCP` <a name="org.cdk8s.plus21.Protocol.TCP"></a>
 
 ---
 
 
-#### `UDP` <a name="org.cdk8s.plus22.Protocol.UDP"></a>
+#### `UDP` <a name="org.cdk8s.plus21.Protocol.UDP"></a>
 
 ---
 
 
-#### `SCTP` <a name="org.cdk8s.plus22.Protocol.SCTP"></a>
+#### `SCTP` <a name="org.cdk8s.plus21.Protocol.SCTP"></a>
 
 ---
 
@@ -6224,21 +6161,21 @@ desired scale without waiting, and on scale down will delete all pods at once.
 
 Restart policy for all containers within the pod.
 
-#### `ALWAYS` <a name="org.cdk8s.plus22.RestartPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="org.cdk8s.plus21.RestartPolicy.ALWAYS"></a>
 
 Always restart the pod after it exits.
 
 ---
 
 
-#### `ON_FAILURE` <a name="org.cdk8s.plus22.RestartPolicy.ON_FAILURE"></a>
+#### `ON_FAILURE` <a name="org.cdk8s.plus21.RestartPolicy.ON_FAILURE"></a>
 
 Only restart if the pod exits with a non-zero exit code.
 
 ---
 
 
-#### `NEVER` <a name="org.cdk8s.plus22.RestartPolicy.NEVER"></a>
+#### `NEVER` <a name="org.cdk8s.plus21.RestartPolicy.NEVER"></a>
 
 Never restart the pod.
 
@@ -6252,7 +6189,7 @@ For some parts of your application (for example, frontends) you may want to expo
 Kubernetes ServiceTypes allow you to specify what kind of Service you want.
 The default is ClusterIP.
 
-#### `CLUSTER_IP` <a name="org.cdk8s.plus22.ServiceType.CLUSTER_IP"></a>
+#### `CLUSTER_IP` <a name="org.cdk8s.plus21.ServiceType.CLUSTER_IP"></a>
 
 Exposes the Service on a cluster-internal IP.
 
@@ -6262,7 +6199,7 @@ This is the default ServiceType
 ---
 
 
-#### `NODE_PORT` <a name="org.cdk8s.plus22.ServiceType.NODE_PORT"></a>
+#### `NODE_PORT` <a name="org.cdk8s.plus21.ServiceType.NODE_PORT"></a>
 
 Exposes the Service on each Node's IP at a static port (the NodePort).
 
@@ -6273,7 +6210,7 @@ by requesting <NodeIP>:<NodePort>.
 ---
 
 
-#### `LOAD_BALANCER` <a name="org.cdk8s.plus22.ServiceType.LOAD_BALANCER"></a>
+#### `LOAD_BALANCER` <a name="org.cdk8s.plus21.ServiceType.LOAD_BALANCER"></a>
 
 Exposes the Service externally using a cloud provider's load balancer.
 
@@ -6283,7 +6220,7 @@ are automatically created.
 ---
 
 
-#### `EXTERNAL_NAME` <a name="org.cdk8s.plus22.ServiceType.EXTERNAL_NAME"></a>
+#### `EXTERNAL_NAME` <a name="org.cdk8s.plus21.ServiceType.EXTERNAL_NAME"></a>
 
 Maps the Service to the contents of the externalName field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -2,16 +2,16 @@
 
 ## Constructs <a name="Constructs"></a>
 
-### ConfigMap <a name="org.cdk8s.plus21.ConfigMap"></a>
+### ConfigMap <a name="org.cdk8s.plus22.ConfigMap"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
+- *Implements:* [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap)
 
 ConfigMap holds configuration data for pods to consume.
 
-#### Initializers <a name="org.cdk8s.plus21.ConfigMap.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.ConfigMap.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ConfigMap;
+import org.cdk8s.plus22.ConfigMap;
 
 ConfigMap.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -20,19 +20,19 @@ ConfigMap.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -40,7 +40,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binaryData`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.parameter.binaryData"></a>
+##### `binaryData`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.parameter.binaryData"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.String`>
 
@@ -56,7 +56,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.parameter.data"></a>
+##### `data`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.parameter.data"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.String`>
 
@@ -73,13 +73,13 @@ You can also add data using `configMap.addData()`.
 
 #### Methods <a name="Methods"></a>
 
-##### `addBinaryData` <a name="org.cdk8s.plus21.ConfigMap.addBinaryData"></a>
+##### `addBinaryData` <a name="org.cdk8s.plus22.ConfigMap.addBinaryData"></a>
 
 ```java
 public addBinaryData(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -87,7 +87,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -95,13 +95,13 @@ The value.
 
 ---
 
-##### `addData` <a name="org.cdk8s.plus21.ConfigMap.addData"></a>
+##### `addData` <a name="org.cdk8s.plus22.ConfigMap.addData"></a>
 
 ```java
 public addData(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -109,7 +109,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -117,14 +117,14 @@ The value.
 
 ---
 
-##### `addDirectory` <a name="org.cdk8s.plus21.ConfigMap.addDirectory"></a>
+##### `addDirectory` <a name="org.cdk8s.plus22.ConfigMap.addDirectory"></a>
 
 ```java
 public addDirectory(java.lang.String localDir)
 public addDirectory(java.lang.String localDir, AddDirectoryOptions options)
 ```
 
-###### `localDir`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.localDir"></a>
+###### `localDir`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.localDir"></a>
 
 - *Type:* `java.lang.String`
 
@@ -132,22 +132,22 @@ A path to a local directory.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.AddDirectoryOptions`](#org.cdk8s.plus21.AddDirectoryOptions)
+- *Type:* [`org.cdk8s.plus22.AddDirectoryOptions`](#org.cdk8s.plus22.AddDirectoryOptions)
 
 Options.
 
 ---
 
-##### `addFile` <a name="org.cdk8s.plus21.ConfigMap.addFile"></a>
+##### `addFile` <a name="org.cdk8s.plus22.ConfigMap.addFile"></a>
 
 ```java
 public addFile(java.lang.String localFile)
 public addFile(java.lang.String localFile, java.lang.String key)
 ```
 
-###### `localFile`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.localFile"></a>
+###### `localFile`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.localFile"></a>
 
 - *Type:* `java.lang.String`
 
@@ -155,7 +155,7 @@ The path to the local file.
 
 ---
 
-###### `key`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -165,15 +165,15 @@ The ConfigMap key (default to the file name).
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMapName` <a name="org.cdk8s.plus21.ConfigMap.fromConfigMapName"></a>
+##### `fromConfigMapName` <a name="org.cdk8s.plus22.ConfigMap.fromConfigMapName"></a>
 
 ```java
-import org.cdk8s.plus21.ConfigMap;
+import org.cdk8s.plus22.ConfigMap;
 
 ConfigMap.fromConfigMapName(java.lang.String name)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
@@ -183,7 +183,7 @@ The name of the config map to import.
 
 #### Properties <a name="Properties"></a>
 
-##### `binaryData`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.property.binaryData"></a>
+##### `binaryData`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.property.binaryData"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getBinaryData();
@@ -197,7 +197,7 @@ Returns a copy. To add data records, use `addBinaryData()` or `addData()`.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="org.cdk8s.plus21.ConfigMap.property.data"></a>
+##### `data`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.property.data"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getData();
@@ -212,9 +212,9 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 ---
 
 
-### Deployment <a name="org.cdk8s.plus21.Deployment"></a>
+### Deployment <a name="org.cdk8s.plus22.Deployment"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
+- *Implements:* [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
 
 A Deployment provides declarative updates for Pods and ReplicaSets.
 
@@ -241,10 +241,10 @@ The following are typical use cases for Deployments:
 - Use the status of the Deployment as an indicator that a rollout has stuck.
 - Clean up older ReplicaSets that you don't need anymore.
 
-#### Initializers <a name="org.cdk8s.plus21.Deployment.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Deployment.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Deployment;
+import org.cdk8s.plus22.Deployment;
 
 Deployment.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -258,19 +258,19 @@ Deployment.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -278,9 +278,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -292,9 +292,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -303,9 +303,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -321,9 +321,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -334,7 +334,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.podMetadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -342,7 +342,7 @@ The pod metadata.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.defaultSelector"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* true
@@ -354,7 +354,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.replicas"></a>
 
 - *Type:* `java.lang.Number`
 - *Default:* 1
@@ -365,60 +365,52 @@ Number of desired pods.
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus21.Deployment.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus22.Deployment.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
+- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus21.Deployment.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus22.Deployment.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
 
 ---
 
-##### `expose` <a name="org.cdk8s.plus21.Deployment.expose"></a>
+##### `expose` <a name="org.cdk8s.plus22.Deployment.expose"></a>
 
 ```java
-public expose(java.lang.Number port)
-public expose(java.lang.Number port, ExposeOptions options)
+public expose()
+public expose(ExposeOptions options)
 ```
 
-###### `port`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.port"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Deployment.parameter.options"></a>
 
-- *Type:* `java.lang.Number`
-
-The port number the service will bind to.
-
----
-
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Deployment.parameter.options"></a>
-
-- *Type:* [`org.cdk8s.plus21.ExposeOptions`](#org.cdk8s.plus21.ExposeOptions)
+- *Type:* [`org.cdk8s.plus22.ExposeOptions`](#org.cdk8s.plus22.ExposeOptions)
 
 Options to determine details of the service and port exposed.
 
 ---
 
-##### `selectByLabel` <a name="org.cdk8s.plus21.Deployment.selectByLabel"></a>
+##### `selectByLabel` <a name="org.cdk8s.plus22.Deployment.selectByLabel"></a>
 
 ```java
 public selectByLabel(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -426,7 +418,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -437,13 +429,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
 
 The containers belonging to the pod.
 
@@ -451,7 +443,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `labelSelector`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.labelSelector"></a>
+##### `labelSelector`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.labelSelector"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getLabelSelector();
@@ -465,7 +457,7 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -477,7 +469,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.replicas"></a>
 
 ```java
 public java.lang.Number getReplicas();
@@ -489,13 +481,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 
 The volumes associated with this pod.
 
@@ -503,32 +495,32 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.Deployment.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.Deployment.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.Deployment.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.Deployment.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### IngressV1Beta1 <a name="org.cdk8s.plus21.IngressV1Beta1"></a>
+### Ingress <a name="org.cdk8s.plus22.Ingress"></a>
 
 Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend.
 
@@ -536,32 +528,32 @@ An Ingress can be configured to give services
 externally-reachable urls, load balance traffic, terminate SSL, offer name
 based virtual hosting etc.
 
-#### Initializers <a name="org.cdk8s.plus21.IngressV1Beta1.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Ingress.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.IngressV1Beta1;
+import org.cdk8s.plus22.Ingress;
 
-IngressV1Beta1.Builder.create(Construct scope, java.lang.String id)
+Ingress.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
-//  .defaultBackend(IngressV1Beta1Backend)
-//  .rules(java.util.List<IngressV1Beta1Rule>)
-//  .tls(java.util.List<IngressV1Beta1Tls>)
+//  .defaultBackend(IngressBackend)
+//  .rules(java.util.List<IngressRule>)
+//  .tls(java.util.List<IngressTls>)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -569,9 +561,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `defaultBackend`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.parameter.defaultBackend"></a>
+##### `defaultBackend`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.parameter.defaultBackend"></a>
 
-- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
+- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
 
 The default backend services requests that do not match any rule.
 
@@ -580,9 +572,9 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.parameter.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.parameter.rules"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Rule`](#org.cdk8s.plus21.IngressV1Beta1Rule)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.IngressRule`](#org.cdk8s.plus22.IngressRule)>
 
 Routing rules for this ingress.
 
@@ -595,9 +587,9 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.parameter.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.parameter.tls"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Tls`](#org.cdk8s.plus21.IngressV1Beta1Tls)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.IngressTls`](#org.cdk8s.plus22.IngressTls)>
 
 TLS settings for this ingress.
 
@@ -611,27 +603,27 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 #### Methods <a name="Methods"></a>
 
-##### `addDefaultBackend` <a name="org.cdk8s.plus21.IngressV1Beta1.addDefaultBackend"></a>
+##### `addDefaultBackend` <a name="org.cdk8s.plus22.Ingress.addDefaultBackend"></a>
 
 ```java
-public addDefaultBackend(IngressV1Beta1Backend backend)
+public addDefaultBackend(IngressBackend backend)
 ```
 
-###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.backend"></a>
 
-- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
+- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
 
 The backend to use for requests that do not match any rule.
 
 ---
 
-##### `addHostDefaultBackend` <a name="org.cdk8s.plus21.IngressV1Beta1.addHostDefaultBackend"></a>
+##### `addHostDefaultBackend` <a name="org.cdk8s.plus22.Ingress.addHostDefaultBackend"></a>
 
 ```java
-public addHostDefaultBackend(java.lang.String host, IngressV1Beta1Backend backend)
+public addHostDefaultBackend(java.lang.String host, IngressBackend backend)
 ```
 
-###### `host`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.host"></a>
 
 - *Type:* `java.lang.String`
 
@@ -639,21 +631,22 @@ The host name to match.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.backend"></a>
 
-- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
+- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
 
 The backend to route to.
 
 ---
 
-##### `addHostRule` <a name="org.cdk8s.plus21.IngressV1Beta1.addHostRule"></a>
+##### `addHostRule` <a name="org.cdk8s.plus22.Ingress.addHostRule"></a>
 
 ```java
-public addHostRule(java.lang.String host, java.lang.String path, IngressV1Beta1Backend backend)
+public addHostRule(java.lang.String host, java.lang.String path, IngressBackend backend)
+public addHostRule(java.lang.String host, java.lang.String path, IngressBackend backend, HttpIngressPathType pathType)
 ```
 
-###### `host`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.host"></a>
 
 - *Type:* `java.lang.String`
 
@@ -661,7 +654,7 @@ The host name.
 
 ---
 
-###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.path"></a>
 
 - *Type:* `java.lang.String`
 
@@ -669,21 +662,30 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.backend"></a>
 
-- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
+- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
 
 The backend to route requests to.
 
 ---
 
-##### `addRule` <a name="org.cdk8s.plus21.IngressV1Beta1.addRule"></a>
+###### `pathType`<sup>Optional</sup> <a name="org.cdk8s.plus22.Ingress.parameter.pathType"></a>
+
+- *Type:* [`org.cdk8s.plus22.HttpIngressPathType`](#org.cdk8s.plus22.HttpIngressPathType)
+
+How the path is matched against request paths.
+
+---
+
+##### `addRule` <a name="org.cdk8s.plus22.Ingress.addRule"></a>
 
 ```java
-public addRule(java.lang.String path, IngressV1Beta1Backend backend)
+public addRule(java.lang.String path, IngressBackend backend)
+public addRule(java.lang.String path, IngressBackend backend, HttpIngressPathType pathType)
 ```
 
-###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.path"></a>
 
 - *Type:* `java.lang.String`
 
@@ -691,46 +693,54 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.backend"></a>
 
-- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
+- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
 
 The backend to route requests to.
 
 ---
 
-##### `addRules` <a name="org.cdk8s.plus21.IngressV1Beta1.addRules"></a>
+###### `pathType`<sup>Optional</sup> <a name="org.cdk8s.plus22.Ingress.parameter.pathType"></a>
+
+- *Type:* [`org.cdk8s.plus22.HttpIngressPathType`](#org.cdk8s.plus22.HttpIngressPathType)
+
+How the path is matched against request paths.
+
+---
+
+##### `addRules` <a name="org.cdk8s.plus22.Ingress.addRules"></a>
 
 ```java
-public addRules(IngressV1Beta1Rule rules)
+public addRules(IngressRule rules)
 ```
 
-###### `rules`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.rules"></a>
+###### `rules`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.rules"></a>
 
-- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Rule`](#org.cdk8s.plus21.IngressV1Beta1Rule)
+- *Type:* [`org.cdk8s.plus22.IngressRule`](#org.cdk8s.plus22.IngressRule)
 
 The rules to add.
 
 ---
 
-##### `addTls` <a name="org.cdk8s.plus21.IngressV1Beta1.addTls"></a>
+##### `addTls` <a name="org.cdk8s.plus22.Ingress.addTls"></a>
 
 ```java
-public addTls(java.util.List<IngressV1Beta1Tls> tls)
+public addTls(java.util.List<IngressTls> tls)
 ```
 
-###### `tls`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1.parameter.tls"></a>
+###### `tls`<sup>Required</sup> <a name="org.cdk8s.plus22.Ingress.parameter.tls"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Tls`](#org.cdk8s.plus21.IngressV1Beta1Tls)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.IngressTls`](#org.cdk8s.plus22.IngressTls)>
 
 ---
 
 
 
 
-### Job <a name="org.cdk8s.plus21.Job"></a>
+### Job <a name="org.cdk8s.plus22.Job"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
+- *Implements:* [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
 
 A Job creates one or more Pods and ensures that a specified number of them successfully terminate.
 
@@ -740,10 +750,10 @@ Deleting a Job will clean up the Pods it created. A simple case is to create one
 The Job object will start a new Pod if the first Pod fails or is deleted (for example due to a node hardware failure or a node reboot).
 You can also use a Job to run multiple Pods in parallel.
 
-#### Initializers <a name="org.cdk8s.plus21.Job.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Job.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Job;
+import org.cdk8s.plus22.Job;
 
 Job.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -758,19 +768,19 @@ Job.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -778,9 +788,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -792,9 +802,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -803,9 +813,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -821,9 +831,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -834,7 +844,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.podMetadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -842,7 +852,7 @@ The pod metadata.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.activeDeadline"></a>
 
 - *Type:* [`org.cdk8s.Duration`](#org.cdk8s.Duration)
 - *Default:* If unset, then there is no deadline.
@@ -851,7 +861,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.backoffLimit"></a>
 
 - *Type:* `java.lang.Number`
 - *Default:* If not set, system defaults to 6.
@@ -860,7 +870,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.ttlAfterFinished"></a>
 
 - *Type:* [`org.cdk8s.Duration`](#org.cdk8s.Duration)
 - *Default:* If this field is unset, the Job won't be automatically deleted.
@@ -878,40 +888,40 @@ field is alpha-level and is only honored by servers that enable the
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus21.Job.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus22.Job.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
+- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus21.Job.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus22.Job.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
 
 The containers belonging to the pod.
 
@@ -919,7 +929,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -931,13 +941,13 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.Job.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 
 The volumes associated with this pod.
 
@@ -945,7 +955,7 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.activeDeadline"></a>
 
 ```java
 public Duration getActiveDeadline();
@@ -959,7 +969,7 @@ If undefined, there is no deadline.
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.backoffLimit"></a>
 
 ```java
 public java.lang.Number getBackoffLimit();
@@ -971,31 +981,31 @@ Number of retries before marking failed.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus21.Job.property.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus22.Job.property.ttlAfterFinished"></a>
 
 ```java
 public Duration getTtlAfterFinished();
@@ -1008,19 +1018,19 @@ TTL before the job is deleted after it is finished.
 ---
 
 
-### Pod <a name="org.cdk8s.plus21.Pod"></a>
+### Pod <a name="org.cdk8s.plus22.Pod"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IPodSpec`](#org.cdk8s.plus21.IPodSpec)
+- *Implements:* [`org.cdk8s.plus22.IPodSpec`](#org.cdk8s.plus22.IPodSpec)
 
 Pod is a collection of containers that can run on a host.
 
 This resource is
 created by clients and scheduled onto hosts.
 
-#### Initializers <a name="org.cdk8s.plus21.Pod.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Pod.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Pod;
+import org.cdk8s.plus22.Pod;
 
 Pod.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1031,19 +1041,19 @@ Pod.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1051,9 +1061,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1065,9 +1075,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -1076,9 +1086,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -1094,9 +1104,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -1109,40 +1119,40 @@ You can also add volumes later using `podSpec.addVolume()`
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus21.Pod.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus22.Pod.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
+- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus21.Pod.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus22.Pod.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
 
 The containers belonging to the pod.
 
@@ -1150,13 +1160,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.Pod.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 
 The volumes associated with this pod.
 
@@ -1164,51 +1174,51 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.Pod.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.Pod.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.Pod.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.Pod.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Resource <a name="org.cdk8s.plus21.Resource"></a>
+### Resource <a name="org.cdk8s.plus22.Resource"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
+- *Implements:* [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource)
 
 Base class for all Kubernetes objects in stdk8s.
 
 Represents a single
 resource.
 
-#### Initializers <a name="org.cdk8s.plus21.Resource.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Resource.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Resource;
+import org.cdk8s.plus22.Resource;
 
 Resource.Builder.create(Construct scope, java.lang.String id)
 //  .nodeFactory(INodeFactory)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Resource.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Resource.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
@@ -1216,7 +1226,7 @@ The scope in which to define this construct.
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Resource.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Resource.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1241,7 +1251,7 @@ A factory for attaching `Node`s to the construct.
 
 #### Properties <a name="Properties"></a>
 
-##### `metadata`<sup>Required</sup> <a name="org.cdk8s.plus21.Resource.property.metadata"></a>
+##### `metadata`<sup>Required</sup> <a name="org.cdk8s.plus22.Resource.property.metadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getMetadata();
@@ -1251,7 +1261,7 @@ public ApiObjectMetadataDefinition getMetadata();
 
 ---
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Resource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Resource.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -1264,9 +1274,9 @@ The name of this API object.
 ---
 
 
-### Secret <a name="org.cdk8s.plus21.Secret"></a>
+### Secret <a name="org.cdk8s.plus22.Secret"></a>
 
-- *Implements:* [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
+- *Implements:* [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
 
 Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 
@@ -1276,10 +1286,10 @@ definition or in a container image.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
 
-#### Initializers <a name="org.cdk8s.plus21.Secret.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Secret.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Secret;
+import org.cdk8s.plus22.Secret;
 
 Secret.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1288,19 +1298,19 @@ Secret.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1308,7 +1318,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.stringData"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.String`>
 
@@ -1321,7 +1331,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.type"></a>
+##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.type"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* undefined - Don't set a type.
@@ -1335,13 +1345,13 @@ handling of secret data by various controllers.
 
 #### Methods <a name="Methods"></a>
 
-##### `addStringData` <a name="org.cdk8s.plus21.Secret.addStringData"></a>
+##### `addStringData` <a name="org.cdk8s.plus22.Secret.addStringData"></a>
 
 ```java
 public addStringData(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1349,7 +1359,7 @@ Key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1357,13 +1367,13 @@ Value.
 
 ---
 
-##### `getStringData` <a name="org.cdk8s.plus21.Secret.getStringData"></a>
+##### `getStringData` <a name="org.cdk8s.plus22.Secret.getStringData"></a>
 
 ```java
 public getStringData(java.lang.String key)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1373,15 +1383,15 @@ Key.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromSecretName` <a name="org.cdk8s.plus21.Secret.fromSecretName"></a>
+##### `fromSecretName` <a name="org.cdk8s.plus22.Secret.fromSecretName"></a>
 
 ```java
-import org.cdk8s.plus21.Secret;
+import org.cdk8s.plus22.Secret;
 
 Secret.fromSecretName(java.lang.String name)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1391,7 +1401,7 @@ The name of the secret to reference.
 
 
 
-### Service <a name="org.cdk8s.plus21.Service"></a>
+### Service <a name="org.cdk8s.plus22.Service"></a>
 
 An abstract way to expose an application running on a set of Pods as a network service.
 
@@ -1407,10 +1417,10 @@ If you're able to use Kubernetes APIs for service discovery in your application,
 that get updated whenever the set of Pods in a Service changes. For non-native applications, Kubernetes offers ways to place a network port
 or load balancer in between your application and the backend Pods.
 
-#### Initializers <a name="org.cdk8s.plus21.Service.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Service.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Service;
+import org.cdk8s.plus22.Service;
 
 Service.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1423,19 +1433,19 @@ Service.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1443,7 +1453,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.clusterIP"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* Automatically assigned.
@@ -1461,7 +1471,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `externalIPs`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.externalIPs"></a>
+##### `externalIPs`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.externalIPs"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 - *Default:* No external IPs.
@@ -1475,7 +1485,7 @@ Kubernetes system.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.externalName"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* No external name.
@@ -1484,7 +1494,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.loadBalancerSourceRanges"></a>
+##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.loadBalancerSourceRanges"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 
@@ -1494,9 +1504,9 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.ports"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ServicePort`](#org.cdk8s.plus21.ServicePort)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ServicePort`](#org.cdk8s.plus22.ServicePort)>
 
 The port exposed by this service.
 
@@ -1504,9 +1514,9 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.parameter.type"></a>
+##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.parameter.type"></a>
 
-- *Type:* [`org.cdk8s.plus21.ServiceType`](#org.cdk8s.plus21.ServiceType)
+- *Type:* [`org.cdk8s.plus22.ServiceType`](#org.cdk8s.plus22.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -1517,44 +1527,36 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 #### Methods <a name="Methods"></a>
 
-##### `addDeployment` <a name="org.cdk8s.plus21.Service.addDeployment"></a>
+##### `addDeployment` <a name="org.cdk8s.plus22.Service.addDeployment"></a>
 
 ```java
-public addDeployment(Deployment deployment, java.lang.Number port)
-public addDeployment(Deployment deployment, java.lang.Number port, ServicePortOptions options)
+public addDeployment(Deployment deployment)
+public addDeployment(Deployment deployment, AddDeploymentOptions options)
 ```
 
-###### `deployment`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.deployment"></a>
+###### `deployment`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.deployment"></a>
 
-- *Type:* [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment)
+- *Type:* [`org.cdk8s.plus22.Deployment`](#org.cdk8s.plus22.Deployment)
 
 The deployment to expose.
 
 ---
 
-###### `port`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.port"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Service.parameter.options"></a>
 
-- *Type:* `java.lang.Number`
-
-The external port.
-
----
-
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Service.parameter.options"></a>
-
-- *Type:* [`org.cdk8s.plus21.ServicePortOptions`](#org.cdk8s.plus21.ServicePortOptions)
+- *Type:* [`org.cdk8s.plus22.AddDeploymentOptions`](#org.cdk8s.plus22.AddDeploymentOptions)
 
 Optional settings for the port.
 
 ---
 
-##### `addSelector` <a name="org.cdk8s.plus21.Service.addSelector"></a>
+##### `addSelector` <a name="org.cdk8s.plus22.Service.addSelector"></a>
 
 ```java
 public addSelector(java.lang.String label, java.lang.String value)
 ```
 
-###### `label`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.label"></a>
+###### `label`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.label"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1562,7 +1564,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1570,14 +1572,14 @@ The label value.
 
 ---
 
-##### `serve` <a name="org.cdk8s.plus21.Service.serve"></a>
+##### `serve` <a name="org.cdk8s.plus22.Service.serve"></a>
 
 ```java
 public serve(java.lang.Number port)
 public serve(java.lang.Number port, ServicePortOptions options)
 ```
 
-###### `port`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.parameter.port"></a>
+###### `port`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.parameter.port"></a>
 
 - *Type:* `java.lang.Number`
 
@@ -1585,22 +1587,22 @@ The port definition.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Service.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Service.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.ServicePortOptions`](#org.cdk8s.plus21.ServicePortOptions)
+- *Type:* [`org.cdk8s.plus22.ServicePortOptions`](#org.cdk8s.plus22.ServicePortOptions)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `ports`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.property.ports"></a>
+##### `ports`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.property.ports"></a>
 
 ```java
 public java.util.List<ServicePort> getPorts();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ServicePort`](#org.cdk8s.plus21.ServicePort)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ServicePort`](#org.cdk8s.plus22.ServicePort)>
 
 Ports for this service.
 
@@ -1608,7 +1610,7 @@ Use `serve()` to expose additional service ports.
 
 ---
 
-##### `selector`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.property.selector"></a>
+##### `selector`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.property.selector"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getSelector();
@@ -1620,19 +1622,19 @@ Returns the labels which are used to select pods for this service.
 
 ---
 
-##### `type`<sup>Required</sup> <a name="org.cdk8s.plus21.Service.property.type"></a>
+##### `type`<sup>Required</sup> <a name="org.cdk8s.plus22.Service.property.type"></a>
 
 ```java
 public ServiceType getType();
 ```
 
-- *Type:* [`org.cdk8s.plus21.ServiceType`](#org.cdk8s.plus21.ServiceType)
+- *Type:* [`org.cdk8s.plus22.ServiceType`](#org.cdk8s.plus22.ServiceType)
 
 Determines how the Service is exposed.
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus21.Service.property.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus22.Service.property.clusterIP"></a>
 
 ```java
 public java.lang.String getClusterIP();
@@ -1644,7 +1646,7 @@ The IP address of the service and is usually assigned randomly by the master.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus21.Service.property.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus22.Service.property.externalName"></a>
 
 ```java
 public java.lang.String getExternalName();
@@ -1657,9 +1659,9 @@ The externalName to be used for EXTERNAL_NAME types.
 ---
 
 
-### ServiceAccount <a name="org.cdk8s.plus21.ServiceAccount"></a>
+### ServiceAccount <a name="org.cdk8s.plus22.ServiceAccount"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Implements:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 A service account provides an identity for processes that run in a Pod.
 
@@ -1672,10 +1674,10 @@ example, default).
 
 > https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account
 
-#### Initializers <a name="org.cdk8s.plus21.ServiceAccount.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.ServiceAccount.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ServiceAccount;
+import org.cdk8s.plus22.ServiceAccount;
 
 ServiceAccount.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1683,19 +1685,19 @@ ServiceAccount.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1703,9 +1705,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountProps.parameter.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountProps.parameter.secrets"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)>
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -1715,15 +1717,15 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 #### Methods <a name="Methods"></a>
 
-##### `addSecret` <a name="org.cdk8s.plus21.ServiceAccount.addSecret"></a>
+##### `addSecret` <a name="org.cdk8s.plus22.ServiceAccount.addSecret"></a>
 
 ```java
 public addSecret(ISecret secret)
 ```
 
-###### `secret`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.parameter.secret"></a>
+###### `secret`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.parameter.secret"></a>
 
-- *Type:* [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
+- *Type:* [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
 
 The secret.
 
@@ -1731,15 +1733,15 @@ The secret.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromServiceAccountName` <a name="org.cdk8s.plus21.ServiceAccount.fromServiceAccountName"></a>
+##### `fromServiceAccountName` <a name="org.cdk8s.plus22.ServiceAccount.fromServiceAccountName"></a>
 
 ```java
-import org.cdk8s.plus21.ServiceAccount;
+import org.cdk8s.plus22.ServiceAccount;
 
 ServiceAccount.fromServiceAccountName(java.lang.String name)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1749,13 +1751,13 @@ The name of the service account resource.
 
 #### Properties <a name="Properties"></a>
 
-##### `secrets`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccount.property.secrets"></a>
+##### `secrets`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccount.property.secrets"></a>
 
 ```java
 public java.util.List<ISecret> getSecrets();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)>
 
 List of secrets allowed to be used by pods running using this service account.
 
@@ -1764,9 +1766,9 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
-### StatefulSet <a name="org.cdk8s.plus21.StatefulSet"></a>
+### StatefulSet <a name="org.cdk8s.plus22.StatefulSet"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
+- *Implements:* [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
 
 StatefulSet is the workload API object used to manage stateful applications.
 
@@ -1793,10 +1795,10 @@ StatefulSets are valuable for applications that require one or more of the follo
 - Ordered, graceful deployment and scaling.
 - Ordered, automated rolling updates.
 
-#### Initializers <a name="org.cdk8s.plus21.StatefulSet.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.StatefulSet.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.StatefulSet;
+import org.cdk8s.plus22.StatefulSet;
 
 StatefulSet.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
@@ -1812,19 +1814,19 @@ StatefulSet.Builder.create(Construct scope, java.lang.String id)
     .build();
 ```
 
-##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.scope"></a>
 
 - *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.id"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.metadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1832,9 +1834,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1846,9 +1848,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -1857,9 +1859,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -1875,9 +1877,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -1888,7 +1890,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.podMetadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -1896,15 +1898,15 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.service"></a>
+##### `service`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.service"></a>
 
-- *Type:* [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service)
+- *Type:* [`org.cdk8s.plus22.Service`](#org.cdk8s.plus22.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.defaultSelector"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* true
@@ -1916,16 +1918,16 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `podManagementPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.podManagementPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus21.PodManagementPolicy`](#org.cdk8s.plus21.PodManagementPolicy)
+- *Type:* [`org.cdk8s.plus22.PodManagementPolicy`](#org.cdk8s.plus22.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.replicas"></a>
 
 - *Type:* `java.lang.Number`
 - *Default:* 1
@@ -1936,37 +1938,37 @@ Number of desired pods.
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus21.StatefulSet.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus22.StatefulSet.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
+- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus21.StatefulSet.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus22.StatefulSet.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
 
 ---
 
-##### `selectByLabel` <a name="org.cdk8s.plus21.StatefulSet.selectByLabel"></a>
+##### `selectByLabel` <a name="org.cdk8s.plus22.StatefulSet.selectByLabel"></a>
 
 ```java
 public selectByLabel(java.lang.String key, java.lang.String value)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1974,7 +1976,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1985,13 +1987,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
 
 The containers belonging to the pod.
 
@@ -1999,7 +2001,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `labelSelector`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.labelSelector"></a>
+##### `labelSelector`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.labelSelector"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getLabelSelector();
@@ -2013,19 +2015,19 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `podManagementPolicy`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.podManagementPolicy"></a>
 
 ```java
 public PodManagementPolicy getPodManagementPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.PodManagementPolicy`](#org.cdk8s.plus21.PodManagementPolicy)
+- *Type:* [`org.cdk8s.plus22.PodManagementPolicy`](#org.cdk8s.plus22.PodManagementPolicy)
 
 Management policy to use for the set.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -2037,7 +2039,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.replicas"></a>
 
 ```java
 public java.lang.Number getReplicas();
@@ -2049,13 +2051,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 
 The volumes associated with this pod.
 
@@ -2063,25 +2065,25 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSet.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSet.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSet.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSet.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 The service account used to run this pod.
 
@@ -2090,14 +2092,110 @@ The service account used to run this pod.
 
 ## Structs <a name="Structs"></a>
 
-### AddDirectoryOptions <a name="org.cdk8s.plus21.AddDirectoryOptions"></a>
+### AddDeploymentOptions <a name="org.cdk8s.plus22.AddDeploymentOptions"></a>
+
+Options to add a deployment to a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus22.AddDeploymentOptions;
+
+AddDeploymentOptions.builder()
+//  .name(java.lang.String)
+//  .nodePort(java.lang.Number)
+//  .protocol(Protocol)
+//  .targetPort(java.lang.Number)
+//  .port(java.lang.Number)
+    .build();
+```
+
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.name"></a>
+
+```java
+public java.lang.String getName();
+```
+
+- *Type:* `java.lang.String`
+
+The name of this port within the service.
+
+This must be a DNS_LABEL. All
+ports within a ServiceSpec must have unique names. This maps to the 'Name'
+field in EndpointPort objects. Optional if only one ServicePort is defined
+on this service.
+
+---
+
+##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.nodePort"></a>
+
+```java
+public java.lang.Number getNodePort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
+
+The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
+
+Usually assigned by the system. If specified, it will be
+allocated to the service if unused or else creation of the service will
+fail. Default is to auto-allocate a port if the ServiceType of this Service
+requires one.
+
+> https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.protocol"></a>
+
+```java
+public Protocol getProtocol();
+```
+
+- *Type:* [`org.cdk8s.plus22.Protocol`](#org.cdk8s.plus22.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.targetPort"></a>
+
+```java
+public java.lang.Number getTargetPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* The value of `port` will be used.
+
+The port number the service will redirect to.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDeploymentOptions.property.port"></a>
+
+```java
+public java.lang.Number getPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* Copied from the first container of the deployment.
+
+The port number the service will bind to.
+
+---
+
+### AddDirectoryOptions <a name="org.cdk8s.plus22.AddDirectoryOptions"></a>
 
 Options for `configmap.addDirectory()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.AddDirectoryOptions;
+import org.cdk8s.plus22.AddDirectoryOptions;
 
 AddDirectoryOptions.builder()
 //  .exclude(java.util.List<java.lang.String>)
@@ -2105,7 +2203,7 @@ AddDirectoryOptions.builder()
     .build();
 ```
 
-##### `exclude`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDirectoryOptions.property.exclude"></a>
+##### `exclude`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDirectoryOptions.property.exclude"></a>
 
 ```java
 public java.util.List<java.lang.String> getExclude();
@@ -2118,7 +2216,7 @@ Glob patterns to exclude when adding files.
 
 ---
 
-##### `keyPrefix`<sup>Optional</sup> <a name="org.cdk8s.plus21.AddDirectoryOptions.property.keyPrefix"></a>
+##### `keyPrefix`<sup>Optional</sup> <a name="org.cdk8s.plus22.AddDirectoryOptions.property.keyPrefix"></a>
 
 ```java
 public java.lang.String getKeyPrefix();
@@ -2131,14 +2229,14 @@ A prefix to add to all keys in the config map.
 
 ---
 
-### CommandProbeOptions <a name="org.cdk8s.plus21.CommandProbeOptions"></a>
+### CommandProbeOptions <a name="org.cdk8s.plus22.CommandProbeOptions"></a>
 
 Options for `Probe.fromCommand()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.CommandProbeOptions;
+import org.cdk8s.plus22.CommandProbeOptions;
 
 CommandProbeOptions.builder()
 //  .failureThreshold(java.lang.Number)
@@ -2149,7 +2247,7 @@ CommandProbeOptions.builder()
     .build();
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.failureThreshold"></a>
 
 ```java
 public java.lang.Number getFailureThreshold();
@@ -2164,7 +2262,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.initialDelaySeconds"></a>
 
 ```java
 public Duration getInitialDelaySeconds();
@@ -2179,7 +2277,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.periodSeconds"></a>
 
 ```java
 public Duration getPeriodSeconds();
@@ -2194,7 +2292,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.successThreshold"></a>
 
 ```java
 public java.lang.Number getSuccessThreshold();
@@ -2209,7 +2307,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommandProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommandProbeOptions.property.timeoutSeconds"></a>
 
 ```java
 public Duration getTimeoutSeconds();
@@ -2226,14 +2324,14 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="org.cdk8s.plus21.ConfigMapProps"></a>
+### ConfigMapProps <a name="org.cdk8s.plus22.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ConfigMapProps;
+import org.cdk8s.plus22.ConfigMapProps;
 
 ConfigMapProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -2242,7 +2340,7 @@ ConfigMapProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -2254,7 +2352,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binaryData`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.property.binaryData"></a>
+##### `binaryData`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.property.binaryData"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getBinaryData();
@@ -2274,7 +2372,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapProps.property.data"></a>
+##### `data`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.property.data"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getData();
@@ -2293,14 +2391,14 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="org.cdk8s.plus21.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="org.cdk8s.plus22.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ConfigMapVolumeOptions;
+import org.cdk8s.plus22.ConfigMapVolumeOptions;
 
 ConfigMapVolumeOptions.builder()
 //  .defaultMode(java.lang.Number)
@@ -2310,7 +2408,7 @@ ConfigMapVolumeOptions.builder()
     .build();
 ```
 
-##### `defaultMode`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapVolumeOptions.property.defaultMode"></a>
+##### `defaultMode`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapVolumeOptions.property.defaultMode"></a>
 
 ```java
 public java.lang.Number getDefaultMode();
@@ -2330,13 +2428,13 @@ file mode, like fsGroup, and the result can be other mode bits set.
 
 ---
 
-##### `items`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapVolumeOptions.property.items"></a>
+##### `items`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapVolumeOptions.property.items"></a>
 
 ```java
 public java.util.Map<java.lang.String, PathMapping> getItems();
 ```
 
-- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus21.PathMapping`](#org.cdk8s.plus21.PathMapping)>
+- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus22.PathMapping`](#org.cdk8s.plus22.PathMapping)>
 - *Default:* no mapping
 
 If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value.
@@ -2349,7 +2447,7 @@ contain the '..' path or start with '..'.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapVolumeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapVolumeOptions.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -2362,7 +2460,7 @@ The volume name.
 
 ---
 
-##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus21.ConfigMapVolumeOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapVolumeOptions.property.optional"></a>
 
 ```java
 public java.lang.Boolean getOptional();
@@ -2375,14 +2473,14 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
-### ContainerProps <a name="org.cdk8s.plus21.ContainerProps"></a>
+### ContainerProps <a name="org.cdk8s.plus22.ContainerProps"></a>
 
 Properties for creating a container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ContainerProps;
+import org.cdk8s.plus22.ContainerProps;
 
 ContainerProps.builder()
     .image(java.lang.String)
@@ -2400,7 +2498,7 @@ ContainerProps.builder()
     .build();
 ```
 
-##### `image`<sup>Required</sup> <a name="org.cdk8s.plus21.ContainerProps.property.image"></a>
+##### `image`<sup>Required</sup> <a name="org.cdk8s.plus22.ContainerProps.property.image"></a>
 
 ```java
 public java.lang.String getImage();
@@ -2412,7 +2510,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.args"></a>
 
 ```java
 public java.util.List<java.lang.String> getArgs();
@@ -2435,7 +2533,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.command"></a>
 
 ```java
 public java.util.List<java.lang.String> getCommand();
@@ -2453,13 +2551,13 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.env"></a>
+##### `env`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.env"></a>
 
 ```java
 public java.util.Map<java.lang.String, EnvValue> getEnv();
 ```
 
-- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus21.EnvValue`](#org.cdk8s.plus21.EnvValue)>
+- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus22.EnvValue`](#org.cdk8s.plus22.EnvValue)>
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -2468,26 +2566,26 @@ Cannot be updated.
 
 ---
 
-##### `imagePullPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.imagePullPolicy"></a>
 
 ```java
 public ImagePullPolicy getImagePullPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.ImagePullPolicy`](#org.cdk8s.plus21.ImagePullPolicy)
+- *Type:* [`org.cdk8s.plus22.ImagePullPolicy`](#org.cdk8s.plus22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.liveness"></a>
 
 ```java
 public Probe getLiveness();
 ```
 
-- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
+- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -2496,7 +2594,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -2511,7 +2609,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -2526,26 +2624,26 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.readiness"></a>
 
 ```java
 public Probe getReadiness();
 ```
 
-- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
+- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.startup"></a>
 
 ```java
 public Probe getStartup();
 ```
 
-- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
+- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -2554,13 +2652,13 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volumeMounts`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.volumeMounts"></a>
+##### `volumeMounts`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.volumeMounts"></a>
 
 ```java
 public java.util.List<VolumeMount> getVolumeMounts();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.VolumeMount`](#org.cdk8s.plus21.VolumeMount)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.VolumeMount`](#org.cdk8s.plus22.VolumeMount)>
 
 Pod volumes to mount into the container's filesystem.
 
@@ -2568,7 +2666,7 @@ Cannot be updated.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.property.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.property.workingDir"></a>
 
 ```java
 public java.lang.String getWorkingDir();
@@ -2583,14 +2681,14 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-### DeploymentProps <a name="org.cdk8s.plus21.DeploymentProps"></a>
+### DeploymentProps <a name="org.cdk8s.plus22.DeploymentProps"></a>
 
 Properties for initialization of `Deployment`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.DeploymentProps;
+import org.cdk8s.plus22.DeploymentProps;
 
 DeploymentProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -2604,7 +2702,7 @@ DeploymentProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -2616,13 +2714,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2634,13 +2732,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2649,13 +2747,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2671,13 +2769,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2688,7 +2786,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadata getPodMetadata();
@@ -2700,7 +2798,7 @@ The pod metadata.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.defaultSelector"></a>
 
 ```java
 public java.lang.Boolean getDefaultSelector();
@@ -2716,7 +2814,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.replicas"></a>
 
 ```java
 public java.lang.Number getReplicas();
@@ -2729,14 +2827,14 @@ Number of desired pods.
 
 ---
 
-### EmptyDirVolumeOptions <a name="org.cdk8s.plus21.EmptyDirVolumeOptions"></a>
+### EmptyDirVolumeOptions <a name="org.cdk8s.plus22.EmptyDirVolumeOptions"></a>
 
 Options for volumes populated with an empty directory.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.EmptyDirVolumeOptions;
+import org.cdk8s.plus22.EmptyDirVolumeOptions;
 
 EmptyDirVolumeOptions.builder()
 //  .medium(EmptyDirMedium)
@@ -2744,13 +2842,13 @@ EmptyDirVolumeOptions.builder()
     .build();
 ```
 
-##### `medium`<sup>Optional</sup> <a name="org.cdk8s.plus21.EmptyDirVolumeOptions.property.medium"></a>
+##### `medium`<sup>Optional</sup> <a name="org.cdk8s.plus22.EmptyDirVolumeOptions.property.medium"></a>
 
 ```java
 public EmptyDirMedium getMedium();
 ```
 
-- *Type:* [`org.cdk8s.plus21.EmptyDirMedium`](#org.cdk8s.plus21.EmptyDirMedium)
+- *Type:* [`org.cdk8s.plus22.EmptyDirMedium`](#org.cdk8s.plus22.EmptyDirMedium)
 - *Default:* EmptyDirMedium.DEFAULT
 
 By default, emptyDir volumes are stored on whatever medium is backing the node - that might be disk or SSD or network storage, depending on your environment.
@@ -2763,7 +2861,7 @@ against your Container's memory limit.
 
 ---
 
-##### `sizeLimit`<sup>Optional</sup> <a name="org.cdk8s.plus21.EmptyDirVolumeOptions.property.sizeLimit"></a>
+##### `sizeLimit`<sup>Optional</sup> <a name="org.cdk8s.plus22.EmptyDirVolumeOptions.property.sizeLimit"></a>
 
 ```java
 public Size getSizeLimit();
@@ -2781,21 +2879,21 @@ here and the sum of memory limits of all containers in a pod.
 
 ---
 
-### EnvValueFromConfigMapOptions <a name="org.cdk8s.plus21.EnvValueFromConfigMapOptions"></a>
+### EnvValueFromConfigMapOptions <a name="org.cdk8s.plus22.EnvValueFromConfigMapOptions"></a>
 
 Options to specify an envionment variable value from a ConfigMap key.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.EnvValueFromConfigMapOptions;
+import org.cdk8s.plus22.EnvValueFromConfigMapOptions;
 
 EnvValueFromConfigMapOptions.builder()
 //  .optional(java.lang.Boolean)
     .build();
 ```
 
-##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValueFromConfigMapOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValueFromConfigMapOptions.property.optional"></a>
 
 ```java
 public java.lang.Boolean getOptional();
@@ -2808,21 +2906,21 @@ Specify whether the ConfigMap or its key must be defined.
 
 ---
 
-### EnvValueFromProcessOptions <a name="org.cdk8s.plus21.EnvValueFromProcessOptions"></a>
+### EnvValueFromProcessOptions <a name="org.cdk8s.plus22.EnvValueFromProcessOptions"></a>
 
 Options to specify an environment variable value from the process environment.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.EnvValueFromProcessOptions;
+import org.cdk8s.plus22.EnvValueFromProcessOptions;
 
 EnvValueFromProcessOptions.builder()
 //  .required(java.lang.Boolean)
     .build();
 ```
 
-##### `required`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValueFromProcessOptions.property.required"></a>
+##### `required`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValueFromProcessOptions.property.required"></a>
 
 ```java
 public java.lang.Boolean getRequired();
@@ -2837,21 +2935,21 @@ If this is set to true, and the key does not exist, an error will thrown.
 
 ---
 
-### EnvValueFromSecretOptions <a name="org.cdk8s.plus21.EnvValueFromSecretOptions"></a>
+### EnvValueFromSecretOptions <a name="org.cdk8s.plus22.EnvValueFromSecretOptions"></a>
 
 Options to specify an environment variable value from a Secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.EnvValueFromSecretOptions;
+import org.cdk8s.plus22.EnvValueFromSecretOptions;
 
 EnvValueFromSecretOptions.builder()
 //  .optional(java.lang.Boolean)
     .build();
 ```
 
-##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValueFromSecretOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValueFromSecretOptions.property.optional"></a>
 
 ```java
 public java.lang.Boolean getOptional();
@@ -2864,24 +2962,25 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="org.cdk8s.plus21.ExposeOptions"></a>
+### ExposeOptions <a name="org.cdk8s.plus22.ExposeOptions"></a>
 
 Options for exposing a deployment via a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ExposeOptions;
+import org.cdk8s.plus22.ExposeOptions;
 
 ExposeOptions.builder()
 //  .name(java.lang.String)
+//  .port(java.lang.Number)
 //  .protocol(Protocol)
 //  .serviceType(ServiceType)
 //  .targetPort(java.lang.Number)
     .build();
 ```
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -2896,13 +2995,26 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.protocol"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.port"></a>
+
+```java
+public java.lang.Number getPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.protocol"></a>
 
 ```java
 public Protocol getProtocol();
 ```
 
-- *Type:* [`org.cdk8s.plus21.Protocol`](#org.cdk8s.plus21.Protocol)
+- *Type:* [`org.cdk8s.plus22.Protocol`](#org.cdk8s.plus22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -2911,20 +3023,20 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `serviceType`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.serviceType"></a>
+##### `serviceType`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.serviceType"></a>
 
 ```java
 public ServiceType getServiceType();
 ```
 
-- *Type:* [`org.cdk8s.plus21.ServiceType`](#org.cdk8s.plus21.ServiceType)
+- *Type:* [`org.cdk8s.plus22.ServiceType`](#org.cdk8s.plus22.ServiceType)
 - *Default:* ClusterIP.
 
 The type of the exposed service.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ExposeOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ExposeOptions.property.targetPort"></a>
 
 ```java
 public java.lang.Number getTargetPort();
@@ -2937,14 +3049,14 @@ The port number the service will redirect to.
 
 ---
 
-### HttpGetProbeOptions <a name="org.cdk8s.plus21.HttpGetProbeOptions"></a>
+### HttpGetProbeOptions <a name="org.cdk8s.plus22.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.HttpGetProbeOptions;
+import org.cdk8s.plus22.HttpGetProbeOptions;
 
 HttpGetProbeOptions.builder()
 //  .failureThreshold(java.lang.Number)
@@ -2956,7 +3068,7 @@ HttpGetProbeOptions.builder()
     .build();
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.failureThreshold"></a>
 
 ```java
 public java.lang.Number getFailureThreshold();
@@ -2971,7 +3083,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.initialDelaySeconds"></a>
 
 ```java
 public Duration getInitialDelaySeconds();
@@ -2986,7 +3098,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.periodSeconds"></a>
 
 ```java
 public Duration getPeriodSeconds();
@@ -3001,7 +3113,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.successThreshold"></a>
 
 ```java
 public java.lang.Number getSuccessThreshold();
@@ -3016,7 +3128,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.timeoutSeconds"></a>
 
 ```java
 public Duration getTimeoutSeconds();
@@ -3033,7 +3145,7 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.HttpGetProbeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.HttpGetProbeOptions.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -3046,24 +3158,24 @@ The TCP port to use when sending the GET request.
 
 ---
 
-### IngressV1Beta1Props <a name="org.cdk8s.plus21.IngressV1Beta1Props"></a>
+### IngressProps <a name="org.cdk8s.plus22.IngressProps"></a>
 
 Properties for `Ingress`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.IngressV1Beta1Props;
+import org.cdk8s.plus22.IngressProps;
 
-IngressV1Beta1Props.builder()
+IngressProps.builder()
 //  .metadata(ApiObjectMetadata)
-//  .defaultBackend(IngressV1Beta1Backend)
-//  .rules(java.util.List<IngressV1Beta1Rule>)
-//  .tls(java.util.List<IngressV1Beta1Tls>)
+//  .defaultBackend(IngressBackend)
+//  .rules(java.util.List<IngressRule>)
+//  .tls(java.util.List<IngressTls>)
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -3075,13 +3187,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `defaultBackend`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.property.defaultBackend"></a>
+##### `defaultBackend`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.property.defaultBackend"></a>
 
 ```java
-public IngressV1Beta1Backend getDefaultBackend();
+public IngressBackend getDefaultBackend();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
+- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
 
 The default backend services requests that do not match any rule.
 
@@ -3090,13 +3202,13 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.property.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.property.rules"></a>
 
 ```java
-public java.util.List<IngressV1Beta1Rule> getRules();
+public java.util.List<IngressRule> getRules();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Rule`](#org.cdk8s.plus21.IngressV1Beta1Rule)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.IngressRule`](#org.cdk8s.plus22.IngressRule)>
 
 Routing rules for this ingress.
 
@@ -3109,13 +3221,13 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Props.property.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressProps.property.tls"></a>
 
 ```java
-public java.util.List<IngressV1Beta1Tls> getTls();
+public java.util.List<IngressTls> getTls();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.IngressV1Beta1Tls`](#org.cdk8s.plus21.IngressV1Beta1Tls)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.IngressTls`](#org.cdk8s.plus22.IngressTls)>
 
 TLS settings for this ingress.
 
@@ -3127,7 +3239,7 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 ---
 
-### IngressV1Beta1Rule <a name="org.cdk8s.plus21.IngressV1Beta1Rule"></a>
+### IngressRule <a name="org.cdk8s.plus22.IngressRule"></a>
 
 Represents the rules mapping the paths under a specified host to the related backend services.
 
@@ -3137,28 +3249,29 @@ then routed to the backend associated with the matching path.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.IngressV1Beta1Rule;
+import org.cdk8s.plus22.IngressRule;
 
-IngressV1Beta1Rule.builder()
-    .backend(IngressV1Beta1Backend)
+IngressRule.builder()
+    .backend(IngressBackend)
 //  .host(java.lang.String)
 //  .path(java.lang.String)
+//  .pathType(HttpIngressPathType)
     .build();
 ```
 
-##### `backend`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Rule.property.backend"></a>
+##### `backend`<sup>Required</sup> <a name="org.cdk8s.plus22.IngressRule.property.backend"></a>
 
 ```java
-public IngressV1Beta1Backend getBackend();
+public IngressBackend getBackend();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IngressV1Beta1Backend`](#org.cdk8s.plus21.IngressV1Beta1Backend)
+- *Type:* [`org.cdk8s.plus22.IngressBackend`](#org.cdk8s.plus22.IngressBackend)
 
 Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ---
 
-##### `host`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Rule.property.host"></a>
+##### `host`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressRule.property.host"></a>
 
 ```java
 public java.lang.String getHost();
@@ -3180,7 +3293,7 @@ host before the IngressRuleValue.
 
 ---
 
-##### `path`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Rule.property.path"></a>
+##### `path`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressRule.property.path"></a>
 
 ```java
 public java.lang.String getPath();
@@ -3194,22 +3307,39 @@ Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows
 
 ---
 
-### IngressV1Beta1Tls <a name="org.cdk8s.plus21.IngressV1Beta1Tls"></a>
+##### `pathType`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressRule.property.pathType"></a>
+
+```java
+public HttpIngressPathType getPathType();
+```
+
+- *Type:* [`org.cdk8s.plus22.HttpIngressPathType`](#org.cdk8s.plus22.HttpIngressPathType)
+
+Specify how the path is matched against request paths.
+
+By default, path
+types will be matched by prefix.
+
+> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+
+---
+
+### IngressTls <a name="org.cdk8s.plus22.IngressTls"></a>
 
 Represents the TLS configuration mapping that is passed to the ingress controller for SSL termination.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.IngressV1Beta1Tls;
+import org.cdk8s.plus22.IngressTls;
 
-IngressV1Beta1Tls.builder()
+IngressTls.builder()
 //  .hosts(java.util.List<java.lang.String>)
 //  .secret(ISecret)
     .build();
 ```
 
-##### `hosts`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Tls.property.hosts"></a>
+##### `hosts`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressTls.property.hosts"></a>
 
 ```java
 public java.util.List<java.lang.String> getHosts();
@@ -3226,13 +3356,13 @@ this list must match the name/s used in the TLS Secret.
 
 ---
 
-##### `secret`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Tls.property.secret"></a>
+##### `secret`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressTls.property.secret"></a>
 
 ```java
 public ISecret getSecret();
 ```
 
-- *Type:* [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
+- *Type:* [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
 - *Default:* If unspecified, it allows SSL routing based on SNI hostname.
 
 Secret is the secret that contains the certificate and key used to terminate SSL traffic on 443.
@@ -3243,14 +3373,14 @@ termination and value of the Host header is used for routing.
 
 ---
 
-### JobProps <a name="org.cdk8s.plus21.JobProps"></a>
+### JobProps <a name="org.cdk8s.plus22.JobProps"></a>
 
 Properties for initialization of `Job`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.JobProps;
+import org.cdk8s.plus22.JobProps;
 
 JobProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -3265,7 +3395,7 @@ JobProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -3277,13 +3407,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3295,13 +3425,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3310,13 +3440,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3332,13 +3462,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3349,7 +3479,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadata getPodMetadata();
@@ -3361,7 +3491,7 @@ The pod metadata.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.activeDeadline"></a>
 
 ```java
 public Duration getActiveDeadline();
@@ -3374,7 +3504,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.backoffLimit"></a>
 
 ```java
 public java.lang.Number getBackoffLimit();
@@ -3387,7 +3517,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.ttlAfterFinished"></a>
 
 ```java
 public Duration getTtlAfterFinished();
@@ -3407,14 +3537,14 @@ field is alpha-level and is only honored by servers that enable the
 
 ---
 
-### MountOptions <a name="org.cdk8s.plus21.MountOptions"></a>
+### MountOptions <a name="org.cdk8s.plus22.MountOptions"></a>
 
 Options for mounts.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.MountOptions;
+import org.cdk8s.plus22.MountOptions;
 
 MountOptions.builder()
 //  .propagation(MountPropagation)
@@ -3424,13 +3554,13 @@ MountOptions.builder()
     .build();
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.propagation"></a>
 
 ```java
 public MountPropagation getPropagation();
 ```
 
-- *Type:* [`org.cdk8s.plus21.MountPropagation`](#org.cdk8s.plus21.MountPropagation)
+- *Type:* [`org.cdk8s.plus22.MountPropagation`](#org.cdk8s.plus22.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -3444,7 +3574,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.readOnly"></a>
+##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.readOnly"></a>
 
 ```java
 public java.lang.Boolean getReadOnly();
@@ -3459,7 +3589,7 @@ Defaults to false.
 
 ---
 
-##### `subPath`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.subPath"></a>
+##### `subPath`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.subPath"></a>
 
 ```java
 public java.lang.String getSubPath();
@@ -3472,7 +3602,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `subPathExpr`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.subPathExpr"></a>
+##### `subPathExpr`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.subPathExpr"></a>
 
 ```java
 public java.lang.String getSubPathExpr();
@@ -3493,14 +3623,14 @@ is beta in 1.15.
 
 ---
 
-### PathMapping <a name="org.cdk8s.plus21.PathMapping"></a>
+### PathMapping <a name="org.cdk8s.plus22.PathMapping"></a>
 
 Maps a string key to a path within a volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.PathMapping;
+import org.cdk8s.plus22.PathMapping;
 
 PathMapping.builder()
     .path(java.lang.String)
@@ -3508,7 +3638,7 @@ PathMapping.builder()
     .build();
 ```
 
-##### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.PathMapping.property.path"></a>
+##### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.PathMapping.property.path"></a>
 
 ```java
 public java.lang.String getPath();
@@ -3524,7 +3654,7 @@ path. May not contain the path element '..'. May not start with the string
 
 ---
 
-##### `mode`<sup>Optional</sup> <a name="org.cdk8s.plus21.PathMapping.property.mode"></a>
+##### `mode`<sup>Optional</sup> <a name="org.cdk8s.plus22.PathMapping.property.mode"></a>
 
 ```java
 public java.lang.Number getMode();
@@ -3540,14 +3670,14 @@ the result can be other mode bits set.
 
 ---
 
-### PodProps <a name="org.cdk8s.plus21.PodProps"></a>
+### PodProps <a name="org.cdk8s.plus22.PodProps"></a>
 
 Properties for initialization of `Pod`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.PodProps;
+import org.cdk8s.plus22.PodProps;
 
 PodProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -3558,7 +3688,7 @@ PodProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -3570,13 +3700,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3588,13 +3718,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3603,13 +3733,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3625,13 +3755,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3642,14 +3772,14 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodSpecProps <a name="org.cdk8s.plus21.PodSpecProps"></a>
+### PodSpecProps <a name="org.cdk8s.plus22.PodSpecProps"></a>
 
 Properties of a `PodSpec`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.PodSpecProps;
+import org.cdk8s.plus22.PodSpecProps;
 
 PodSpecProps.builder()
 //  .containers(java.util.List<ContainerProps>)
@@ -3659,13 +3789,13 @@ PodSpecProps.builder()
     .build();
 ```
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3677,13 +3807,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3692,13 +3822,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3714,13 +3844,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3731,7 +3861,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodTemplateProps <a name="org.cdk8s.plus21.PodTemplateProps"></a>
+### PodTemplateProps <a name="org.cdk8s.plus22.PodTemplateProps"></a>
 
 Properties of a `PodTemplate`.
 
@@ -3740,7 +3870,7 @@ Adds metadata information on top of the spec.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.PodTemplateProps;
+import org.cdk8s.plus22.PodTemplateProps;
 
 PodTemplateProps.builder()
 //  .containers(java.util.List<ContainerProps>)
@@ -3751,13 +3881,13 @@ PodTemplateProps.builder()
     .build();
 ```
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3769,13 +3899,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3784,13 +3914,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3806,13 +3936,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3823,7 +3953,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadata getPodMetadata();
@@ -3835,14 +3965,14 @@ The pod metadata.
 
 ---
 
-### ProbeOptions <a name="org.cdk8s.plus21.ProbeOptions"></a>
+### ProbeOptions <a name="org.cdk8s.plus22.ProbeOptions"></a>
 
 Probe options.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ProbeOptions;
+import org.cdk8s.plus22.ProbeOptions;
 
 ProbeOptions.builder()
 //  .failureThreshold(java.lang.Number)
@@ -3853,7 +3983,7 @@ ProbeOptions.builder()
     .build();
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.failureThreshold"></a>
 
 ```java
 public java.lang.Number getFailureThreshold();
@@ -3868,7 +3998,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.initialDelaySeconds"></a>
 
 ```java
 public Duration getInitialDelaySeconds();
@@ -3883,7 +4013,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.periodSeconds"></a>
 
 ```java
 public Duration getPeriodSeconds();
@@ -3898,7 +4028,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.successThreshold"></a>
 
 ```java
 public java.lang.Number getSuccessThreshold();
@@ -3913,7 +4043,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus21.ProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.ProbeOptions.property.timeoutSeconds"></a>
 
 ```java
 public Duration getTimeoutSeconds();
@@ -3930,21 +4060,21 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ResourceProps <a name="org.cdk8s.plus21.ResourceProps"></a>
+### ResourceProps <a name="org.cdk8s.plus22.ResourceProps"></a>
 
 Initialization properties for resources.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ResourceProps;
+import org.cdk8s.plus22.ResourceProps;
 
 ResourceProps.builder()
 //  .metadata(ApiObjectMetadata)
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ResourceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ResourceProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -3956,12 +4086,12 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-### SecretProps <a name="org.cdk8s.plus21.SecretProps"></a>
+### SecretProps <a name="org.cdk8s.plus22.SecretProps"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.SecretProps;
+import org.cdk8s.plus22.SecretProps;
 
 SecretProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -3970,7 +4100,7 @@ SecretProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -3982,7 +4112,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.stringData"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getStringData();
@@ -3999,7 +4129,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.type"></a>
 
 ```java
 public java.lang.String getType();
@@ -4015,14 +4145,14 @@ handling of secret data by various controllers.
 
 ---
 
-### SecretValue <a name="org.cdk8s.plus21.SecretValue"></a>
+### SecretValue <a name="org.cdk8s.plus22.SecretValue"></a>
 
 Represents a specific value in JSON secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.SecretValue;
+import org.cdk8s.plus22.SecretValue;
 
 SecretValue.builder()
     .key(java.lang.String)
@@ -4030,7 +4160,7 @@ SecretValue.builder()
     .build();
 ```
 
-##### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.SecretValue.property.key"></a>
+##### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.SecretValue.property.key"></a>
 
 ```java
 public java.lang.String getKey();
@@ -4042,19 +4172,19 @@ The JSON key.
 
 ---
 
-##### `secret`<sup>Required</sup> <a name="org.cdk8s.plus21.SecretValue.property.secret"></a>
+##### `secret`<sup>Required</sup> <a name="org.cdk8s.plus22.SecretValue.property.secret"></a>
 
 ```java
 public ISecret getSecret();
 ```
 
-- *Type:* [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
+- *Type:* [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
 
 The secret.
 
 ---
 
-### ServiceAccountProps <a name="org.cdk8s.plus21.ServiceAccountProps"></a>
+### ServiceAccountProps <a name="org.cdk8s.plus22.ServiceAccountProps"></a>
 
 Properties for initialization of `ServiceAccount`.
 
@@ -4063,7 +4193,7 @@ Properties for initialization of `ServiceAccount`.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ServiceAccountProps;
+import org.cdk8s.plus22.ServiceAccountProps;
 
 ServiceAccountProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -4071,7 +4201,7 @@ ServiceAccountProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -4083,13 +4213,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountProps.property.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountProps.property.secrets"></a>
 
 ```java
 public java.util.List<ISecret> getSecrets();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)>
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -4097,21 +4227,21 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 ---
 
-### ServiceIngressV1BetaBackendOptions <a name="org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions"></a>
+### ServiceIngressBackendOptions <a name="org.cdk8s.plus22.ServiceIngressBackendOptions"></a>
 
 Options for setting up backends for ingress rules.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions;
+import org.cdk8s.plus22.ServiceIngressBackendOptions;
 
-ServiceIngressV1BetaBackendOptions.builder()
+ServiceIngressBackendOptions.builder()
 //  .port(java.lang.Number)
     .build();
 ```
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceIngressBackendOptions.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -4129,14 +4259,14 @@ This option will fail if the service does not expose any ports.
 
 ---
 
-### ServicePort <a name="org.cdk8s.plus21.ServicePort"></a>
+### ServicePort <a name="org.cdk8s.plus22.ServicePort"></a>
 
 Definition of a service port.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ServicePort;
+import org.cdk8s.plus22.ServicePort;
 
 ServicePort.builder()
 //  .name(java.lang.String)
@@ -4147,7 +4277,7 @@ ServicePort.builder()
     .build();
 ```
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePort.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePort.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -4164,15 +4294,14 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePort.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePort.property.nodePort"></a>
 
 ```java
 public java.lang.Number getNodePort();
 ```
 
 - *Type:* `java.lang.Number`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -4185,13 +4314,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePort.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePort.property.protocol"></a>
 
 ```java
 public Protocol getProtocol();
 ```
 
-- *Type:* [`org.cdk8s.plus21.Protocol`](#org.cdk8s.plus21.Protocol)
+- *Type:* [`org.cdk8s.plus22.Protocol`](#org.cdk8s.plus22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -4200,7 +4329,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePort.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePort.property.targetPort"></a>
 
 ```java
 public java.lang.Number getTargetPort();
@@ -4213,7 +4342,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Required</sup> <a name="org.cdk8s.plus21.ServicePort.property.port"></a>
+##### `port`<sup>Required</sup> <a name="org.cdk8s.plus22.ServicePort.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -4225,12 +4354,12 @@ The port number the service will bind to.
 
 ---
 
-### ServicePortOptions <a name="org.cdk8s.plus21.ServicePortOptions"></a>
+### ServicePortOptions <a name="org.cdk8s.plus22.ServicePortOptions"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ServicePortOptions;
+import org.cdk8s.plus22.ServicePortOptions;
 
 ServicePortOptions.builder()
 //  .name(java.lang.String)
@@ -4240,7 +4369,7 @@ ServicePortOptions.builder()
     .build();
 ```
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePortOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePortOptions.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -4257,15 +4386,14 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePortOptions.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePortOptions.property.nodePort"></a>
 
 ```java
 public java.lang.Number getNodePort();
 ```
 
 - *Type:* `java.lang.Number`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -4278,13 +4406,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePortOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePortOptions.property.protocol"></a>
 
 ```java
 public Protocol getProtocol();
 ```
 
-- *Type:* [`org.cdk8s.plus21.Protocol`](#org.cdk8s.plus21.Protocol)
+- *Type:* [`org.cdk8s.plus22.Protocol`](#org.cdk8s.plus22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -4293,7 +4421,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServicePortOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServicePortOptions.property.targetPort"></a>
 
 ```java
 public java.lang.Number getTargetPort();
@@ -4306,14 +4434,14 @@ The port number the service will redirect to.
 
 ---
 
-### ServiceProps <a name="org.cdk8s.plus21.ServiceProps"></a>
+### ServiceProps <a name="org.cdk8s.plus22.ServiceProps"></a>
 
 Properties for initialization of `Service`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.ServiceProps;
+import org.cdk8s.plus22.ServiceProps;
 
 ServiceProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -4326,7 +4454,7 @@ ServiceProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -4338,7 +4466,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.clusterIP"></a>
 
 ```java
 public java.lang.String getClusterIP();
@@ -4360,7 +4488,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `externalIPs`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.externalIPs"></a>
+##### `externalIPs`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.externalIPs"></a>
 
 ```java
 public java.util.List<java.lang.String> getExternalIPs();
@@ -4378,7 +4506,7 @@ Kubernetes system.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.externalName"></a>
 
 ```java
 public java.lang.String getExternalName();
@@ -4391,7 +4519,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.loadBalancerSourceRanges"></a>
+##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.loadBalancerSourceRanges"></a>
 
 ```java
 public java.util.List<java.lang.String> getLoadBalancerSourceRanges();
@@ -4405,13 +4533,13 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.ports"></a>
 
 ```java
 public java.util.List<ServicePort> getPorts();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ServicePort`](#org.cdk8s.plus21.ServicePort)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ServicePort`](#org.cdk8s.plus22.ServicePort)>
 
 The port exposed by this service.
 
@@ -4419,13 +4547,13 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceProps.property.type"></a>
 
 ```java
 public ServiceType getType();
 ```
 
-- *Type:* [`org.cdk8s.plus21.ServiceType`](#org.cdk8s.plus21.ServiceType)
+- *Type:* [`org.cdk8s.plus22.ServiceType`](#org.cdk8s.plus22.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -4434,14 +4562,14 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 ---
 
-### StatefulSetProps <a name="org.cdk8s.plus21.StatefulSetProps"></a>
+### StatefulSetProps <a name="org.cdk8s.plus22.StatefulSetProps"></a>
 
 Properties for initialization of `StatefulSet`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.StatefulSetProps;
+import org.cdk8s.plus22.StatefulSetProps;
 
 StatefulSetProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -4457,7 +4585,7 @@ StatefulSetProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -4469,13 +4597,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.containers"></a>
 
 ```java
 public java.util.List<ContainerProps> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4487,13 +4615,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4502,13 +4630,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4524,13 +4652,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4541,7 +4669,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadata getPodMetadata();
@@ -4553,19 +4681,19 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.service"></a>
+##### `service`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.service"></a>
 
 ```java
 public Service getService();
 ```
 
-- *Type:* [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service)
+- *Type:* [`org.cdk8s.plus22.Service`](#org.cdk8s.plus22.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.defaultSelector"></a>
 
 ```java
 public java.lang.Boolean getDefaultSelector();
@@ -4581,20 +4709,20 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `podManagementPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.podManagementPolicy"></a>
 
 ```java
 public PodManagementPolicy getPodManagementPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.PodManagementPolicy`](#org.cdk8s.plus21.PodManagementPolicy)
+- *Type:* [`org.cdk8s.plus22.PodManagementPolicy`](#org.cdk8s.plus22.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.replicas"></a>
 
 ```java
 public java.lang.Number getReplicas();
@@ -4607,14 +4735,14 @@ Number of desired pods.
 
 ---
 
-### VolumeMount <a name="org.cdk8s.plus21.VolumeMount"></a>
+### VolumeMount <a name="org.cdk8s.plus22.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.VolumeMount;
+import org.cdk8s.plus22.VolumeMount;
 
 VolumeMount.builder()
 //  .propagation(MountPropagation)
@@ -4626,13 +4754,13 @@ VolumeMount.builder()
     .build();
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.propagation"></a>
 
 ```java
 public MountPropagation getPropagation();
 ```
 
-- *Type:* [`org.cdk8s.plus21.MountPropagation`](#org.cdk8s.plus21.MountPropagation)
+- *Type:* [`org.cdk8s.plus22.MountPropagation`](#org.cdk8s.plus22.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -4646,7 +4774,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.readOnly"></a>
+##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.readOnly"></a>
 
 ```java
 public java.lang.Boolean getReadOnly();
@@ -4661,7 +4789,7 @@ Defaults to false.
 
 ---
 
-##### `subPath`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.subPath"></a>
+##### `subPath`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.subPath"></a>
 
 ```java
 public java.lang.String getSubPath();
@@ -4674,7 +4802,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `subPathExpr`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.subPathExpr"></a>
+##### `subPathExpr`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.subPathExpr"></a>
 
 ```java
 public java.lang.String getSubPathExpr();
@@ -4695,7 +4823,7 @@ is beta in 1.15.
 
 ---
 
-##### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.VolumeMount.property.path"></a>
+##### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.VolumeMount.property.path"></a>
 
 ```java
 public java.lang.String getPath();
@@ -4710,13 +4838,13 @@ contain ':'.
 
 ---
 
-##### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.VolumeMount.property.volume"></a>
+##### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.VolumeMount.property.volume"></a>
 
 ```java
 public Volume getVolume();
 ```
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
 
 The volume to mount.
 
@@ -4724,14 +4852,14 @@ The volume to mount.
 
 ## Classes <a name="Classes"></a>
 
-### Container <a name="org.cdk8s.plus21.Container"></a>
+### Container <a name="org.cdk8s.plus22.Container"></a>
 
 A single application container that you want to run within a pod.
 
-#### Initializers <a name="org.cdk8s.plus21.Container.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Container.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Container;
+import org.cdk8s.plus22.Container;
 
 Container.Builder.create()
     .image(java.lang.String)
@@ -4749,7 +4877,7 @@ Container.Builder.create()
     .build();
 ```
 
-##### `image`<sup>Required</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.image"></a>
+##### `image`<sup>Required</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.image"></a>
 
 - *Type:* `java.lang.String`
 
@@ -4757,7 +4885,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.args"></a>
+##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.args"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 - *Default:* []
@@ -4776,7 +4904,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.command"></a>
+##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.command"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 - *Default:* The docker image's ENTRYPOINT.
@@ -4790,9 +4918,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.env"></a>
+##### `env`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.env"></a>
 
-- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus21.EnvValue`](#org.cdk8s.plus21.EnvValue)>
+- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus22.EnvValue`](#org.cdk8s.plus22.EnvValue)>
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -4801,18 +4929,18 @@ Cannot be updated.
 
 ---
 
-##### `imagePullPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.imagePullPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus21.ImagePullPolicy`](#org.cdk8s.plus21.ImagePullPolicy)
+- *Type:* [`org.cdk8s.plus22.ImagePullPolicy`](#org.cdk8s.plus22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
+- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -4821,7 +4949,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* 'main'
@@ -4832,7 +4960,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.port"></a>
 
 - *Type:* `java.lang.Number`
 - *Default:* No port is exposed.
@@ -4843,18 +4971,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
+- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`org.cdk8s.plus21.Probe`](#org.cdk8s.plus21.Probe)
+- *Type:* [`org.cdk8s.plus22.Probe`](#org.cdk8s.plus22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -4863,9 +4991,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volumeMounts`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.volumeMounts"></a>
+##### `volumeMounts`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.volumeMounts"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.VolumeMount`](#org.cdk8s.plus21.VolumeMount)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.VolumeMount`](#org.cdk8s.plus22.VolumeMount)>
 
 Pod volumes to mount into the container's filesystem.
 
@@ -4873,7 +5001,7 @@ Cannot be updated.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus21.ContainerProps.parameter.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus22.ContainerProps.parameter.workingDir"></a>
 
 - *Type:* `java.lang.String`
 - *Default:* The container runtime's default.
@@ -4886,13 +5014,13 @@ If not specified, the container runtime's default will be used, which might be c
 
 #### Methods <a name="Methods"></a>
 
-##### `addEnv` <a name="org.cdk8s.plus21.Container.addEnv"></a>
+##### `addEnv` <a name="org.cdk8s.plus22.Container.addEnv"></a>
 
 ```java
 public addEnv(java.lang.String name, EnvValue value)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
@@ -4900,22 +5028,22 @@ The variable name.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.parameter.value"></a>
 
-- *Type:* [`org.cdk8s.plus21.EnvValue`](#org.cdk8s.plus21.EnvValue)
+- *Type:* [`org.cdk8s.plus22.EnvValue`](#org.cdk8s.plus22.EnvValue)
 
 The variable value.
 
 ---
 
-##### `mount` <a name="org.cdk8s.plus21.Container.mount"></a>
+##### `mount` <a name="org.cdk8s.plus22.Container.mount"></a>
 
 ```java
 public mount(java.lang.String path, Volume volume)
 public mount(java.lang.String path, Volume volume, MountOptions options)
 ```
 
-###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.parameter.path"></a>
 
 - *Type:* `java.lang.String`
 
@@ -4923,30 +5051,30 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
 
 The volume to mount.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.MountOptions`](#org.cdk8s.plus21.MountOptions)
+- *Type:* [`org.cdk8s.plus22.MountOptions`](#org.cdk8s.plus22.MountOptions)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `env`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.env"></a>
+##### `env`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.env"></a>
 
 ```java
 public java.util.Map<java.lang.String, EnvValue> getEnv();
 ```
 
-- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus21.EnvValue`](#org.cdk8s.plus21.EnvValue)>
+- *Type:* java.util.Map<java.lang.String, [`org.cdk8s.plus22.EnvValue`](#org.cdk8s.plus22.EnvValue)>
 
 The environment variables for this container.
 
@@ -4954,7 +5082,7 @@ Returns a copy. To add environment variables use `addEnv()`.
 
 ---
 
-##### `image`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.image"></a>
+##### `image`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.image"></a>
 
 ```java
 public java.lang.String getImage();
@@ -4966,31 +5094,31 @@ The container image.
 
 ---
 
-##### `imagePullPolicy`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.imagePullPolicy"></a>
 
 ```java
 public ImagePullPolicy getImagePullPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.ImagePullPolicy`](#org.cdk8s.plus21.ImagePullPolicy)
+- *Type:* [`org.cdk8s.plus22.ImagePullPolicy`](#org.cdk8s.plus22.ImagePullPolicy)
 
 Image pull policy for this container.
 
 ---
 
-##### `mounts`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.mounts"></a>
+##### `mounts`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.mounts"></a>
 
 ```java
 public java.util.List<VolumeMount> getMounts();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.VolumeMount`](#org.cdk8s.plus21.VolumeMount)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.VolumeMount`](#org.cdk8s.plus22.VolumeMount)>
 
 Volume mounts configured for this container.
 
 ---
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Container.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5002,7 +5130,7 @@ The name of the container.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.property.args"></a>
 
 ```java
 public java.util.List<java.lang.String> getArgs();
@@ -5014,7 +5142,7 @@ Arguments to the entrypoint.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.property.command"></a>
 
 ```java
 public java.util.List<java.lang.String> getCommand();
@@ -5026,7 +5154,7 @@ Entrypoint array (the command to execute when the container starts).
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -5038,7 +5166,7 @@ The port this container exposes.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus21.Container.property.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="org.cdk8s.plus22.Container.property.workingDir"></a>
 
 ```java
 public java.lang.String getWorkingDir();
@@ -5051,31 +5179,31 @@ The working directory inside the container.
 ---
 
 
-### EnvValue <a name="org.cdk8s.plus21.EnvValue"></a>
+### EnvValue <a name="org.cdk8s.plus22.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMap` <a name="org.cdk8s.plus21.EnvValue.fromConfigMap"></a>
+##### `fromConfigMap` <a name="org.cdk8s.plus22.EnvValue.fromConfigMap"></a>
 
 ```java
-import org.cdk8s.plus21.EnvValue;
+import org.cdk8s.plus22.EnvValue;
 
 EnvValue.fromConfigMap(IConfigMap configMap, java.lang.String key)
 EnvValue.fromConfigMap(IConfigMap configMap, java.lang.String key, EnvValueFromConfigMapOptions options)
 ```
 
-###### `configMap`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.configMap"></a>
+###### `configMap`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.configMap"></a>
 
-- *Type:* [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
+- *Type:* [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap)
 
 The config map.
 
 ---
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5083,24 +5211,24 @@ The key to extract the value from.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.EnvValueFromConfigMapOptions`](#org.cdk8s.plus21.EnvValueFromConfigMapOptions)
+- *Type:* [`org.cdk8s.plus22.EnvValueFromConfigMapOptions`](#org.cdk8s.plus22.EnvValueFromConfigMapOptions)
 
 Additional options.
 
 ---
 
-##### `fromProcess` <a name="org.cdk8s.plus21.EnvValue.fromProcess"></a>
+##### `fromProcess` <a name="org.cdk8s.plus22.EnvValue.fromProcess"></a>
 
 ```java
-import org.cdk8s.plus21.EnvValue;
+import org.cdk8s.plus22.EnvValue;
 
 EnvValue.fromProcess(java.lang.String key)
 EnvValue.fromProcess(java.lang.String key, EnvValueFromProcessOptions options)
 ```
 
-###### `key`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.key"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5108,48 +5236,48 @@ The key to read.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.EnvValueFromProcessOptions`](#org.cdk8s.plus21.EnvValueFromProcessOptions)
+- *Type:* [`org.cdk8s.plus22.EnvValueFromProcessOptions`](#org.cdk8s.plus22.EnvValueFromProcessOptions)
 
 Additional options.
 
 ---
 
-##### `fromSecretValue` <a name="org.cdk8s.plus21.EnvValue.fromSecretValue"></a>
+##### `fromSecretValue` <a name="org.cdk8s.plus22.EnvValue.fromSecretValue"></a>
 
 ```java
-import org.cdk8s.plus21.EnvValue;
+import org.cdk8s.plus22.EnvValue;
 
 EnvValue.fromSecretValue(SecretValue secretValue)
 EnvValue.fromSecretValue(SecretValue secretValue, EnvValueFromSecretOptions options)
 ```
 
-###### `secretValue`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.secretValue"></a>
+###### `secretValue`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.secretValue"></a>
 
-- *Type:* [`org.cdk8s.plus21.SecretValue`](#org.cdk8s.plus21.SecretValue)
+- *Type:* [`org.cdk8s.plus22.SecretValue`](#org.cdk8s.plus22.SecretValue)
 
 The secret value (secrent + key).
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.EnvValueFromSecretOptions`](#org.cdk8s.plus21.EnvValueFromSecretOptions)
+- *Type:* [`org.cdk8s.plus22.EnvValueFromSecretOptions`](#org.cdk8s.plus22.EnvValueFromSecretOptions)
 
 Additional options.
 
 ---
 
-##### `fromValue` <a name="org.cdk8s.plus21.EnvValue.fromValue"></a>
+##### `fromValue` <a name="org.cdk8s.plus22.EnvValue.fromValue"></a>
 
 ```java
-import org.cdk8s.plus21.EnvValue;
+import org.cdk8s.plus22.EnvValue;
 
 EnvValue.fromValue(java.lang.String value)
 ```
 
-###### `value`<sup>Required</sup> <a name="org.cdk8s.plus21.EnvValue.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.EnvValue.parameter.value"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5159,7 +5287,7 @@ The value.
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.property.value"></a>
+##### `value`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.property.value"></a>
 
 ```java
 public java.lang.Object getValue();
@@ -5169,7 +5297,7 @@ public java.lang.Object getValue();
 
 ---
 
-##### `valueFrom`<sup>Optional</sup> <a name="org.cdk8s.plus21.EnvValue.property.valueFrom"></a>
+##### `valueFrom`<sup>Optional</sup> <a name="org.cdk8s.plus22.EnvValue.property.valueFrom"></a>
 
 ```java
 public java.lang.Object getValueFrom();
@@ -5180,48 +5308,48 @@ public java.lang.Object getValueFrom();
 ---
 
 
-### IngressV1Beta1Backend <a name="org.cdk8s.plus21.IngressV1Beta1Backend"></a>
+### IngressBackend <a name="org.cdk8s.plus22.IngressBackend"></a>
 
 The backend for an ingress path.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromService` <a name="org.cdk8s.plus21.IngressV1Beta1Backend.fromService"></a>
+##### `fromService` <a name="org.cdk8s.plus22.IngressBackend.fromService"></a>
 
 ```java
-import org.cdk8s.plus21.IngressV1Beta1Backend;
+import org.cdk8s.plus22.IngressBackend;
 
-IngressV1Beta1Backend.fromService(Service service)
-IngressV1Beta1Backend.fromService(Service service, ServiceIngressV1BetaBackendOptions options)
+IngressBackend.fromService(Service service)
+IngressBackend.fromService(Service service, ServiceIngressBackendOptions options)
 ```
 
-###### `service`<sup>Required</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Backend.parameter.service"></a>
+###### `service`<sup>Required</sup> <a name="org.cdk8s.plus22.IngressBackend.parameter.service"></a>
 
-- *Type:* [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service)
+- *Type:* [`org.cdk8s.plus22.Service`](#org.cdk8s.plus22.Service)
 
 The service object.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.IngressV1Beta1Backend.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.IngressBackend.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions`](#org.cdk8s.plus21.ServiceIngressV1BetaBackendOptions)
+- *Type:* [`org.cdk8s.plus22.ServiceIngressBackendOptions`](#org.cdk8s.plus22.ServiceIngressBackendOptions)
 
 ---
 
 
 
-### PodSpec <a name="org.cdk8s.plus21.PodSpec"></a>
+### PodSpec <a name="org.cdk8s.plus22.PodSpec"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IPodSpec`](#org.cdk8s.plus21.IPodSpec)
+- *Implements:* [`org.cdk8s.plus22.IPodSpec`](#org.cdk8s.plus22.IPodSpec)
 
 Provides read/write capabilities ontop of a `PodSpecProps`.
 
-#### Initializers <a name="org.cdk8s.plus21.PodSpec.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.PodSpec.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.PodSpec;
+import org.cdk8s.plus22.PodSpec;
 
 PodSpec.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
@@ -5231,9 +5359,9 @@ PodSpec.Builder.create()
     .build();
 ```
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -5245,9 +5373,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -5256,9 +5384,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -5274,9 +5402,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -5289,40 +5417,40 @@ You can also add volumes later using `podSpec.addVolume()`
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus21.PodSpec.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus22.PodSpec.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.PodSpec.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
+- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus21.PodSpec.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus22.PodSpec.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.PodSpec.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.PodSpec.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
 
 The containers belonging to the pod.
 
@@ -5330,13 +5458,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.PodSpec.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 
 The volumes associated with this pod.
 
@@ -5344,41 +5472,41 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpec.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpec.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpec.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### PodTemplate <a name="org.cdk8s.plus21.PodTemplate"></a>
+### PodTemplate <a name="org.cdk8s.plus22.PodTemplate"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
+- *Implements:* [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
 
 Provides read/write capabilities ontop of a `PodTemplateProps`.
 
-#### Initializers <a name="org.cdk8s.plus21.PodTemplate.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.PodTemplate.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.PodTemplate;
+import org.cdk8s.plus22.PodTemplate;
 
 PodTemplate.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
@@ -5389,9 +5517,9 @@ PodTemplate.Builder.create()
     .build();
 ```
 
-##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.containers"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)>
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -5403,9 +5531,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.restartPolicy"></a>
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -5414,9 +5542,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.serviceAccount"></a>
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -5432,9 +5560,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.volumes"></a>
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -5445,7 +5573,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.podMetadata"></a>
 
 - *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
 
@@ -5457,7 +5585,7 @@ The pod metadata.
 
 #### Properties <a name="Properties"></a>
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.PodTemplate.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.PodTemplate.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -5470,14 +5598,14 @@ Provides read/write access to the underlying pod metadata of the resource.
 ---
 
 
-### Probe <a name="org.cdk8s.plus21.Probe"></a>
+### Probe <a name="org.cdk8s.plus22.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 
-#### Initializers <a name="org.cdk8s.plus21.Probe.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Probe.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Probe;
+import org.cdk8s.plus22.Probe;
 
 new Probe();
 ```
@@ -5485,16 +5613,16 @@ new Probe();
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromCommand` <a name="org.cdk8s.plus21.Probe.fromCommand"></a>
+##### `fromCommand` <a name="org.cdk8s.plus22.Probe.fromCommand"></a>
 
 ```java
-import org.cdk8s.plus21.Probe;
+import org.cdk8s.plus22.Probe;
 
 Probe.fromCommand(java.util.List<java.lang.String> command)
 Probe.fromCommand(java.util.List<java.lang.String> command, CommandProbeOptions options)
 ```
 
-###### `command`<sup>Required</sup> <a name="org.cdk8s.plus21.Probe.parameter.command"></a>
+###### `command`<sup>Required</sup> <a name="org.cdk8s.plus22.Probe.parameter.command"></a>
 
 - *Type:* java.util.List<`java.lang.String`>
 
@@ -5502,24 +5630,24 @@ The command to execute.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Probe.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Probe.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.CommandProbeOptions`](#org.cdk8s.plus21.CommandProbeOptions)
+- *Type:* [`org.cdk8s.plus22.CommandProbeOptions`](#org.cdk8s.plus22.CommandProbeOptions)
 
 Options.
 
 ---
 
-##### `fromHttpGet` <a name="org.cdk8s.plus21.Probe.fromHttpGet"></a>
+##### `fromHttpGet` <a name="org.cdk8s.plus22.Probe.fromHttpGet"></a>
 
 ```java
-import org.cdk8s.plus21.Probe;
+import org.cdk8s.plus22.Probe;
 
 Probe.fromHttpGet(java.lang.String path)
 Probe.fromHttpGet(java.lang.String path, HttpGetProbeOptions options)
 ```
 
-###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.Probe.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus22.Probe.parameter.path"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5527,9 +5655,9 @@ The URL path to hit.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Probe.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Probe.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.HttpGetProbeOptions`](#org.cdk8s.plus21.HttpGetProbeOptions)
+- *Type:* [`org.cdk8s.plus22.HttpGetProbeOptions`](#org.cdk8s.plus22.HttpGetProbeOptions)
 
 Options.
 
@@ -5537,7 +5665,7 @@ Options.
 
 
 
-### Volume <a name="org.cdk8s.plus21.Volume"></a>
+### Volume <a name="org.cdk8s.plus22.Volume"></a>
 
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
@@ -5570,21 +5698,21 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
-#### Initializers <a name="org.cdk8s.plus21.Volume.Initializer"></a>
+#### Initializers <a name="org.cdk8s.plus22.Volume.Initializer"></a>
 
 ```java
-import org.cdk8s.plus21.Volume;
+import org.cdk8s.plus22.Volume;
 
 new Volume(java.lang.String name, java.lang.Object config);
 ```
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-##### `config`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.config"></a>
+##### `config`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.parameter.config"></a>
 
 - *Type:* `java.lang.Object`
 
@@ -5593,49 +5721,49 @@ new Volume(java.lang.String name, java.lang.Object config);
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMap` <a name="org.cdk8s.plus21.Volume.fromConfigMap"></a>
+##### `fromConfigMap` <a name="org.cdk8s.plus22.Volume.fromConfigMap"></a>
 
 ```java
-import org.cdk8s.plus21.Volume;
+import org.cdk8s.plus22.Volume;
 
 Volume.fromConfigMap(IConfigMap configMap)
 Volume.fromConfigMap(IConfigMap configMap, ConfigMapVolumeOptions options)
 ```
 
-###### `configMap`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.configMap"></a>
+###### `configMap`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.parameter.configMap"></a>
 
-- *Type:* [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
+- *Type:* [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap)
 
 The config map to use to populate the volume.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Volume.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Volume.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.ConfigMapVolumeOptions`](#org.cdk8s.plus21.ConfigMapVolumeOptions)
+- *Type:* [`org.cdk8s.plus22.ConfigMapVolumeOptions`](#org.cdk8s.plus22.ConfigMapVolumeOptions)
 
 Options.
 
 ---
 
-##### `fromEmptyDir` <a name="org.cdk8s.plus21.Volume.fromEmptyDir"></a>
+##### `fromEmptyDir` <a name="org.cdk8s.plus22.Volume.fromEmptyDir"></a>
 
 ```java
-import org.cdk8s.plus21.Volume;
+import org.cdk8s.plus22.Volume;
 
 Volume.fromEmptyDir(java.lang.String name)
 Volume.fromEmptyDir(java.lang.String name, EmptyDirVolumeOptions options)
 ```
 
-###### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.parameter.name"></a>
 
 - *Type:* `java.lang.String`
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Volume.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Volume.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus21.EmptyDirVolumeOptions`](#org.cdk8s.plus21.EmptyDirVolumeOptions)
+- *Type:* [`org.cdk8s.plus22.EmptyDirVolumeOptions`](#org.cdk8s.plus22.EmptyDirVolumeOptions)
 
 Additional options.
 
@@ -5643,7 +5771,7 @@ Additional options.
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.Volume.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5656,18 +5784,18 @@ public java.lang.String getName();
 
 ## Protocols <a name="Protocols"></a>
 
-### IConfigMap <a name="org.cdk8s.plus21.IConfigMap"></a>
+### IConfigMap <a name="org.cdk8s.plus22.IConfigMap"></a>
 
-- *Extends:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
+- *Extends:* [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource)
 
-- *Implemented By:* [`org.cdk8s.plus21.ConfigMap`](#org.cdk8s.plus21.ConfigMap), [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
+- *Implemented By:* [`org.cdk8s.plus22.ConfigMap`](#org.cdk8s.plus22.ConfigMap), [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap)
 
 Represents a config map.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.IConfigMap.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.IConfigMap.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5679,9 +5807,9 @@ The Kubernetes name of this resource.
 
 ---
 
-### IPodSpec <a name="org.cdk8s.plus21.IPodSpec"></a>
+### IPodSpec <a name="org.cdk8s.plus22.IPodSpec"></a>
 
-- *Implemented By:* [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment), [`org.cdk8s.plus21.Job`](#org.cdk8s.plus21.Job), [`org.cdk8s.plus21.Pod`](#org.cdk8s.plus21.Pod), [`org.cdk8s.plus21.PodSpec`](#org.cdk8s.plus21.PodSpec), [`org.cdk8s.plus21.PodTemplate`](#org.cdk8s.plus21.PodTemplate), [`org.cdk8s.plus21.StatefulSet`](#org.cdk8s.plus21.StatefulSet), [`org.cdk8s.plus21.IPodSpec`](#org.cdk8s.plus21.IPodSpec), [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
+- *Implemented By:* [`org.cdk8s.plus22.Deployment`](#org.cdk8s.plus22.Deployment), [`org.cdk8s.plus22.Job`](#org.cdk8s.plus22.Job), [`org.cdk8s.plus22.Pod`](#org.cdk8s.plus22.Pod), [`org.cdk8s.plus22.PodSpec`](#org.cdk8s.plus22.PodSpec), [`org.cdk8s.plus22.PodTemplate`](#org.cdk8s.plus22.PodTemplate), [`org.cdk8s.plus22.StatefulSet`](#org.cdk8s.plus22.StatefulSet), [`org.cdk8s.plus22.IPodSpec`](#org.cdk8s.plus22.IPodSpec), [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod spec. (e.g `Deployment`, `Job`, `Pod`, ...).
 
@@ -5689,29 +5817,29 @@ Use the `PodSpec` class as an implementation helper.
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="org.cdk8s.plus21.IPodSpec.addContainer"></a>
+##### `addContainer` <a name="org.cdk8s.plus22.IPodSpec.addContainer"></a>
 
 ```java
 public addContainer(ContainerProps container)
 ```
 
-###### `container`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodSpec.parameter.container"></a>
 
-- *Type:* [`org.cdk8s.plus21.ContainerProps`](#org.cdk8s.plus21.ContainerProps)
+- *Type:* [`org.cdk8s.plus22.ContainerProps`](#org.cdk8s.plus22.ContainerProps)
 
 The container.
 
 ---
 
-##### `addVolume` <a name="org.cdk8s.plus21.IPodSpec.addVolume"></a>
+##### `addVolume` <a name="org.cdk8s.plus22.IPodSpec.addVolume"></a>
 
 ```java
 public addVolume(Volume volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodSpec.parameter.volume"></a>
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)
 
 The volume.
 
@@ -5719,13 +5847,13 @@ The volume.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodSpec.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
 
 The containers belonging to the pod.
 
@@ -5733,13 +5861,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodSpec.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 
 The volumes associated with this pod.
 
@@ -5747,35 +5875,35 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.IPodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.IPodSpec.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.IPodSpec.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.IPodSpec.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-### IPodTemplate <a name="org.cdk8s.plus21.IPodTemplate"></a>
+### IPodTemplate <a name="org.cdk8s.plus22.IPodTemplate"></a>
 
-- *Extends:* [`org.cdk8s.plus21.IPodSpec`](#org.cdk8s.plus21.IPodSpec)
+- *Extends:* [`org.cdk8s.plus22.IPodSpec`](#org.cdk8s.plus22.IPodSpec)
 
-- *Implemented By:* [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment), [`org.cdk8s.plus21.Job`](#org.cdk8s.plus21.Job), [`org.cdk8s.plus21.PodTemplate`](#org.cdk8s.plus21.PodTemplate), [`org.cdk8s.plus21.StatefulSet`](#org.cdk8s.plus21.StatefulSet), [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
+- *Implemented By:* [`org.cdk8s.plus22.Deployment`](#org.cdk8s.plus22.Deployment), [`org.cdk8s.plus22.Job`](#org.cdk8s.plus22.Job), [`org.cdk8s.plus22.PodTemplate`](#org.cdk8s.plus22.PodTemplate), [`org.cdk8s.plus22.StatefulSet`](#org.cdk8s.plus22.StatefulSet), [`org.cdk8s.plus22.IPodTemplate`](#org.cdk8s.plus22.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod template. (e.g `Deployment`, `Job`, ...).
 
@@ -5784,13 +5912,13 @@ Use the `PodTemplate` class as an implementation helper.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.containers"></a>
 
 ```java
 public java.util.List<Container> getContainers();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Container`](#org.cdk8s.plus21.Container)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Container`](#org.cdk8s.plus22.Container)>
 
 The containers belonging to the pod.
 
@@ -5798,13 +5926,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
 ```
 
-- *Type:* java.util.List<[`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)>
+- *Type:* java.util.List<[`org.cdk8s.plus22.Volume`](#org.cdk8s.plus22.Volume)>
 
 The volumes associated with this pod.
 
@@ -5812,31 +5940,31 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
 ```
 
-- *Type:* [`org.cdk8s.plus21.RestartPolicy`](#org.cdk8s.plus21.RestartPolicy)
+- *Type:* [`org.cdk8s.plus22.RestartPolicy`](#org.cdk8s.plus22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
 ```
 
-- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Type:* [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="org.cdk8s.plus22.IPodTemplate.property.podMetadata"></a>
 
 ```java
 public ApiObjectMetadataDefinition getPodMetadata();
@@ -5848,16 +5976,16 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-### IResource <a name="org.cdk8s.plus21.IResource"></a>
+### IResource <a name="org.cdk8s.plus22.IResource"></a>
 
-- *Implemented By:* [`org.cdk8s.plus21.ConfigMap`](#org.cdk8s.plus21.ConfigMap), [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment), [`org.cdk8s.plus21.IngressV1Beta1`](#org.cdk8s.plus21.IngressV1Beta1), [`org.cdk8s.plus21.Job`](#org.cdk8s.plus21.Job), [`org.cdk8s.plus21.Pod`](#org.cdk8s.plus21.Pod), [`org.cdk8s.plus21.Resource`](#org.cdk8s.plus21.Resource), [`org.cdk8s.plus21.Secret`](#org.cdk8s.plus21.Secret), [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service), [`org.cdk8s.plus21.ServiceAccount`](#org.cdk8s.plus21.ServiceAccount), [`org.cdk8s.plus21.StatefulSet`](#org.cdk8s.plus21.StatefulSet), [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap), [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource), [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret), [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Implemented By:* [`org.cdk8s.plus22.ConfigMap`](#org.cdk8s.plus22.ConfigMap), [`org.cdk8s.plus22.Deployment`](#org.cdk8s.plus22.Deployment), [`org.cdk8s.plus22.Ingress`](#org.cdk8s.plus22.Ingress), [`org.cdk8s.plus22.Job`](#org.cdk8s.plus22.Job), [`org.cdk8s.plus22.Pod`](#org.cdk8s.plus22.Pod), [`org.cdk8s.plus22.Resource`](#org.cdk8s.plus22.Resource), [`org.cdk8s.plus22.Secret`](#org.cdk8s.plus22.Secret), [`org.cdk8s.plus22.Service`](#org.cdk8s.plus22.Service), [`org.cdk8s.plus22.ServiceAccount`](#org.cdk8s.plus22.ServiceAccount), [`org.cdk8s.plus22.StatefulSet`](#org.cdk8s.plus22.StatefulSet), [`org.cdk8s.plus22.IConfigMap`](#org.cdk8s.plus22.IConfigMap), [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource), [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret), [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 Represents a resource.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.IResource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.IResource.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5869,16 +5997,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### ISecret <a name="org.cdk8s.plus21.ISecret"></a>
+### ISecret <a name="org.cdk8s.plus22.ISecret"></a>
 
-- *Extends:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
+- *Extends:* [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource)
 
-- *Implemented By:* [`org.cdk8s.plus21.Secret`](#org.cdk8s.plus21.Secret), [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
+- *Implemented By:* [`org.cdk8s.plus22.Secret`](#org.cdk8s.plus22.Secret), [`org.cdk8s.plus22.ISecret`](#org.cdk8s.plus22.ISecret)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.ISecret.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.ISecret.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5890,16 +6018,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### IServiceAccount <a name="org.cdk8s.plus21.IServiceAccount"></a>
+### IServiceAccount <a name="org.cdk8s.plus22.IServiceAccount"></a>
 
-- *Extends:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
+- *Extends:* [`org.cdk8s.plus22.IResource`](#org.cdk8s.plus22.IResource)
 
-- *Implemented By:* [`org.cdk8s.plus21.ServiceAccount`](#org.cdk8s.plus21.ServiceAccount), [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Implemented By:* [`org.cdk8s.plus22.ServiceAccount`](#org.cdk8s.plus22.ServiceAccount), [`org.cdk8s.plus22.IServiceAccount`](#org.cdk8s.plus22.IServiceAccount)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="org.cdk8s.plus21.IServiceAccount.property.name"></a>
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus22.IServiceAccount.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -5917,14 +6045,14 @@ The Kubernetes name of this resource.
 
 The medium on which to store the volume.
 
-#### `DEFAULT` <a name="org.cdk8s.plus21.EmptyDirMedium.DEFAULT"></a>
+#### `DEFAULT` <a name="org.cdk8s.plus22.EmptyDirMedium.DEFAULT"></a>
 
 The default volume of the backing node.
 
 ---
 
 
-#### `MEMORY` <a name="org.cdk8s.plus21.EmptyDirMedium.MEMORY"></a>
+#### `MEMORY` <a name="org.cdk8s.plus22.EmptyDirMedium.MEMORY"></a>
 
 Mount a tmpfs (RAM-backed filesystem) for you instead.
 
@@ -5935,9 +6063,36 @@ files you write will count against your Container's memory limit.
 ---
 
 
+### HttpIngressPathType <a name="HttpIngressPathType"></a>
+
+Specify how the path is matched against request paths.
+
+> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+
+#### `PREFIX` <a name="org.cdk8s.plus22.HttpIngressPathType.PREFIX"></a>
+
+Matches the URL path exactly.
+
+---
+
+
+#### `EXACT` <a name="org.cdk8s.plus22.HttpIngressPathType.EXACT"></a>
+
+Matches based on a URL path prefix split by '/'.
+
+---
+
+
+#### `IMPLEMENTATION_SPECIFIC` <a name="org.cdk8s.plus22.HttpIngressPathType.IMPLEMENTATION_SPECIFIC"></a>
+
+Matching is specified by the underlying IngressClass.
+
+---
+
+
 ### ImagePullPolicy <a name="ImagePullPolicy"></a>
 
-#### `ALWAYS` <a name="org.cdk8s.plus21.ImagePullPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="org.cdk8s.plus22.ImagePullPolicy.ALWAYS"></a>
 
 Every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest.
 
@@ -5951,7 +6106,7 @@ the image tag is omitted.
 ---
 
 
-#### `IF_NOT_PRESENT` <a name="org.cdk8s.plus21.ImagePullPolicy.IF_NOT_PRESENT"></a>
+#### `IF_NOT_PRESENT` <a name="org.cdk8s.plus22.ImagePullPolicy.IF_NOT_PRESENT"></a>
 
 The image is pulled only if it is not already present locally.
 
@@ -5961,7 +6116,7 @@ not :latest
 ---
 
 
-#### `NEVER` <a name="org.cdk8s.plus21.ImagePullPolicy.NEVER"></a>
+#### `NEVER` <a name="org.cdk8s.plus22.ImagePullPolicy.NEVER"></a>
 
 The image is assumed to exist locally.
 
@@ -5972,7 +6127,7 @@ No attempt is made to pull the image.
 
 ### MountPropagation <a name="MountPropagation"></a>
 
-#### `NONE` <a name="org.cdk8s.plus21.MountPropagation.NONE"></a>
+#### `NONE` <a name="org.cdk8s.plus22.MountPropagation.NONE"></a>
 
 This volume mount will not receive any subsequent mounts that are mounted to this volume or any of its subdirectories by the host.
 
@@ -5987,7 +6142,7 @@ kernel documentation
 ---
 
 
-#### `HOST_TO_CONTAINER` <a name="org.cdk8s.plus21.MountPropagation.HOST_TO_CONTAINER"></a>
+#### `HOST_TO_CONTAINER` <a name="org.cdk8s.plus22.MountPropagation.HOST_TO_CONTAINER"></a>
 
 This volume mount will receive all subsequent mounts that are mounted to this volume or any of its subdirectories.
 
@@ -6004,7 +6159,7 @@ kernel documentation
 ---
 
 
-#### `BIDIRECTIONAL` <a name="org.cdk8s.plus21.MountPropagation.BIDIRECTIONAL"></a>
+#### `BIDIRECTIONAL` <a name="org.cdk8s.plus22.MountPropagation.BIDIRECTIONAL"></a>
 
 This volume mount behaves the same the HostToContainer mount.
 
@@ -6038,29 +6193,29 @@ continuing. When scaling down, the pods are removed in the opposite order.
 The alternative policy is `Parallel` which will create pods in parallel to match the
 desired scale without waiting, and on scale down will delete all pods at once.
 
-#### `ORDERED_READY` <a name="org.cdk8s.plus21.PodManagementPolicy.ORDERED_READY"></a>
+#### `ORDERED_READY` <a name="org.cdk8s.plus22.PodManagementPolicy.ORDERED_READY"></a>
 
 ---
 
 
-#### `PARALLEL` <a name="org.cdk8s.plus21.PodManagementPolicy.PARALLEL"></a>
+#### `PARALLEL` <a name="org.cdk8s.plus22.PodManagementPolicy.PARALLEL"></a>
 
 ---
 
 
 ### Protocol <a name="Protocol"></a>
 
-#### `TCP` <a name="org.cdk8s.plus21.Protocol.TCP"></a>
+#### `TCP` <a name="org.cdk8s.plus22.Protocol.TCP"></a>
 
 ---
 
 
-#### `UDP` <a name="org.cdk8s.plus21.Protocol.UDP"></a>
+#### `UDP` <a name="org.cdk8s.plus22.Protocol.UDP"></a>
 
 ---
 
 
-#### `SCTP` <a name="org.cdk8s.plus21.Protocol.SCTP"></a>
+#### `SCTP` <a name="org.cdk8s.plus22.Protocol.SCTP"></a>
 
 ---
 
@@ -6069,21 +6224,21 @@ desired scale without waiting, and on scale down will delete all pods at once.
 
 Restart policy for all containers within the pod.
 
-#### `ALWAYS` <a name="org.cdk8s.plus21.RestartPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="org.cdk8s.plus22.RestartPolicy.ALWAYS"></a>
 
 Always restart the pod after it exits.
 
 ---
 
 
-#### `ON_FAILURE` <a name="org.cdk8s.plus21.RestartPolicy.ON_FAILURE"></a>
+#### `ON_FAILURE` <a name="org.cdk8s.plus22.RestartPolicy.ON_FAILURE"></a>
 
 Only restart if the pod exits with a non-zero exit code.
 
 ---
 
 
-#### `NEVER` <a name="org.cdk8s.plus21.RestartPolicy.NEVER"></a>
+#### `NEVER` <a name="org.cdk8s.plus22.RestartPolicy.NEVER"></a>
 
 Never restart the pod.
 
@@ -6097,7 +6252,7 @@ For some parts of your application (for example, frontends) you may want to expo
 Kubernetes ServiceTypes allow you to specify what kind of Service you want.
 The default is ClusterIP.
 
-#### `CLUSTER_IP` <a name="org.cdk8s.plus21.ServiceType.CLUSTER_IP"></a>
+#### `CLUSTER_IP` <a name="org.cdk8s.plus22.ServiceType.CLUSTER_IP"></a>
 
 Exposes the Service on a cluster-internal IP.
 
@@ -6107,7 +6262,7 @@ This is the default ServiceType
 ---
 
 
-#### `NODE_PORT` <a name="org.cdk8s.plus21.ServiceType.NODE_PORT"></a>
+#### `NODE_PORT` <a name="org.cdk8s.plus22.ServiceType.NODE_PORT"></a>
 
 Exposes the Service on each Node's IP at a static port (the NodePort).
 
@@ -6118,7 +6273,7 @@ by requesting <NodeIP>:<NodePort>.
 ---
 
 
-#### `LOAD_BALANCER` <a name="org.cdk8s.plus21.ServiceType.LOAD_BALANCER"></a>
+#### `LOAD_BALANCER` <a name="org.cdk8s.plus22.ServiceType.LOAD_BALANCER"></a>
 
 Exposes the Service externally using a cloud provider's load balancer.
 
@@ -6128,7 +6283,7 @@ are automatically created.
 ---
 
 
-#### `EXTERNAL_NAME` <a name="org.cdk8s.plus21.ServiceType.EXTERNAL_NAME"></a>
+#### `EXTERNAL_NAME` <a name="org.cdk8s.plus22.ServiceType.EXTERNAL_NAME"></a>
 
 Maps the Service to the contents of the externalName field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -2,18 +2,18 @@
 
 ## Constructs <a name="Constructs"></a>
 
-### ConfigMap <a name="cdk8s_plus_21.ConfigMap"></a>
+### ConfigMap <a name="cdk8s_plus_22.ConfigMap"></a>
 
-- *Implements:* [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
+- *Implements:* [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap)
 
 ConfigMap holds configuration data for pods to consume.
 
-#### Initializers <a name="cdk8s_plus_21.ConfigMap.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.ConfigMap.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ConfigMap(
+cdk8s_plus_22.ConfigMap(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -22,19 +22,19 @@ cdk8s_plus_21.ConfigMap(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -42,7 +42,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binary_data`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.parameter.binary_data"></a>
+##### `binary_data`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.parameter.binary_data"></a>
 
 - *Type:* typing.Mapping[`str`]
 
@@ -58,7 +58,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.parameter.data"></a>
+##### `data`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.parameter.data"></a>
 
 - *Type:* typing.Mapping[`str`]
 
@@ -75,7 +75,7 @@ You can also add data using `configMap.addData()`.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_binary_data` <a name="cdk8s_plus_21.ConfigMap.add_binary_data"></a>
+##### `add_binary_data` <a name="cdk8s_plus_22.ConfigMap.add_binary_data"></a>
 
 ```python
 def add_binary_data(
@@ -84,7 +84,7 @@ def add_binary_data(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -92,7 +92,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -100,7 +100,7 @@ The value.
 
 ---
 
-##### `add_data` <a name="cdk8s_plus_21.ConfigMap.add_data"></a>
+##### `add_data` <a name="cdk8s_plus_22.ConfigMap.add_data"></a>
 
 ```python
 def add_data(
@@ -109,7 +109,7 @@ def add_data(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -117,7 +117,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -125,7 +125,7 @@ The value.
 
 ---
 
-##### `add_directory` <a name="cdk8s_plus_21.ConfigMap.add_directory"></a>
+##### `add_directory` <a name="cdk8s_plus_22.ConfigMap.add_directory"></a>
 
 ```python
 def add_directory(
@@ -135,7 +135,7 @@ def add_directory(
 )
 ```
 
-###### `local_dir`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.local_dir"></a>
+###### `local_dir`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.local_dir"></a>
 
 - *Type:* `str`
 
@@ -143,7 +143,7 @@ A path to a local directory.
 
 ---
 
-###### `exclude`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDirectoryOptions.parameter.exclude"></a>
+###### `exclude`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDirectoryOptions.parameter.exclude"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* include all files
@@ -152,7 +152,7 @@ Glob patterns to exclude when adding files.
 
 ---
 
-###### `key_prefix`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDirectoryOptions.parameter.key_prefix"></a>
+###### `key_prefix`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDirectoryOptions.parameter.key_prefix"></a>
 
 - *Type:* `str`
 - *Default:* ""
@@ -161,7 +161,7 @@ A prefix to add to all keys in the config map.
 
 ---
 
-##### `add_file` <a name="cdk8s_plus_21.ConfigMap.add_file"></a>
+##### `add_file` <a name="cdk8s_plus_22.ConfigMap.add_file"></a>
 
 ```python
 def add_file(
@@ -170,7 +170,7 @@ def add_file(
 )
 ```
 
-###### `local_file`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.local_file"></a>
+###### `local_file`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.local_file"></a>
 
 - *Type:* `str`
 
@@ -178,7 +178,7 @@ The path to the local file.
 
 ---
 
-###### `key`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -188,17 +188,17 @@ The ConfigMap key (default to the file name).
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_config_map_name` <a name="cdk8s_plus_21.ConfigMap.from_config_map_name"></a>
+##### `from_config_map_name` <a name="cdk8s_plus_22.ConfigMap.from_config_map_name"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ConfigMap.from_config_map_name(
+cdk8s_plus_22.ConfigMap.from_config_map_name(
   name: str
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -208,7 +208,7 @@ The name of the config map to import.
 
 #### Properties <a name="Properties"></a>
 
-##### `binary_data`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.property.binary_data"></a>
+##### `binary_data`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.property.binary_data"></a>
 
 ```python
 binary_data: typing.Mapping[str]
@@ -222,7 +222,7 @@ Returns a copy. To add data records, use `addBinaryData()` or `addData()`.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.property.data"></a>
+##### `data`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.property.data"></a>
 
 ```python
 data: typing.Mapping[str]
@@ -237,9 +237,9 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 ---
 
 
-### Deployment <a name="cdk8s_plus_21.Deployment"></a>
+### Deployment <a name="cdk8s_plus_22.Deployment"></a>
 
-- *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
+- *Implements:* [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
 
 A Deployment provides declarative updates for Pods and ReplicaSets.
 
@@ -266,12 +266,12 @@ The following are typical use cases for Deployments:
 - Use the status of the Deployment as an indicator that a rollout has stuck.
 - Clean up older ReplicaSets that you don't need anymore.
 
-#### Initializers <a name="cdk8s_plus_21.Deployment.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Deployment.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Deployment(
+cdk8s_plus_22.Deployment(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -285,19 +285,19 @@ cdk8s_plus_21.Deployment(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -305,9 +305,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -319,9 +319,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -330,9 +330,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -348,9 +348,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -361,7 +361,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.pod_metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -369,7 +369,7 @@ The pod metadata.
 
 ---
 
-##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.default_selector"></a>
+##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.default_selector"></a>
 
 - *Type:* `bool`
 - *Default:* true
@@ -381,7 +381,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.replicas"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 1
@@ -392,7 +392,7 @@ Number of desired pods.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_21.Deployment.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_22.Deployment.add_container"></a>
 
 ```python
 def add_container(
@@ -411,7 +411,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -419,7 +419,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -438,7 +438,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -452,9 +452,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -463,18 +463,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -483,7 +483,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -494,7 +494,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -505,18 +505,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -525,9 +525,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -535,7 +535,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -546,7 +546,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_21.Deployment.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_22.Deployment.add_volume"></a>
 
 ```python
 def add_volume(
@@ -554,33 +554,25 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
 
 ---
 
-##### `expose` <a name="cdk8s_plus_21.Deployment.expose"></a>
+##### `expose` <a name="cdk8s_plus_22.Deployment.expose"></a>
 
 ```python
 def expose(
-  port: typing.Union[int, float],
   name: str = None,
+  port: typing.Union[int, float] = None,
   protocol: Protocol = None,
   service_type: ServiceType = None,
   target_port: typing.Union[int, float] = None
 )
 ```
 
-###### `port`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.port"></a>
-
-- *Type:* `typing.Union[int, float]`
-
-The port number the service will bind to.
-
----
-
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* undefined Uses the system generated name.
@@ -591,9 +583,18 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.protocol"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.port"></a>
 
-- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
+
+---
+
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.protocol"></a>
+
+- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -602,16 +603,16 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-###### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.service_type"></a>
+###### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.service_type"></a>
 
-- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
+- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
 - *Default:* ClusterIP.
 
 The type of the exposed service.
 
 ---
 
-###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.target_port"></a>
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.target_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* The port of the first container in the deployment (ie. containers[0].port)
@@ -620,7 +621,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `select_by_label` <a name="cdk8s_plus_21.Deployment.select_by_label"></a>
+##### `select_by_label` <a name="cdk8s_plus_22.Deployment.select_by_label"></a>
 
 ```python
 def select_by_label(
@@ -629,7 +630,7 @@ def select_by_label(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -637,7 +638,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -648,13 +649,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
+- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
 
 The containers belonging to the pod.
 
@@ -662,7 +663,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.label_selector"></a>
+##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.label_selector"></a>
 
 ```python
 label_selector: typing.Mapping[str]
@@ -676,7 +677,7 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -688,7 +689,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.replicas"></a>
 
 ```python
 replicas: typing.Union[int, float]
@@ -700,13 +701,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 
 The volumes associated with this pod.
 
@@ -714,32 +715,32 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.Deployment.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.Deployment.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.Deployment.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.Deployment.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### IngressV1Beta1 <a name="cdk8s_plus_21.IngressV1Beta1"></a>
+### Ingress <a name="cdk8s_plus_22.Ingress"></a>
 
 Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend.
 
@@ -747,34 +748,34 @@ An Ingress can be configured to give services
 externally-reachable urls, load balance traffic, terminate SSL, offer name
 based virtual hosting etc.
 
-#### Initializers <a name="cdk8s_plus_21.IngressV1Beta1.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Ingress.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.IngressV1Beta1(
+cdk8s_plus_22.Ingress(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
-  default_backend: IngressV1Beta1Backend = None,
-  rules: typing.List[IngressV1Beta1Rule] = None,
-  tls: typing.List[IngressV1Beta1Tls] = None
+  default_backend: IngressBackend = None,
+  rules: typing.List[IngressRule] = None,
+  tls: typing.List[IngressTls] = None
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -782,9 +783,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `default_backend`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.parameter.default_backend"></a>
+##### `default_backend`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.parameter.default_backend"></a>
 
-- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
 
 The default backend services requests that do not match any rule.
 
@@ -793,9 +794,9 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.parameter.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.parameter.rules"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Rule`](#cdk8s_plus_21.IngressV1Beta1Rule)]
+- *Type:* typing.List[[`cdk8s_plus_22.IngressRule`](#cdk8s_plus_22.IngressRule)]
 
 Routing rules for this ingress.
 
@@ -808,9 +809,9 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.parameter.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.parameter.tls"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Tls`](#cdk8s_plus_21.IngressV1Beta1Tls)]
+- *Type:* typing.List[[`cdk8s_plus_22.IngressTls`](#cdk8s_plus_22.IngressTls)]
 
 TLS settings for this ingress.
 
@@ -824,32 +825,32 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_default_backend` <a name="cdk8s_plus_21.IngressV1Beta1.add_default_backend"></a>
+##### `add_default_backend` <a name="cdk8s_plus_22.Ingress.add_default_backend"></a>
 
 ```python
 def add_default_backend(
-  backend: IngressV1Beta1Backend
+  backend: IngressBackend
 )
 ```
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
 
 The backend to use for requests that do not match any rule.
 
 ---
 
-##### `add_host_default_backend` <a name="cdk8s_plus_21.IngressV1Beta1.add_host_default_backend"></a>
+##### `add_host_default_backend` <a name="cdk8s_plus_22.Ingress.add_host_default_backend"></a>
 
 ```python
 def add_host_default_backend(
   host: str,
-  backend: IngressV1Beta1Backend
+  backend: IngressBackend
 )
 ```
 
-###### `host`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.host"></a>
 
 - *Type:* `str`
 
@@ -857,25 +858,26 @@ The host name to match.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
 
 The backend to route to.
 
 ---
 
-##### `add_host_rule` <a name="cdk8s_plus_21.IngressV1Beta1.add_host_rule"></a>
+##### `add_host_rule` <a name="cdk8s_plus_22.Ingress.add_host_rule"></a>
 
 ```python
 def add_host_rule(
   host: str,
   path: str,
-  backend: IngressV1Beta1Backend
+  backend: IngressBackend,
+  path_type: HttpIngressPathType = None
 )
 ```
 
-###### `host`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.host"></a>
 
 - *Type:* `str`
 
@@ -883,7 +885,7 @@ The host name.
 
 ---
 
-###### `path`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.path"></a>
 
 - *Type:* `str`
 
@@ -891,24 +893,33 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
 
 The backend to route requests to.
 
 ---
 
-##### `add_rule` <a name="cdk8s_plus_21.IngressV1Beta1.add_rule"></a>
+###### `path_type`<sup>Optional</sup> <a name="cdk8s_plus_22.Ingress.parameter.path_type"></a>
+
+- *Type:* [`cdk8s_plus_22.HttpIngressPathType`](#cdk8s_plus_22.HttpIngressPathType)
+
+How the path is matched against request paths.
+
+---
+
+##### `add_rule` <a name="cdk8s_plus_22.Ingress.add_rule"></a>
 
 ```python
 def add_rule(
   path: str,
-  backend: IngressV1Beta1Backend
+  backend: IngressBackend,
+  path_type: HttpIngressPathType = None
 )
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.path"></a>
 
 - *Type:* `str`
 
@@ -916,33 +927,42 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
 
 The backend to route requests to.
 
 ---
 
-##### `add_rules` <a name="cdk8s_plus_21.IngressV1Beta1.add_rules"></a>
+###### `path_type`<sup>Optional</sup> <a name="cdk8s_plus_22.Ingress.parameter.path_type"></a>
+
+- *Type:* [`cdk8s_plus_22.HttpIngressPathType`](#cdk8s_plus_22.HttpIngressPathType)
+
+How the path is matched against request paths.
+
+---
+
+##### `add_rules` <a name="cdk8s_plus_22.Ingress.add_rules"></a>
 
 ```python
 def add_rules(
-  backend: IngressV1Beta1Backend,
+  backend: IngressBackend,
   host: str = None,
-  path: str = None
+  path: str = None,
+  path_type: HttpIngressPathType = None
 )
 ```
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.IngressRule.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
 
 Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ---
 
-###### `host`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.parameter.host"></a>
+###### `host`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.parameter.host"></a>
 
 - *Type:* `str`
 - *Default:* If the host is unspecified, the Ingress routes all traffic based
@@ -960,7 +980,7 @@ host before the IngressRuleValue.
 
 ---
 
-###### `path`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.parameter.path"></a>
+###### `path`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.parameter.path"></a>
 
 - *Type:* `str`
 - *Default:* If unspecified, the path defaults to a catch all sending traffic
@@ -970,26 +990,39 @@ Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows
 
 ---
 
-##### `add_tls` <a name="cdk8s_plus_21.IngressV1Beta1.add_tls"></a>
+###### `path_type`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.parameter.path_type"></a>
+
+- *Type:* [`cdk8s_plus_22.HttpIngressPathType`](#cdk8s_plus_22.HttpIngressPathType)
+
+Specify how the path is matched against request paths.
+
+By default, path
+types will be matched by prefix.
+
+> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+
+---
+
+##### `add_tls` <a name="cdk8s_plus_22.Ingress.add_tls"></a>
 
 ```python
 def add_tls(
-  tls: typing.List[IngressV1Beta1Tls]
+  tls: typing.List[IngressTls]
 )
 ```
 
-###### `tls`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.tls"></a>
+###### `tls`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.tls"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Tls`](#cdk8s_plus_21.IngressV1Beta1Tls)]
+- *Type:* typing.List[[`cdk8s_plus_22.IngressTls`](#cdk8s_plus_22.IngressTls)]
 
 ---
 
 
 
 
-### Job <a name="cdk8s_plus_21.Job"></a>
+### Job <a name="cdk8s_plus_22.Job"></a>
 
-- *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
+- *Implements:* [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
 
 A Job creates one or more Pods and ensures that a specified number of them successfully terminate.
 
@@ -999,12 +1032,12 @@ Deleting a Job will clean up the Pods it created. A simple case is to create one
 The Job object will start a new Pod if the first Pod fails or is deleted (for example due to a node hardware failure or a node reboot).
 You can also use a Job to run multiple Pods in parallel.
 
-#### Initializers <a name="cdk8s_plus_21.Job.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Job.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Job(
+cdk8s_plus_22.Job(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -1019,19 +1052,19 @@ cdk8s_plus_21.Job(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Job.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Job.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Job.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Job.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -1039,9 +1072,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1053,9 +1086,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -1064,9 +1097,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -1082,9 +1115,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -1095,7 +1128,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.pod_metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -1103,7 +1136,7 @@ The pod metadata.
 
 ---
 
-##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.active_deadline"></a>
+##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.active_deadline"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* If unset, then there is no deadline.
@@ -1112,7 +1145,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.backoff_limit"></a>
+##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.backoff_limit"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* If not set, system defaults to 6.
@@ -1121,7 +1154,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.ttl_after_finished"></a>
+##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.ttl_after_finished"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* If this field is unset, the Job won't be automatically deleted.
@@ -1139,7 +1172,7 @@ field is alpha-level and is only honored by servers that enable the
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_21.Job.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_22.Job.add_container"></a>
 
 ```python
 def add_container(
@@ -1158,7 +1191,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -1166,7 +1199,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -1185,7 +1218,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -1199,9 +1232,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -1210,18 +1243,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -1230,7 +1263,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -1241,7 +1274,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -1252,18 +1285,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -1272,9 +1305,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -1282,7 +1315,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -1293,7 +1326,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_21.Job.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_22.Job.add_volume"></a>
 
 ```python
 def add_volume(
@@ -1301,22 +1334,22 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Job.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.Job.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.Job.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.Job.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
+- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
 
 The containers belonging to the pod.
 
@@ -1324,7 +1357,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.Job.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.Job.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -1336,13 +1369,13 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.Job.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.Job.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 
 The volumes associated with this pod.
 
@@ -1350,7 +1383,7 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.active_deadline"></a>
+##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.active_deadline"></a>
 
 ```python
 active_deadline: Duration
@@ -1364,7 +1397,7 @@ If undefined, there is no deadline.
 
 ---
 
-##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.backoff_limit"></a>
+##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.backoff_limit"></a>
 
 ```python
 backoff_limit: typing.Union[int, float]
@@ -1376,31 +1409,31 @@ Number of retries before marking failed.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.ttl_after_finished"></a>
+##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.ttl_after_finished"></a>
 
 ```python
 ttl_after_finished: Duration
@@ -1413,21 +1446,21 @@ TTL before the job is deleted after it is finished.
 ---
 
 
-### Pod <a name="cdk8s_plus_21.Pod"></a>
+### Pod <a name="cdk8s_plus_22.Pod"></a>
 
-- *Implements:* [`cdk8s_plus_21.IPodSpec`](#cdk8s_plus_21.IPodSpec)
+- *Implements:* [`cdk8s_plus_22.IPodSpec`](#cdk8s_plus_22.IPodSpec)
 
 Pod is a collection of containers that can run on a host.
 
 This resource is
 created by clients and scheduled onto hosts.
 
-#### Initializers <a name="cdk8s_plus_21.Pod.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Pod.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Pod(
+cdk8s_plus_22.Pod(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -1438,19 +1471,19 @@ cdk8s_plus_21.Pod(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -1458,9 +1491,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1472,9 +1505,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -1483,9 +1516,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -1501,9 +1534,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -1516,7 +1549,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_21.Pod.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_22.Pod.add_container"></a>
 
 ```python
 def add_container(
@@ -1535,7 +1568,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -1543,7 +1576,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -1562,7 +1595,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -1576,9 +1609,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -1587,18 +1620,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -1607,7 +1640,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -1618,7 +1651,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -1629,18 +1662,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -1649,9 +1682,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -1659,7 +1692,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -1670,7 +1703,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_21.Pod.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_22.Pod.add_volume"></a>
 
 ```python
 def add_volume(
@@ -1678,22 +1711,22 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
+- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
 
 The containers belonging to the pod.
 
@@ -1701,13 +1734,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 
 The volumes associated with this pod.
 
@@ -1715,53 +1748,53 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.Pod.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.Pod.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.Pod.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.Pod.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Resource <a name="cdk8s_plus_21.Resource"></a>
+### Resource <a name="cdk8s_plus_22.Resource"></a>
 
-- *Implements:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
+- *Implements:* [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource)
 
 Base class for all Kubernetes objects in stdk8s.
 
 Represents a single
 resource.
 
-#### Initializers <a name="cdk8s_plus_21.Resource.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Resource.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Resource(
+cdk8s_plus_22.Resource(
   scope: Construct,
   id: str,
   node_factory: INodeFactory = None
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Resource.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Resource.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
@@ -1769,7 +1802,7 @@ The scope in which to define this construct.
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Resource.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Resource.parameter.id"></a>
 
 - *Type:* `str`
 
@@ -1794,7 +1827,7 @@ A factory for attaching `Node`s to the construct.
 
 #### Properties <a name="Properties"></a>
 
-##### `metadata`<sup>Required</sup> <a name="cdk8s_plus_21.Resource.property.metadata"></a>
+##### `metadata`<sup>Required</sup> <a name="cdk8s_plus_22.Resource.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadataDefinition
@@ -1804,7 +1837,7 @@ metadata: ApiObjectMetadataDefinition
 
 ---
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Resource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Resource.property.name"></a>
 
 ```python
 name: str
@@ -1817,9 +1850,9 @@ The name of this API object.
 ---
 
 
-### Secret <a name="cdk8s_plus_21.Secret"></a>
+### Secret <a name="cdk8s_plus_22.Secret"></a>
 
-- *Implements:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
+- *Implements:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
 
 Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 
@@ -1829,12 +1862,12 @@ definition or in a container image.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
 
-#### Initializers <a name="cdk8s_plus_21.Secret.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Secret.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Secret(
+cdk8s_plus_22.Secret(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -1843,19 +1876,19 @@ cdk8s_plus_21.Secret(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -1863,7 +1896,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.string_data"></a>
+##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.string_data"></a>
 
 - *Type:* typing.Mapping[`str`]
 
@@ -1876,7 +1909,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.type"></a>
 
 - *Type:* `str`
 - *Default:* undefined - Don't set a type.
@@ -1890,7 +1923,7 @@ handling of secret data by various controllers.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_string_data` <a name="cdk8s_plus_21.Secret.add_string_data"></a>
+##### `add_string_data` <a name="cdk8s_plus_22.Secret.add_string_data"></a>
 
 ```python
 def add_string_data(
@@ -1899,7 +1932,7 @@ def add_string_data(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -1907,7 +1940,7 @@ Key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -1915,7 +1948,7 @@ Value.
 
 ---
 
-##### `get_string_data` <a name="cdk8s_plus_21.Secret.get_string_data"></a>
+##### `get_string_data` <a name="cdk8s_plus_22.Secret.get_string_data"></a>
 
 ```python
 def get_string_data(
@@ -1923,7 +1956,7 @@ def get_string_data(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -1933,17 +1966,17 @@ Key.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_secret_name` <a name="cdk8s_plus_21.Secret.from_secret_name"></a>
+##### `from_secret_name` <a name="cdk8s_plus_22.Secret.from_secret_name"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Secret.from_secret_name(
+cdk8s_plus_22.Secret.from_secret_name(
   name: str
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -1953,7 +1986,7 @@ The name of the secret to reference.
 
 
 
-### Service <a name="cdk8s_plus_21.Service"></a>
+### Service <a name="cdk8s_plus_22.Service"></a>
 
 An abstract way to expose an application running on a set of Pods as a network service.
 
@@ -1969,12 +2002,12 @@ If you're able to use Kubernetes APIs for service discovery in your application,
 that get updated whenever the set of Pods in a Service changes. For non-native applications, Kubernetes offers ways to place a network port
 or load balancer in between your application and the backend Pods.
 
-#### Initializers <a name="cdk8s_plus_21.Service.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Service.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Service(
+cdk8s_plus_22.Service(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -1987,19 +2020,19 @@ cdk8s_plus_21.Service(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -2007,7 +2040,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.cluster_i_p"></a>
+##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.cluster_i_p"></a>
 
 - *Type:* `str`
 - *Default:* Automatically assigned.
@@ -2025,7 +2058,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `external_i_ps`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.external_i_ps"></a>
+##### `external_i_ps`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.external_i_ps"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* No external IPs.
@@ -2039,7 +2072,7 @@ Kubernetes system.
 
 ---
 
-##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.external_name"></a>
+##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.external_name"></a>
 
 - *Type:* `str`
 - *Default:* No external name.
@@ -2048,7 +2081,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `load_balancer_source_ranges`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.load_balancer_source_ranges"></a>
+##### `load_balancer_source_ranges`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.load_balancer_source_ranges"></a>
 
 - *Type:* typing.List[`str`]
 
@@ -2058,9 +2091,9 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.ports"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.ServicePort`](#cdk8s_plus_21.ServicePort)]
+- *Type:* typing.List[[`cdk8s_plus_22.ServicePort`](#cdk8s_plus_22.ServicePort)]
 
 The port exposed by this service.
 
@@ -2068,9 +2101,9 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.type"></a>
 
-- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
+- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -2081,36 +2114,28 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 #### Methods <a name="Methods"></a>
 
-##### `add_deployment` <a name="cdk8s_plus_21.Service.add_deployment"></a>
+##### `add_deployment` <a name="cdk8s_plus_22.Service.add_deployment"></a>
 
 ```python
 def add_deployment(
   deployment: Deployment,
-  port: typing.Union[int, float],
   name: str = None,
   node_port: typing.Union[int, float] = None,
   protocol: Protocol = None,
-  target_port: typing.Union[int, float] = None
+  target_port: typing.Union[int, float] = None,
+  port: typing.Union[int, float] = None
 )
 ```
 
-###### `deployment`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.deployment"></a>
+###### `deployment`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.deployment"></a>
 
-- *Type:* [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment)
+- *Type:* [`cdk8s_plus_22.Deployment`](#cdk8s_plus_22.Deployment)
 
 The deployment to expose.
 
 ---
 
-###### `port`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.port"></a>
-
-- *Type:* `typing.Union[int, float]`
-
-The external port.
-
----
-
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -2123,11 +2148,10 @@ on this service.
 
 ---
 
-###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.node_port"></a>
+###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.node_port"></a>
 
 - *Type:* `typing.Union[int, float]`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -2140,9 +2164,9 @@ requires one.
 
 ---
 
-###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.protocol"></a>
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.protocol"></a>
 
-- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
+- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -2151,7 +2175,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.target_port"></a>
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.target_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* The value of `port` will be used.
@@ -2160,7 +2184,16 @@ The port number the service will redirect to.
 
 ---
 
-##### `add_selector` <a name="cdk8s_plus_21.Service.add_selector"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the first container of the deployment.
+
+The port number the service will bind to.
+
+---
+
+##### `add_selector` <a name="cdk8s_plus_22.Service.add_selector"></a>
 
 ```python
 def add_selector(
@@ -2169,7 +2202,7 @@ def add_selector(
 )
 ```
 
-###### `label`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.label"></a>
+###### `label`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.label"></a>
 
 - *Type:* `str`
 
@@ -2177,7 +2210,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -2185,7 +2218,7 @@ The label value.
 
 ---
 
-##### `serve` <a name="cdk8s_plus_21.Service.serve"></a>
+##### `serve` <a name="cdk8s_plus_22.Service.serve"></a>
 
 ```python
 def serve(
@@ -2197,7 +2230,7 @@ def serve(
 )
 ```
 
-###### `port`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.port"></a>
+###### `port`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 
@@ -2205,7 +2238,7 @@ The port definition.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -2218,11 +2251,10 @@ on this service.
 
 ---
 
-###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.node_port"></a>
+###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.parameter.node_port"></a>
 
 - *Type:* `typing.Union[int, float]`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -2235,9 +2267,9 @@ requires one.
 
 ---
 
-###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.protocol"></a>
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.parameter.protocol"></a>
 
-- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
+- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -2246,7 +2278,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.target_port"></a>
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.parameter.target_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* The value of `port` will be used.
@@ -2258,13 +2290,13 @@ The port number the service will redirect to.
 
 #### Properties <a name="Properties"></a>
 
-##### `ports`<sup>Required</sup> <a name="cdk8s_plus_21.Service.property.ports"></a>
+##### `ports`<sup>Required</sup> <a name="cdk8s_plus_22.Service.property.ports"></a>
 
 ```python
 ports: typing.List[ServicePort]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ServicePort`](#cdk8s_plus_21.ServicePort)]
+- *Type:* typing.List[[`cdk8s_plus_22.ServicePort`](#cdk8s_plus_22.ServicePort)]
 
 Ports for this service.
 
@@ -2272,7 +2304,7 @@ Use `serve()` to expose additional service ports.
 
 ---
 
-##### `selector`<sup>Required</sup> <a name="cdk8s_plus_21.Service.property.selector"></a>
+##### `selector`<sup>Required</sup> <a name="cdk8s_plus_22.Service.property.selector"></a>
 
 ```python
 selector: typing.Mapping[str]
@@ -2284,19 +2316,19 @@ Returns the labels which are used to select pods for this service.
 
 ---
 
-##### `type`<sup>Required</sup> <a name="cdk8s_plus_21.Service.property.type"></a>
+##### `type`<sup>Required</sup> <a name="cdk8s_plus_22.Service.property.type"></a>
 
 ```python
 type: ServiceType
 ```
 
-- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
+- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
 
 Determines how the Service is exposed.
 
 ---
 
-##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_21.Service.property.cluster_i_p"></a>
+##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_22.Service.property.cluster_i_p"></a>
 
 ```python
 cluster_i_p: str
@@ -2308,7 +2340,7 @@ The IP address of the service and is usually assigned randomly by the master.
 
 ---
 
-##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_21.Service.property.external_name"></a>
+##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_22.Service.property.external_name"></a>
 
 ```python
 external_name: str
@@ -2321,9 +2353,9 @@ The externalName to be used for EXTERNAL_NAME types.
 ---
 
 
-### ServiceAccount <a name="cdk8s_plus_21.ServiceAccount"></a>
+### ServiceAccount <a name="cdk8s_plus_22.ServiceAccount"></a>
 
-- *Implements:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Implements:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 A service account provides an identity for processes that run in a Pod.
 
@@ -2336,12 +2368,12 @@ example, default).
 
 > https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account
 
-#### Initializers <a name="cdk8s_plus_21.ServiceAccount.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.ServiceAccount.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ServiceAccount(
+cdk8s_plus_22.ServiceAccount(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -2349,19 +2381,19 @@ cdk8s_plus_21.ServiceAccount(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -2369,9 +2401,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountProps.parameter.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountProps.parameter.secrets"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)]
+- *Type:* typing.List[[`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)]
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -2381,7 +2413,7 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_secret` <a name="cdk8s_plus_21.ServiceAccount.add_secret"></a>
+##### `add_secret` <a name="cdk8s_plus_22.ServiceAccount.add_secret"></a>
 
 ```python
 def add_secret(
@@ -2389,9 +2421,9 @@ def add_secret(
 )
 ```
 
-###### `secret`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.parameter.secret"></a>
+###### `secret`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.parameter.secret"></a>
 
-- *Type:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
+- *Type:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
 
 The secret.
 
@@ -2399,17 +2431,17 @@ The secret.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_service_account_name` <a name="cdk8s_plus_21.ServiceAccount.from_service_account_name"></a>
+##### `from_service_account_name` <a name="cdk8s_plus_22.ServiceAccount.from_service_account_name"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ServiceAccount.from_service_account_name(
+cdk8s_plus_22.ServiceAccount.from_service_account_name(
   name: str
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -2419,13 +2451,13 @@ The name of the service account resource.
 
 #### Properties <a name="Properties"></a>
 
-##### `secrets`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.property.secrets"></a>
+##### `secrets`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.property.secrets"></a>
 
 ```python
 secrets: typing.List[ISecret]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)]
+- *Type:* typing.List[[`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)]
 
 List of secrets allowed to be used by pods running using this service account.
 
@@ -2434,9 +2466,9 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
-### StatefulSet <a name="cdk8s_plus_21.StatefulSet"></a>
+### StatefulSet <a name="cdk8s_plus_22.StatefulSet"></a>
 
-- *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
+- *Implements:* [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
 
 StatefulSet is the workload API object used to manage stateful applications.
 
@@ -2463,12 +2495,12 @@ StatefulSets are valuable for applications that require one or more of the follo
 - Ordered, graceful deployment and scaling.
 - Ordered, automated rolling updates.
 
-#### Initializers <a name="cdk8s_plus_21.StatefulSet.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.StatefulSet.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.StatefulSet(
+cdk8s_plus_22.StatefulSet(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -2484,19 +2516,19 @@ cdk8s_plus_21.StatefulSet(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -2504,9 +2536,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2518,9 +2550,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2529,9 +2561,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2547,9 +2579,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2560,7 +2592,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.pod_metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -2568,15 +2600,15 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.service"></a>
+##### `service`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.service"></a>
 
-- *Type:* [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service)
+- *Type:* [`cdk8s_plus_22.Service`](#cdk8s_plus_22.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.default_selector"></a>
+##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.default_selector"></a>
 
 - *Type:* `bool`
 - *Default:* true
@@ -2588,16 +2620,16 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `pod_management_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.pod_management_policy"></a>
+##### `pod_management_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.pod_management_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.PodManagementPolicy`](#cdk8s_plus_21.PodManagementPolicy)
+- *Type:* [`cdk8s_plus_22.PodManagementPolicy`](#cdk8s_plus_22.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.replicas"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 1
@@ -2608,7 +2640,7 @@ Number of desired pods.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_21.StatefulSet.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_22.StatefulSet.add_container"></a>
 
 ```python
 def add_container(
@@ -2627,7 +2659,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -2635,7 +2667,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -2654,7 +2686,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -2668,9 +2700,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -2679,18 +2711,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -2699,7 +2731,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -2710,7 +2742,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -2721,18 +2753,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -2741,9 +2773,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -2751,7 +2783,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -2762,7 +2794,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_21.StatefulSet.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_22.StatefulSet.add_volume"></a>
 
 ```python
 def add_volume(
@@ -2770,13 +2802,13 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
 
 ---
 
-##### `select_by_label` <a name="cdk8s_plus_21.StatefulSet.select_by_label"></a>
+##### `select_by_label` <a name="cdk8s_plus_22.StatefulSet.select_by_label"></a>
 
 ```python
 def select_by_label(
@@ -2785,7 +2817,7 @@ def select_by_label(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -2793,7 +2825,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -2804,13 +2836,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
+- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
 
 The containers belonging to the pod.
 
@@ -2818,7 +2850,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.label_selector"></a>
+##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.label_selector"></a>
 
 ```python
 label_selector: typing.Mapping[str]
@@ -2832,19 +2864,19 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `pod_management_policy`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.pod_management_policy"></a>
+##### `pod_management_policy`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.pod_management_policy"></a>
 
 ```python
 pod_management_policy: PodManagementPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.PodManagementPolicy`](#cdk8s_plus_21.PodManagementPolicy)
+- *Type:* [`cdk8s_plus_22.PodManagementPolicy`](#cdk8s_plus_22.PodManagementPolicy)
 
 Management policy to use for the set.
 
 ---
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -2856,7 +2888,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.replicas"></a>
 
 ```python
 replicas: typing.Union[int, float]
@@ -2868,13 +2900,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 
 The volumes associated with this pod.
 
@@ -2882,25 +2914,25 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSet.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSet.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSet.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSet.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 The service account used to run this pod.
 
@@ -2909,22 +2941,118 @@ The service account used to run this pod.
 
 ## Structs <a name="Structs"></a>
 
-### AddDirectoryOptions <a name="cdk8s_plus_21.AddDirectoryOptions"></a>
+### AddDeploymentOptions <a name="cdk8s_plus_22.AddDeploymentOptions"></a>
+
+Options to add a deployment to a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.AddDeploymentOptions(
+  name: str = None,
+  node_port: typing.Union[int, float] = None,
+  protocol: Protocol = None,
+  target_port: typing.Union[int, float] = None,
+  port: typing.Union[int, float] = None
+)
+```
+
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.name"></a>
+
+```python
+name: str
+```
+
+- *Type:* `str`
+
+The name of this port within the service.
+
+This must be a DNS_LABEL. All
+ports within a ServiceSpec must have unique names. This maps to the 'Name'
+field in EndpointPort objects. Optional if only one ServicePort is defined
+on this service.
+
+---
+
+##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.node_port"></a>
+
+```python
+node_port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
+
+The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
+
+Usually assigned by the system. If specified, it will be
+allocated to the service if unused or else creation of the service will
+fail. Default is to auto-allocate a port if the ServiceType of this Service
+requires one.
+
+> https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.protocol"></a>
+
+```python
+protocol: Protocol
+```
+
+- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.target_port"></a>
+
+```python
+target_port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* The value of `port` will be used.
+
+The port number the service will redirect to.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.port"></a>
+
+```python
+port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the first container of the deployment.
+
+The port number the service will bind to.
+
+---
+
+### AddDirectoryOptions <a name="cdk8s_plus_22.AddDirectoryOptions"></a>
 
 Options for `configmap.addDirectory()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.AddDirectoryOptions(
+cdk8s_plus_22.AddDirectoryOptions(
   exclude: typing.List[str] = None,
   key_prefix: str = None
 )
 ```
 
-##### `exclude`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDirectoryOptions.property.exclude"></a>
+##### `exclude`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDirectoryOptions.property.exclude"></a>
 
 ```python
 exclude: typing.List[str]
@@ -2937,7 +3065,7 @@ Glob patterns to exclude when adding files.
 
 ---
 
-##### `key_prefix`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDirectoryOptions.property.key_prefix"></a>
+##### `key_prefix`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDirectoryOptions.property.key_prefix"></a>
 
 ```python
 key_prefix: str
@@ -2950,16 +3078,16 @@ A prefix to add to all keys in the config map.
 
 ---
 
-### CommandProbeOptions <a name="cdk8s_plus_21.CommandProbeOptions"></a>
+### CommandProbeOptions <a name="cdk8s_plus_22.CommandProbeOptions"></a>
 
 Options for `Probe.fromCommand()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.CommandProbeOptions(
+cdk8s_plus_22.CommandProbeOptions(
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
   period_seconds: Duration = None,
@@ -2968,7 +3096,7 @@ cdk8s_plus_21.CommandProbeOptions(
 )
 ```
 
-##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.failure_threshold"></a>
+##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.failure_threshold"></a>
 
 ```python
 failure_threshold: typing.Union[int, float]
@@ -2983,7 +3111,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.initial_delay_seconds"></a>
+##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.initial_delay_seconds"></a>
 
 ```python
 initial_delay_seconds: Duration
@@ -2998,7 +3126,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.period_seconds"></a>
+##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.period_seconds"></a>
 
 ```python
 period_seconds: Duration
@@ -3013,7 +3141,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.success_threshold"></a>
+##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.success_threshold"></a>
 
 ```python
 success_threshold: typing.Union[int, float]
@@ -3028,7 +3156,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.timeout_seconds"></a>
+##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.timeout_seconds"></a>
 
 ```python
 timeout_seconds: Duration
@@ -3045,23 +3173,23 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="cdk8s_plus_21.ConfigMapProps"></a>
+### ConfigMapProps <a name="cdk8s_plus_22.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ConfigMapProps(
+cdk8s_plus_22.ConfigMapProps(
   metadata: ApiObjectMetadata = None,
   binary_data: typing.Mapping[str] = None,
   data: typing.Mapping[str] = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -3073,7 +3201,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binary_data`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.property.binary_data"></a>
+##### `binary_data`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.property.binary_data"></a>
 
 ```python
 binary_data: typing.Mapping[str]
@@ -3093,7 +3221,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.property.data"></a>
+##### `data`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.property.data"></a>
 
 ```python
 data: typing.Mapping[str]
@@ -3112,16 +3240,16 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="cdk8s_plus_21.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="cdk8s_plus_22.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ConfigMapVolumeOptions(
+cdk8s_plus_22.ConfigMapVolumeOptions(
   default_mode: typing.Union[int, float] = None,
   items: typing.Mapping[PathMapping] = None,
   name: str = None,
@@ -3129,7 +3257,7 @@ cdk8s_plus_21.ConfigMapVolumeOptions(
 )
 ```
 
-##### `default_mode`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.property.default_mode"></a>
+##### `default_mode`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.property.default_mode"></a>
 
 ```python
 default_mode: typing.Union[int, float]
@@ -3149,13 +3277,13 @@ file mode, like fsGroup, and the result can be other mode bits set.
 
 ---
 
-##### `items`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.property.items"></a>
+##### `items`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.property.items"></a>
 
 ```python
 items: typing.Mapping[PathMapping]
 ```
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.PathMapping`](#cdk8s_plus_21.PathMapping)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.PathMapping`](#cdk8s_plus_22.PathMapping)]
 - *Default:* no mapping
 
 If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value.
@@ -3168,7 +3296,7 @@ contain the '..' path or start with '..'.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.property.name"></a>
 
 ```python
 name: str
@@ -3181,7 +3309,7 @@ The volume name.
 
 ---
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.property.optional"></a>
 
 ```python
 optional: bool
@@ -3194,16 +3322,16 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
-### ContainerProps <a name="cdk8s_plus_21.ContainerProps"></a>
+### ContainerProps <a name="cdk8s_plus_22.ContainerProps"></a>
 
 Properties for creating a container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ContainerProps(
+cdk8s_plus_22.ContainerProps(
   image: str,
   args: typing.List[str] = None,
   command: typing.List[str] = None,
@@ -3219,7 +3347,7 @@ cdk8s_plus_21.ContainerProps(
 )
 ```
 
-##### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.property.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.property.image"></a>
 
 ```python
 image: str
@@ -3231,7 +3359,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.args"></a>
 
 ```python
 args: typing.List[str]
@@ -3254,7 +3382,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.command"></a>
 
 ```python
 command: typing.List[str]
@@ -3272,13 +3400,13 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.env"></a>
+##### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.env"></a>
 
 ```python
 env: typing.Mapping[EnvValue]
 ```
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -3287,26 +3415,26 @@ Cannot be updated.
 
 ---
 
-##### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.image_pull_policy"></a>
+##### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.image_pull_policy"></a>
 
 ```python
 image_pull_policy: ImagePullPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.liveness"></a>
 
 ```python
 liveness: Probe
 ```
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -3315,7 +3443,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.name"></a>
 
 ```python
 name: str
@@ -3330,7 +3458,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -3345,26 +3473,26 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.readiness"></a>
 
 ```python
 readiness: Probe
 ```
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.startup"></a>
 
 ```python
 startup: Probe
 ```
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -3373,13 +3501,13 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.volume_mounts"></a>
+##### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.volume_mounts"></a>
 
 ```python
 volume_mounts: typing.List[VolumeMount]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -3387,7 +3515,7 @@ Cannot be updated.
 
 ---
 
-##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.working_dir"></a>
+##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.working_dir"></a>
 
 ```python
 working_dir: str
@@ -3402,16 +3530,16 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-### DeploymentProps <a name="cdk8s_plus_21.DeploymentProps"></a>
+### DeploymentProps <a name="cdk8s_plus_22.DeploymentProps"></a>
 
 Properties for initialization of `Deployment`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.DeploymentProps(
+cdk8s_plus_22.DeploymentProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -3423,7 +3551,7 @@ cdk8s_plus_21.DeploymentProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -3435,13 +3563,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3453,13 +3581,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3468,13 +3596,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3490,13 +3618,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3507,7 +3635,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadata
@@ -3519,7 +3647,7 @@ The pod metadata.
 
 ---
 
-##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.default_selector"></a>
+##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.default_selector"></a>
 
 ```python
 default_selector: bool
@@ -3535,7 +3663,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.replicas"></a>
 
 ```python
 replicas: typing.Union[int, float]
@@ -3548,28 +3676,28 @@ Number of desired pods.
 
 ---
 
-### EmptyDirVolumeOptions <a name="cdk8s_plus_21.EmptyDirVolumeOptions"></a>
+### EmptyDirVolumeOptions <a name="cdk8s_plus_22.EmptyDirVolumeOptions"></a>
 
 Options for volumes populated with an empty directory.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.EmptyDirVolumeOptions(
+cdk8s_plus_22.EmptyDirVolumeOptions(
   medium: EmptyDirMedium = None,
   size_limit: Size = None
 )
 ```
 
-##### `medium`<sup>Optional</sup> <a name="cdk8s_plus_21.EmptyDirVolumeOptions.property.medium"></a>
+##### `medium`<sup>Optional</sup> <a name="cdk8s_plus_22.EmptyDirVolumeOptions.property.medium"></a>
 
 ```python
 medium: EmptyDirMedium
 ```
 
-- *Type:* [`cdk8s_plus_21.EmptyDirMedium`](#cdk8s_plus_21.EmptyDirMedium)
+- *Type:* [`cdk8s_plus_22.EmptyDirMedium`](#cdk8s_plus_22.EmptyDirMedium)
 - *Default:* EmptyDirMedium.DEFAULT
 
 By default, emptyDir volumes are stored on whatever medium is backing the node - that might be disk or SSD or network storage, depending on your environment.
@@ -3582,7 +3710,7 @@ against your Container's memory limit.
 
 ---
 
-##### `size_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.EmptyDirVolumeOptions.property.size_limit"></a>
+##### `size_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.EmptyDirVolumeOptions.property.size_limit"></a>
 
 ```python
 size_limit: Size
@@ -3600,21 +3728,21 @@ here and the sum of memory limits of all containers in a pod.
 
 ---
 
-### EnvValueFromConfigMapOptions <a name="cdk8s_plus_21.EnvValueFromConfigMapOptions"></a>
+### EnvValueFromConfigMapOptions <a name="cdk8s_plus_22.EnvValueFromConfigMapOptions"></a>
 
 Options to specify an envionment variable value from a ConfigMap key.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.EnvValueFromConfigMapOptions(
+cdk8s_plus_22.EnvValueFromConfigMapOptions(
   optional: bool = None
 )
 ```
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromConfigMapOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromConfigMapOptions.property.optional"></a>
 
 ```python
 optional: bool
@@ -3627,21 +3755,21 @@ Specify whether the ConfigMap or its key must be defined.
 
 ---
 
-### EnvValueFromProcessOptions <a name="cdk8s_plus_21.EnvValueFromProcessOptions"></a>
+### EnvValueFromProcessOptions <a name="cdk8s_plus_22.EnvValueFromProcessOptions"></a>
 
 Options to specify an environment variable value from the process environment.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.EnvValueFromProcessOptions(
+cdk8s_plus_22.EnvValueFromProcessOptions(
   required: bool = None
 )
 ```
 
-##### `required`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromProcessOptions.property.required"></a>
+##### `required`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromProcessOptions.property.required"></a>
 
 ```python
 required: bool
@@ -3656,21 +3784,21 @@ If this is set to true, and the key does not exist, an error will thrown.
 
 ---
 
-### EnvValueFromSecretOptions <a name="cdk8s_plus_21.EnvValueFromSecretOptions"></a>
+### EnvValueFromSecretOptions <a name="cdk8s_plus_22.EnvValueFromSecretOptions"></a>
 
 Options to specify an environment variable value from a Secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.EnvValueFromSecretOptions(
+cdk8s_plus_22.EnvValueFromSecretOptions(
   optional: bool = None
 )
 ```
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromSecretOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromSecretOptions.property.optional"></a>
 
 ```python
 optional: bool
@@ -3683,24 +3811,25 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="cdk8s_plus_21.ExposeOptions"></a>
+### ExposeOptions <a name="cdk8s_plus_22.ExposeOptions"></a>
 
 Options for exposing a deployment via a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ExposeOptions(
+cdk8s_plus_22.ExposeOptions(
   name: str = None,
+  port: typing.Union[int, float] = None,
   protocol: Protocol = None,
   service_type: ServiceType = None,
   target_port: typing.Union[int, float] = None
 )
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.name"></a>
 
 ```python
 name: str
@@ -3715,13 +3844,26 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.protocol"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.port"></a>
+
+```python
+port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.protocol"></a>
 
 ```python
 protocol: Protocol
 ```
 
-- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
+- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -3730,20 +3872,20 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.service_type"></a>
+##### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.service_type"></a>
 
 ```python
 service_type: ServiceType
 ```
 
-- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
+- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
 - *Default:* ClusterIP.
 
 The type of the exposed service.
 
 ---
 
-##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.target_port"></a>
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.target_port"></a>
 
 ```python
 target_port: typing.Union[int, float]
@@ -3756,16 +3898,16 @@ The port number the service will redirect to.
 
 ---
 
-### HttpGetProbeOptions <a name="cdk8s_plus_21.HttpGetProbeOptions"></a>
+### HttpGetProbeOptions <a name="cdk8s_plus_22.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.HttpGetProbeOptions(
+cdk8s_plus_22.HttpGetProbeOptions(
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
   period_seconds: Duration = None,
@@ -3775,7 +3917,7 @@ cdk8s_plus_21.HttpGetProbeOptions(
 )
 ```
 
-##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.failure_threshold"></a>
+##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.failure_threshold"></a>
 
 ```python
 failure_threshold: typing.Union[int, float]
@@ -3790,7 +3932,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.initial_delay_seconds"></a>
+##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.initial_delay_seconds"></a>
 
 ```python
 initial_delay_seconds: Duration
@@ -3805,7 +3947,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.period_seconds"></a>
+##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.period_seconds"></a>
 
 ```python
 period_seconds: Duration
@@ -3820,7 +3962,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.success_threshold"></a>
+##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.success_threshold"></a>
 
 ```python
 success_threshold: typing.Union[int, float]
@@ -3835,7 +3977,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.timeout_seconds"></a>
+##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.timeout_seconds"></a>
 
 ```python
 timeout_seconds: Duration
@@ -3852,7 +3994,7 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -3865,24 +4007,24 @@ The TCP port to use when sending the GET request.
 
 ---
 
-### IngressV1Beta1Props <a name="cdk8s_plus_21.IngressV1Beta1Props"></a>
+### IngressProps <a name="cdk8s_plus_22.IngressProps"></a>
 
 Properties for `Ingress`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.IngressV1Beta1Props(
+cdk8s_plus_22.IngressProps(
   metadata: ApiObjectMetadata = None,
-  default_backend: IngressV1Beta1Backend = None,
-  rules: typing.List[IngressV1Beta1Rule] = None,
-  tls: typing.List[IngressV1Beta1Tls] = None
+  default_backend: IngressBackend = None,
+  rules: typing.List[IngressRule] = None,
+  tls: typing.List[IngressTls] = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -3894,13 +4036,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `default_backend`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.property.default_backend"></a>
+##### `default_backend`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.property.default_backend"></a>
 
 ```python
-default_backend: IngressV1Beta1Backend
+default_backend: IngressBackend
 ```
 
-- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
 
 The default backend services requests that do not match any rule.
 
@@ -3909,13 +4051,13 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.property.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.property.rules"></a>
 
 ```python
-rules: typing.List[IngressV1Beta1Rule]
+rules: typing.List[IngressRule]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Rule`](#cdk8s_plus_21.IngressV1Beta1Rule)]
+- *Type:* typing.List[[`cdk8s_plus_22.IngressRule`](#cdk8s_plus_22.IngressRule)]
 
 Routing rules for this ingress.
 
@@ -3928,13 +4070,13 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.property.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.property.tls"></a>
 
 ```python
-tls: typing.List[IngressV1Beta1Tls]
+tls: typing.List[IngressTls]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Tls`](#cdk8s_plus_21.IngressV1Beta1Tls)]
+- *Type:* typing.List[[`cdk8s_plus_22.IngressTls`](#cdk8s_plus_22.IngressTls)]
 
 TLS settings for this ingress.
 
@@ -3946,7 +4088,7 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 ---
 
-### IngressV1Beta1Rule <a name="cdk8s_plus_21.IngressV1Beta1Rule"></a>
+### IngressRule <a name="cdk8s_plus_22.IngressRule"></a>
 
 Represents the rules mapping the paths under a specified host to the related backend services.
 
@@ -3956,28 +4098,29 @@ then routed to the backend associated with the matching path.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.IngressV1Beta1Rule(
-  backend: IngressV1Beta1Backend,
+cdk8s_plus_22.IngressRule(
+  backend: IngressBackend,
   host: str = None,
-  path: str = None
+  path: str = None,
+  path_type: HttpIngressPathType = None
 )
 ```
 
-##### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.property.backend"></a>
+##### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.IngressRule.property.backend"></a>
 
 ```python
-backend: IngressV1Beta1Backend
+backend: IngressBackend
 ```
 
-- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
 
 Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ---
 
-##### `host`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.property.host"></a>
+##### `host`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.property.host"></a>
 
 ```python
 host: str
@@ -3999,7 +4142,7 @@ host before the IngressRuleValue.
 
 ---
 
-##### `path`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.property.path"></a>
+##### `path`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.property.path"></a>
 
 ```python
 path: str
@@ -4013,22 +4156,39 @@ Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows
 
 ---
 
-### IngressV1Beta1Tls <a name="cdk8s_plus_21.IngressV1Beta1Tls"></a>
+##### `path_type`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.property.path_type"></a>
+
+```python
+path_type: HttpIngressPathType
+```
+
+- *Type:* [`cdk8s_plus_22.HttpIngressPathType`](#cdk8s_plus_22.HttpIngressPathType)
+
+Specify how the path is matched against request paths.
+
+By default, path
+types will be matched by prefix.
+
+> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+
+---
+
+### IngressTls <a name="cdk8s_plus_22.IngressTls"></a>
 
 Represents the TLS configuration mapping that is passed to the ingress controller for SSL termination.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.IngressV1Beta1Tls(
+cdk8s_plus_22.IngressTls(
   hosts: typing.List[str] = None,
   secret: ISecret = None
 )
 ```
 
-##### `hosts`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Tls.property.hosts"></a>
+##### `hosts`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressTls.property.hosts"></a>
 
 ```python
 hosts: typing.List[str]
@@ -4045,13 +4205,13 @@ this list must match the name/s used in the TLS Secret.
 
 ---
 
-##### `secret`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Tls.property.secret"></a>
+##### `secret`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressTls.property.secret"></a>
 
 ```python
 secret: ISecret
 ```
 
-- *Type:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
+- *Type:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
 - *Default:* If unspecified, it allows SSL routing based on SNI hostname.
 
 Secret is the secret that contains the certificate and key used to terminate SSL traffic on 443.
@@ -4062,16 +4222,16 @@ termination and value of the Host header is used for routing.
 
 ---
 
-### JobProps <a name="cdk8s_plus_21.JobProps"></a>
+### JobProps <a name="cdk8s_plus_22.JobProps"></a>
 
 Properties for initialization of `Job`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.JobProps(
+cdk8s_plus_22.JobProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -4084,7 +4244,7 @@ cdk8s_plus_21.JobProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4096,13 +4256,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4114,13 +4274,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4129,13 +4289,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4151,13 +4311,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4168,7 +4328,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadata
@@ -4180,7 +4340,7 @@ The pod metadata.
 
 ---
 
-##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.active_deadline"></a>
+##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.active_deadline"></a>
 
 ```python
 active_deadline: Duration
@@ -4193,7 +4353,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.backoff_limit"></a>
+##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.backoff_limit"></a>
 
 ```python
 backoff_limit: typing.Union[int, float]
@@ -4206,7 +4366,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.ttl_after_finished"></a>
+##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.ttl_after_finished"></a>
 
 ```python
 ttl_after_finished: Duration
@@ -4226,16 +4386,16 @@ field is alpha-level and is only honored by servers that enable the
 
 ---
 
-### MountOptions <a name="cdk8s_plus_21.MountOptions"></a>
+### MountOptions <a name="cdk8s_plus_22.MountOptions"></a>
 
 Options for mounts.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.MountOptions(
+cdk8s_plus_22.MountOptions(
   propagation: MountPropagation = None,
   read_only: bool = None,
   sub_path: str = None,
@@ -4243,13 +4403,13 @@ cdk8s_plus_21.MountOptions(
 )
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.propagation"></a>
 
 ```python
 propagation: MountPropagation
 ```
 
-- *Type:* [`cdk8s_plus_21.MountPropagation`](#cdk8s_plus_21.MountPropagation)
+- *Type:* [`cdk8s_plus_22.MountPropagation`](#cdk8s_plus_22.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -4263,7 +4423,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.read_only"></a>
+##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.read_only"></a>
 
 ```python
 read_only: bool
@@ -4278,7 +4438,7 @@ Defaults to false.
 
 ---
 
-##### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.sub_path"></a>
+##### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.sub_path"></a>
 
 ```python
 sub_path: str
@@ -4291,7 +4451,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.sub_path_expr"></a>
+##### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.sub_path_expr"></a>
 
 ```python
 sub_path_expr: str
@@ -4312,22 +4472,22 @@ is beta in 1.15.
 
 ---
 
-### PathMapping <a name="cdk8s_plus_21.PathMapping"></a>
+### PathMapping <a name="cdk8s_plus_22.PathMapping"></a>
 
 Maps a string key to a path within a volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.PathMapping(
+cdk8s_plus_22.PathMapping(
   path: str,
   mode: typing.Union[int, float] = None
 )
 ```
 
-##### `path`<sup>Required</sup> <a name="cdk8s_plus_21.PathMapping.property.path"></a>
+##### `path`<sup>Required</sup> <a name="cdk8s_plus_22.PathMapping.property.path"></a>
 
 ```python
 path: str
@@ -4343,7 +4503,7 @@ path. May not contain the path element '..'. May not start with the string
 
 ---
 
-##### `mode`<sup>Optional</sup> <a name="cdk8s_plus_21.PathMapping.property.mode"></a>
+##### `mode`<sup>Optional</sup> <a name="cdk8s_plus_22.PathMapping.property.mode"></a>
 
 ```python
 mode: typing.Union[int, float]
@@ -4359,16 +4519,16 @@ the result can be other mode bits set.
 
 ---
 
-### PodProps <a name="cdk8s_plus_21.PodProps"></a>
+### PodProps <a name="cdk8s_plus_22.PodProps"></a>
 
 Properties for initialization of `Pod`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.PodProps(
+cdk8s_plus_22.PodProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -4377,7 +4537,7 @@ cdk8s_plus_21.PodProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4389,13 +4549,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4407,13 +4567,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4422,13 +4582,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4444,13 +4604,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4461,16 +4621,16 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodSpecProps <a name="cdk8s_plus_21.PodSpecProps"></a>
+### PodSpecProps <a name="cdk8s_plus_22.PodSpecProps"></a>
 
 Properties of a `PodSpec`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.PodSpecProps(
+cdk8s_plus_22.PodSpecProps(
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
@@ -4478,13 +4638,13 @@ cdk8s_plus_21.PodSpecProps(
 )
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4496,13 +4656,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4511,13 +4671,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4533,13 +4693,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4550,7 +4710,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodTemplateProps <a name="cdk8s_plus_21.PodTemplateProps"></a>
+### PodTemplateProps <a name="cdk8s_plus_22.PodTemplateProps"></a>
 
 Properties of a `PodTemplate`.
 
@@ -4559,9 +4719,9 @@ Adds metadata information on top of the spec.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.PodTemplateProps(
+cdk8s_plus_22.PodTemplateProps(
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
@@ -4570,13 +4730,13 @@ cdk8s_plus_21.PodTemplateProps(
 )
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4588,13 +4748,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4603,13 +4763,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4625,13 +4785,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4642,7 +4802,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadata
@@ -4654,16 +4814,16 @@ The pod metadata.
 
 ---
 
-### ProbeOptions <a name="cdk8s_plus_21.ProbeOptions"></a>
+### ProbeOptions <a name="cdk8s_plus_22.ProbeOptions"></a>
 
 Probe options.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ProbeOptions(
+cdk8s_plus_22.ProbeOptions(
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
   period_seconds: Duration = None,
@@ -4672,7 +4832,7 @@ cdk8s_plus_21.ProbeOptions(
 )
 ```
 
-##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.failure_threshold"></a>
+##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.failure_threshold"></a>
 
 ```python
 failure_threshold: typing.Union[int, float]
@@ -4687,7 +4847,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.initial_delay_seconds"></a>
+##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.initial_delay_seconds"></a>
 
 ```python
 initial_delay_seconds: Duration
@@ -4702,7 +4862,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.period_seconds"></a>
+##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.period_seconds"></a>
 
 ```python
 period_seconds: Duration
@@ -4717,7 +4877,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.success_threshold"></a>
+##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.success_threshold"></a>
 
 ```python
 success_threshold: typing.Union[int, float]
@@ -4732,7 +4892,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.timeout_seconds"></a>
+##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.timeout_seconds"></a>
 
 ```python
 timeout_seconds: Duration
@@ -4749,21 +4909,21 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ResourceProps <a name="cdk8s_plus_21.ResourceProps"></a>
+### ResourceProps <a name="cdk8s_plus_22.ResourceProps"></a>
 
 Initialization properties for resources.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ResourceProps(
+cdk8s_plus_22.ResourceProps(
   metadata: ApiObjectMetadata = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ResourceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ResourceProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4775,21 +4935,21 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-### SecretProps <a name="cdk8s_plus_21.SecretProps"></a>
+### SecretProps <a name="cdk8s_plus_22.SecretProps"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.SecretProps(
+cdk8s_plus_22.SecretProps(
   metadata: ApiObjectMetadata = None,
   string_data: typing.Mapping[str] = None,
   type: str = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4801,7 +4961,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.string_data"></a>
+##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.string_data"></a>
 
 ```python
 string_data: typing.Mapping[str]
@@ -4818,7 +4978,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.type"></a>
 
 ```python
 type: str
@@ -4834,22 +4994,22 @@ handling of secret data by various controllers.
 
 ---
 
-### SecretValue <a name="cdk8s_plus_21.SecretValue"></a>
+### SecretValue <a name="cdk8s_plus_22.SecretValue"></a>
 
 Represents a specific value in JSON secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.SecretValue(
+cdk8s_plus_22.SecretValue(
   key: str,
   secret: ISecret
 )
 ```
 
-##### `key`<sup>Required</sup> <a name="cdk8s_plus_21.SecretValue.property.key"></a>
+##### `key`<sup>Required</sup> <a name="cdk8s_plus_22.SecretValue.property.key"></a>
 
 ```python
 key: str
@@ -4861,19 +5021,19 @@ The JSON key.
 
 ---
 
-##### `secret`<sup>Required</sup> <a name="cdk8s_plus_21.SecretValue.property.secret"></a>
+##### `secret`<sup>Required</sup> <a name="cdk8s_plus_22.SecretValue.property.secret"></a>
 
 ```python
 secret: ISecret
 ```
 
-- *Type:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
+- *Type:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
 
 The secret.
 
 ---
 
-### ServiceAccountProps <a name="cdk8s_plus_21.ServiceAccountProps"></a>
+### ServiceAccountProps <a name="cdk8s_plus_22.ServiceAccountProps"></a>
 
 Properties for initialization of `ServiceAccount`.
 
@@ -4882,15 +5042,15 @@ Properties for initialization of `ServiceAccount`.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ServiceAccountProps(
+cdk8s_plus_22.ServiceAccountProps(
   metadata: ApiObjectMetadata = None,
   secrets: typing.List[ISecret] = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4902,13 +5062,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountProps.property.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountProps.property.secrets"></a>
 
 ```python
 secrets: typing.List[ISecret]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)]
+- *Type:* typing.List[[`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)]
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -4916,21 +5076,21 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 ---
 
-### ServiceIngressV1BetaBackendOptions <a name="cdk8s_plus_21.ServiceIngressV1BetaBackendOptions"></a>
+### ServiceIngressBackendOptions <a name="cdk8s_plus_22.ServiceIngressBackendOptions"></a>
 
 Options for setting up backends for ingress rules.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ServiceIngressV1BetaBackendOptions(
+cdk8s_plus_22.ServiceIngressBackendOptions(
   port: typing.Union[int, float] = None
 )
 ```
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceIngressV1BetaBackendOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceIngressBackendOptions.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -4948,16 +5108,16 @@ This option will fail if the service does not expose any ports.
 
 ---
 
-### ServicePort <a name="cdk8s_plus_21.ServicePort"></a>
+### ServicePort <a name="cdk8s_plus_22.ServicePort"></a>
 
 Definition of a service port.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ServicePort(
+cdk8s_plus_22.ServicePort(
   name: str = None,
   node_port: typing.Union[int, float] = None,
   protocol: Protocol = None,
@@ -4966,7 +5126,7 @@ cdk8s_plus_21.ServicePort(
 )
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePort.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePort.property.name"></a>
 
 ```python
 name: str
@@ -4983,15 +5143,14 @@ on this service.
 
 ---
 
-##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePort.property.node_port"></a>
+##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePort.property.node_port"></a>
 
 ```python
 node_port: typing.Union[int, float]
 ```
 
 - *Type:* `typing.Union[int, float]`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -5004,13 +5163,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePort.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePort.property.protocol"></a>
 
 ```python
 protocol: Protocol
 ```
 
-- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
+- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -5019,7 +5178,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePort.property.target_port"></a>
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePort.property.target_port"></a>
 
 ```python
 target_port: typing.Union[int, float]
@@ -5032,7 +5191,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Required</sup> <a name="cdk8s_plus_21.ServicePort.property.port"></a>
+##### `port`<sup>Required</sup> <a name="cdk8s_plus_22.ServicePort.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -5044,14 +5203,14 @@ The port number the service will bind to.
 
 ---
 
-### ServicePortOptions <a name="cdk8s_plus_21.ServicePortOptions"></a>
+### ServicePortOptions <a name="cdk8s_plus_22.ServicePortOptions"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ServicePortOptions(
+cdk8s_plus_22.ServicePortOptions(
   name: str = None,
   node_port: typing.Union[int, float] = None,
   protocol: Protocol = None,
@@ -5059,7 +5218,7 @@ cdk8s_plus_21.ServicePortOptions(
 )
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.property.name"></a>
 
 ```python
 name: str
@@ -5076,15 +5235,14 @@ on this service.
 
 ---
 
-##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.property.node_port"></a>
+##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.property.node_port"></a>
 
 ```python
 node_port: typing.Union[int, float]
 ```
 
 - *Type:* `typing.Union[int, float]`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -5097,13 +5255,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.property.protocol"></a>
 
 ```python
 protocol: Protocol
 ```
 
-- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
+- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -5112,7 +5270,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.property.target_port"></a>
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.property.target_port"></a>
 
 ```python
 target_port: typing.Union[int, float]
@@ -5125,16 +5283,16 @@ The port number the service will redirect to.
 
 ---
 
-### ServiceProps <a name="cdk8s_plus_21.ServiceProps"></a>
+### ServiceProps <a name="cdk8s_plus_22.ServiceProps"></a>
 
 Properties for initialization of `Service`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.ServiceProps(
+cdk8s_plus_22.ServiceProps(
   metadata: ApiObjectMetadata = None,
   cluster_i_p: str = None,
   external_i_ps: typing.List[str] = None,
@@ -5145,7 +5303,7 @@ cdk8s_plus_21.ServiceProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -5157,7 +5315,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.cluster_i_p"></a>
+##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.cluster_i_p"></a>
 
 ```python
 cluster_i_p: str
@@ -5179,7 +5337,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `external_i_ps`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.external_i_ps"></a>
+##### `external_i_ps`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.external_i_ps"></a>
 
 ```python
 external_i_ps: typing.List[str]
@@ -5197,7 +5355,7 @@ Kubernetes system.
 
 ---
 
-##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.external_name"></a>
+##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.external_name"></a>
 
 ```python
 external_name: str
@@ -5210,7 +5368,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `load_balancer_source_ranges`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.load_balancer_source_ranges"></a>
+##### `load_balancer_source_ranges`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.load_balancer_source_ranges"></a>
 
 ```python
 load_balancer_source_ranges: typing.List[str]
@@ -5224,13 +5382,13 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.ports"></a>
 
 ```python
 ports: typing.List[ServicePort]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ServicePort`](#cdk8s_plus_21.ServicePort)]
+- *Type:* typing.List[[`cdk8s_plus_22.ServicePort`](#cdk8s_plus_22.ServicePort)]
 
 The port exposed by this service.
 
@@ -5238,13 +5396,13 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.type"></a>
 
 ```python
 type: ServiceType
 ```
 
-- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
+- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -5253,16 +5411,16 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 ---
 
-### StatefulSetProps <a name="cdk8s_plus_21.StatefulSetProps"></a>
+### StatefulSetProps <a name="cdk8s_plus_22.StatefulSetProps"></a>
 
 Properties for initialization of `StatefulSet`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.StatefulSetProps(
+cdk8s_plus_22.StatefulSetProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -5276,7 +5434,7 @@ cdk8s_plus_21.StatefulSetProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -5288,13 +5446,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -5306,13 +5464,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -5321,13 +5479,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -5343,13 +5501,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -5360,7 +5518,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadata
@@ -5372,19 +5530,19 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.service"></a>
+##### `service`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.service"></a>
 
 ```python
 service: Service
 ```
 
-- *Type:* [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service)
+- *Type:* [`cdk8s_plus_22.Service`](#cdk8s_plus_22.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.default_selector"></a>
+##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.default_selector"></a>
 
 ```python
 default_selector: bool
@@ -5400,20 +5558,20 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `pod_management_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.pod_management_policy"></a>
+##### `pod_management_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.pod_management_policy"></a>
 
 ```python
 pod_management_policy: PodManagementPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.PodManagementPolicy`](#cdk8s_plus_21.PodManagementPolicy)
+- *Type:* [`cdk8s_plus_22.PodManagementPolicy`](#cdk8s_plus_22.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.replicas"></a>
 
 ```python
 replicas: typing.Union[int, float]
@@ -5426,16 +5584,16 @@ Number of desired pods.
 
 ---
 
-### VolumeMount <a name="cdk8s_plus_21.VolumeMount"></a>
+### VolumeMount <a name="cdk8s_plus_22.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.VolumeMount(
+cdk8s_plus_22.VolumeMount(
   propagation: MountPropagation = None,
   read_only: bool = None,
   sub_path: str = None,
@@ -5445,13 +5603,13 @@ cdk8s_plus_21.VolumeMount(
 )
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.propagation"></a>
 
 ```python
 propagation: MountPropagation
 ```
 
-- *Type:* [`cdk8s_plus_21.MountPropagation`](#cdk8s_plus_21.MountPropagation)
+- *Type:* [`cdk8s_plus_22.MountPropagation`](#cdk8s_plus_22.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -5465,7 +5623,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.read_only"></a>
+##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.read_only"></a>
 
 ```python
 read_only: bool
@@ -5480,7 +5638,7 @@ Defaults to false.
 
 ---
 
-##### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.sub_path"></a>
+##### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.sub_path"></a>
 
 ```python
 sub_path: str
@@ -5493,7 +5651,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.sub_path_expr"></a>
+##### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.sub_path_expr"></a>
 
 ```python
 sub_path_expr: str
@@ -5514,7 +5672,7 @@ is beta in 1.15.
 
 ---
 
-##### `path`<sup>Required</sup> <a name="cdk8s_plus_21.VolumeMount.property.path"></a>
+##### `path`<sup>Required</sup> <a name="cdk8s_plus_22.VolumeMount.property.path"></a>
 
 ```python
 path: str
@@ -5529,13 +5687,13 @@ contain ':'.
 
 ---
 
-##### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.VolumeMount.property.volume"></a>
+##### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.VolumeMount.property.volume"></a>
 
 ```python
 volume: Volume
 ```
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
 
 The volume to mount.
 
@@ -5543,16 +5701,16 @@ The volume to mount.
 
 ## Classes <a name="Classes"></a>
 
-### Container <a name="cdk8s_plus_21.Container"></a>
+### Container <a name="cdk8s_plus_22.Container"></a>
 
 A single application container that you want to run within a pod.
 
-#### Initializers <a name="cdk8s_plus_21.Container.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Container.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Container(
+cdk8s_plus_22.Container(
   image: str,
   args: typing.List[str] = None,
   command: typing.List[str] = None,
@@ -5568,7 +5726,7 @@ cdk8s_plus_21.Container(
 )
 ```
 
-##### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -5576,7 +5734,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -5595,7 +5753,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -5609,9 +5767,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
+##### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -5620,18 +5778,18 @@ Cannot be updated.
 
 ---
 
-##### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
+##### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -5640,7 +5798,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -5651,7 +5809,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -5662,18 +5820,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -5682,9 +5840,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
+##### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -5692,7 +5850,7 @@ Cannot be updated.
 
 ---
 
-##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
+##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -5705,7 +5863,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 #### Methods <a name="Methods"></a>
 
-##### `add_env` <a name="cdk8s_plus_21.Container.add_env"></a>
+##### `add_env` <a name="cdk8s_plus_22.Container.add_env"></a>
 
 ```python
 def add_env(
@@ -5714,7 +5872,7 @@ def add_env(
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Container.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -5722,15 +5880,15 @@ The variable name.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.Container.parameter.value"></a>
 
-- *Type:* [`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)
+- *Type:* [`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)
 
 The variable value.
 
 ---
 
-##### `mount` <a name="cdk8s_plus_21.Container.mount"></a>
+##### `mount` <a name="cdk8s_plus_22.Container.mount"></a>
 
 ```python
 def mount(
@@ -5743,7 +5901,7 @@ def mount(
 )
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_22.Container.parameter.path"></a>
 
 - *Type:* `str`
 
@@ -5751,17 +5909,17 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.Container.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
 
 The volume to mount.
 
 ---
 
-###### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.propagation"></a>
+###### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.propagation"></a>
 
-- *Type:* [`cdk8s_plus_21.MountPropagation`](#cdk8s_plus_21.MountPropagation)
+- *Type:* [`cdk8s_plus_22.MountPropagation`](#cdk8s_plus_22.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -5775,7 +5933,7 @@ This field is beta in 1.10.
 
 ---
 
-###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.read_only"></a>
+###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.read_only"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -5786,7 +5944,7 @@ Defaults to false.
 
 ---
 
-###### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.sub_path"></a>
+###### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.sub_path"></a>
 
 - *Type:* `str`
 - *Default:* "" the volume's root
@@ -5795,7 +5953,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-###### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.sub_path_expr"></a>
+###### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.sub_path_expr"></a>
 
 - *Type:* `str`
 - *Default:* "" volume's root.
@@ -5815,13 +5973,13 @@ is beta in 1.15.
 
 #### Properties <a name="Properties"></a>
 
-##### `env`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.env"></a>
+##### `env`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.env"></a>
 
 ```python
 env: typing.Mapping[EnvValue]
 ```
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 
 The environment variables for this container.
 
@@ -5829,7 +5987,7 @@ Returns a copy. To add environment variables use `addEnv()`.
 
 ---
 
-##### `image`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.image"></a>
 
 ```python
 image: str
@@ -5841,31 +5999,31 @@ The container image.
 
 ---
 
-##### `image_pull_policy`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.image_pull_policy"></a>
+##### `image_pull_policy`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.image_pull_policy"></a>
 
 ```python
 image_pull_policy: ImagePullPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 
 Image pull policy for this container.
 
 ---
 
-##### `mounts`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.mounts"></a>
+##### `mounts`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.mounts"></a>
 
 ```python
 mounts: typing.List[VolumeMount]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Volume mounts configured for this container.
 
 ---
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.name"></a>
 
 ```python
 name: str
@@ -5877,7 +6035,7 @@ The name of the container.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.Container.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.Container.property.args"></a>
 
 ```python
 args: typing.List[str]
@@ -5889,7 +6047,7 @@ Arguments to the entrypoint.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.Container.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.Container.property.command"></a>
 
 ```python
 command: typing.List[str]
@@ -5901,7 +6059,7 @@ Entrypoint array (the command to execute when the container starts).
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.Container.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.Container.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -5913,7 +6071,7 @@ The port this container exposes.
 
 ---
 
-##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.Container.property.working_dir"></a>
+##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.Container.property.working_dir"></a>
 
 ```python
 working_dir: str
@@ -5926,34 +6084,34 @@ The working directory inside the container.
 ---
 
 
-### EnvValue <a name="cdk8s_plus_21.EnvValue"></a>
+### EnvValue <a name="cdk8s_plus_22.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_config_map` <a name="cdk8s_plus_21.EnvValue.from_config_map"></a>
+##### `from_config_map` <a name="cdk8s_plus_22.EnvValue.from_config_map"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.EnvValue.from_config_map(
+cdk8s_plus_22.EnvValue.from_config_map(
   config_map: IConfigMap,
   key: str,
   optional: bool = None
 )
 ```
 
-###### `config_map`<sup>Required</sup> <a name="cdk8s_plus_21.EnvValue.parameter.config_map"></a>
+###### `config_map`<sup>Required</sup> <a name="cdk8s_plus_22.EnvValue.parameter.config_map"></a>
 
-- *Type:* [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
+- *Type:* [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap)
 
 The config map.
 
 ---
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.EnvValue.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -5961,7 +6119,7 @@ The key to extract the value from.
 
 ---
 
-###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromConfigMapOptions.parameter.optional"></a>
+###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromConfigMapOptions.parameter.optional"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -5970,18 +6128,18 @@ Specify whether the ConfigMap or its key must be defined.
 
 ---
 
-##### `from_process` <a name="cdk8s_plus_21.EnvValue.from_process"></a>
+##### `from_process` <a name="cdk8s_plus_22.EnvValue.from_process"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.EnvValue.from_process(
+cdk8s_plus_22.EnvValue.from_process(
   key: str,
   required: bool = None
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.EnvValue.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -5989,7 +6147,7 @@ The key to read.
 
 ---
 
-###### `required`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromProcessOptions.parameter.required"></a>
+###### `required`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromProcessOptions.parameter.required"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -6000,19 +6158,19 @@ If this is set to true, and the key does not exist, an error will thrown.
 
 ---
 
-##### `from_secret_value` <a name="cdk8s_plus_21.EnvValue.from_secret_value"></a>
+##### `from_secret_value` <a name="cdk8s_plus_22.EnvValue.from_secret_value"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.EnvValue.from_secret_value(
+cdk8s_plus_22.EnvValue.from_secret_value(
   key: str,
   secret: ISecret,
   optional: bool = None
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.SecretValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.SecretValue.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -6020,15 +6178,15 @@ The JSON key.
 
 ---
 
-###### `secret`<sup>Required</sup> <a name="cdk8s_plus_21.SecretValue.parameter.secret"></a>
+###### `secret`<sup>Required</sup> <a name="cdk8s_plus_22.SecretValue.parameter.secret"></a>
 
-- *Type:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
+- *Type:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
 
 The secret.
 
 ---
 
-###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromSecretOptions.parameter.optional"></a>
+###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromSecretOptions.parameter.optional"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -6037,17 +6195,17 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-##### `from_value` <a name="cdk8s_plus_21.EnvValue.from_value"></a>
+##### `from_value` <a name="cdk8s_plus_22.EnvValue.from_value"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.EnvValue.from_value(
+cdk8s_plus_22.EnvValue.from_value(
   value: str
 )
 ```
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.EnvValue.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.EnvValue.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -6057,7 +6215,7 @@ The value.
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValue.property.value"></a>
+##### `value`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValue.property.value"></a>
 
 ```python
 value: typing.Any
@@ -6067,7 +6225,7 @@ value: typing.Any
 
 ---
 
-##### `value_from`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValue.property.value_from"></a>
+##### `value_from`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValue.property.value_from"></a>
 
 ```python
 value_from: typing.Any
@@ -6078,33 +6236,33 @@ value_from: typing.Any
 ---
 
 
-### IngressV1Beta1Backend <a name="cdk8s_plus_21.IngressV1Beta1Backend"></a>
+### IngressBackend <a name="cdk8s_plus_22.IngressBackend"></a>
 
 The backend for an ingress path.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_service` <a name="cdk8s_plus_21.IngressV1Beta1Backend.from_service"></a>
+##### `from_service` <a name="cdk8s_plus_22.IngressBackend.from_service"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.IngressV1Beta1Backend.from_service(
+cdk8s_plus_22.IngressBackend.from_service(
   service: Service,
   port: typing.Union[int, float] = None
 )
 ```
 
-###### `service`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1Backend.parameter.service"></a>
+###### `service`<sup>Required</sup> <a name="cdk8s_plus_22.IngressBackend.parameter.service"></a>
 
-- *Type:* [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service)
+- *Type:* [`cdk8s_plus_22.Service`](#cdk8s_plus_22.Service)
 
 The service object.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceIngressV1BetaBackendOptions.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceIngressBackendOptions.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* if the service exposes a single port, this port will be used.
@@ -6120,18 +6278,18 @@ This option will fail if the service does not expose any ports.
 
 
 
-### PodSpec <a name="cdk8s_plus_21.PodSpec"></a>
+### PodSpec <a name="cdk8s_plus_22.PodSpec"></a>
 
-- *Implements:* [`cdk8s_plus_21.IPodSpec`](#cdk8s_plus_21.IPodSpec)
+- *Implements:* [`cdk8s_plus_22.IPodSpec`](#cdk8s_plus_22.IPodSpec)
 
 Provides read/write capabilities ontop of a `PodSpecProps`.
 
-#### Initializers <a name="cdk8s_plus_21.PodSpec.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.PodSpec.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.PodSpec(
+cdk8s_plus_22.PodSpec(
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
@@ -6139,9 +6297,9 @@ cdk8s_plus_21.PodSpec(
 )
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -6153,9 +6311,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -6164,9 +6322,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -6182,9 +6340,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -6197,7 +6355,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_21.PodSpec.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_22.PodSpec.add_container"></a>
 
 ```python
 def add_container(
@@ -6216,7 +6374,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -6224,7 +6382,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -6243,7 +6401,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -6257,9 +6415,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -6268,18 +6426,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -6288,7 +6446,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -6299,7 +6457,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -6310,18 +6468,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -6330,9 +6488,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -6340,7 +6498,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -6351,7 +6509,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_21.PodSpec.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_22.PodSpec.add_volume"></a>
 
 ```python
 def add_volume(
@@ -6359,22 +6517,22 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.PodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.PodSpec.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.PodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.PodSpec.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
+- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
 
 The containers belonging to the pod.
 
@@ -6382,13 +6540,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.PodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.PodSpec.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 
 The volumes associated with this pod.
 
@@ -6396,43 +6554,43 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpec.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpec.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpec.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpec.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### PodTemplate <a name="cdk8s_plus_21.PodTemplate"></a>
+### PodTemplate <a name="cdk8s_plus_22.PodTemplate"></a>
 
-- *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
+- *Implements:* [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
 
 Provides read/write capabilities ontop of a `PodTemplateProps`.
 
-#### Initializers <a name="cdk8s_plus_21.PodTemplate.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.PodTemplate.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.PodTemplate(
+cdk8s_plus_22.PodTemplate(
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
@@ -6441,9 +6599,9 @@ cdk8s_plus_21.PodTemplate(
 )
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -6455,9 +6613,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -6466,9 +6624,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -6484,9 +6642,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -6497,7 +6655,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.pod_metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -6509,7 +6667,7 @@ The pod metadata.
 
 #### Properties <a name="Properties"></a>
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.PodTemplate.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.PodTemplate.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -6522,27 +6680,27 @@ Provides read/write access to the underlying pod metadata of the resource.
 ---
 
 
-### Probe <a name="cdk8s_plus_21.Probe"></a>
+### Probe <a name="cdk8s_plus_22.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 
-#### Initializers <a name="cdk8s_plus_21.Probe.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Probe.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Probe()
+cdk8s_plus_22.Probe()
 ```
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_command` <a name="cdk8s_plus_21.Probe.from_command"></a>
+##### `from_command` <a name="cdk8s_plus_22.Probe.from_command"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Probe.from_command(
+cdk8s_plus_22.Probe.from_command(
   command: typing.List[str],
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
@@ -6552,7 +6710,7 @@ cdk8s_plus_21.Probe.from_command(
 )
 ```
 
-###### `command`<sup>Required</sup> <a name="cdk8s_plus_21.Probe.parameter.command"></a>
+###### `command`<sup>Required</sup> <a name="cdk8s_plus_22.Probe.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 
@@ -6560,7 +6718,7 @@ The command to execute.
 
 ---
 
-###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.failure_threshold"></a>
+###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.failure_threshold"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 3
@@ -6571,7 +6729,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.initial_delay_seconds"></a>
+###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.initial_delay_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* immediate
@@ -6582,7 +6740,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.period_seconds"></a>
+###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.period_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* Duration.seconds(10) Minimum value is 1.
@@ -6593,7 +6751,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.success_threshold"></a>
+###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.success_threshold"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 1 Must be 1 for liveness and startup. Minimum value is 1.
@@ -6604,7 +6762,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.timeout_seconds"></a>
+###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.timeout_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* Duration.seconds(1)
@@ -6617,12 +6775,12 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-##### `from_http_get` <a name="cdk8s_plus_21.Probe.from_http_get"></a>
+##### `from_http_get` <a name="cdk8s_plus_22.Probe.from_http_get"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Probe.from_http_get(
+cdk8s_plus_22.Probe.from_http_get(
   path: str,
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
@@ -6633,7 +6791,7 @@ cdk8s_plus_21.Probe.from_http_get(
 )
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s_plus_21.Probe.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_22.Probe.parameter.path"></a>
 
 - *Type:* `str`
 
@@ -6641,7 +6799,7 @@ The URL path to hit.
 
 ---
 
-###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.failure_threshold"></a>
+###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.failure_threshold"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 3
@@ -6652,7 +6810,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.initial_delay_seconds"></a>
+###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.initial_delay_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* immediate
@@ -6663,7 +6821,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.period_seconds"></a>
+###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.period_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* Duration.seconds(10) Minimum value is 1.
@@ -6674,7 +6832,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.success_threshold"></a>
+###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.success_threshold"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 1 Must be 1 for liveness and startup. Minimum value is 1.
@@ -6685,7 +6843,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.timeout_seconds"></a>
+###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.timeout_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* Duration.seconds(1)
@@ -6698,7 +6856,7 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* defaults to `container.port`.
@@ -6709,7 +6867,7 @@ The TCP port to use when sending the GET request.
 
 
 
-### Volume <a name="cdk8s_plus_21.Volume"></a>
+### Volume <a name="cdk8s_plus_22.Volume"></a>
 
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
@@ -6742,24 +6900,24 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
-#### Initializers <a name="cdk8s_plus_21.Volume.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_22.Volume.Initializer"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Volume(
+cdk8s_plus_22.Volume(
   name: str,
   config: typing.Any
 )
 ```
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.parameter.name"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `config`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.config"></a>
+##### `config`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.parameter.config"></a>
 
 - *Type:* `typing.Any`
 
@@ -6768,12 +6926,12 @@ cdk8s_plus_21.Volume(
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_config_map` <a name="cdk8s_plus_21.Volume.from_config_map"></a>
+##### `from_config_map` <a name="cdk8s_plus_22.Volume.from_config_map"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Volume.from_config_map(
+cdk8s_plus_22.Volume.from_config_map(
   config_map: IConfigMap,
   default_mode: typing.Union[int, float] = None,
   items: typing.Mapping[PathMapping] = None,
@@ -6782,15 +6940,15 @@ cdk8s_plus_21.Volume.from_config_map(
 )
 ```
 
-###### `config_map`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.config_map"></a>
+###### `config_map`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.parameter.config_map"></a>
 
-- *Type:* [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
+- *Type:* [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap)
 
 The config map to use to populate the volume.
 
 ---
 
-###### `default_mode`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.parameter.default_mode"></a>
+###### `default_mode`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.parameter.default_mode"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 0644. Directories within the path are not affected by this
@@ -6806,9 +6964,9 @@ file mode, like fsGroup, and the result can be other mode bits set.
 
 ---
 
-###### `items`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.parameter.items"></a>
+###### `items`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.parameter.items"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.PathMapping`](#cdk8s_plus_21.PathMapping)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.PathMapping`](#cdk8s_plus_22.PathMapping)]
 - *Default:* no mapping
 
 If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value.
@@ -6821,7 +6979,7 @@ contain the '..' path or start with '..'.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* auto-generated
@@ -6830,7 +6988,7 @@ The volume name.
 
 ---
 
-###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.parameter.optional"></a>
+###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.parameter.optional"></a>
 
 - *Type:* `bool`
 - *Default:* undocumented
@@ -6839,27 +6997,27 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
-##### `from_empty_dir` <a name="cdk8s_plus_21.Volume.from_empty_dir"></a>
+##### `from_empty_dir` <a name="cdk8s_plus_22.Volume.from_empty_dir"></a>
 
 ```python
-import cdk8s_plus_21
+import cdk8s_plus_22
 
-cdk8s_plus_21.Volume.from_empty_dir(
+cdk8s_plus_22.Volume.from_empty_dir(
   name: str,
   medium: EmptyDirMedium = None,
   size_limit: Size = None
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.parameter.name"></a>
 
 - *Type:* `str`
 
 ---
 
-###### `medium`<sup>Optional</sup> <a name="cdk8s_plus_21.EmptyDirVolumeOptions.parameter.medium"></a>
+###### `medium`<sup>Optional</sup> <a name="cdk8s_plus_22.EmptyDirVolumeOptions.parameter.medium"></a>
 
-- *Type:* [`cdk8s_plus_21.EmptyDirMedium`](#cdk8s_plus_21.EmptyDirMedium)
+- *Type:* [`cdk8s_plus_22.EmptyDirMedium`](#cdk8s_plus_22.EmptyDirMedium)
 - *Default:* EmptyDirMedium.DEFAULT
 
 By default, emptyDir volumes are stored on whatever medium is backing the node - that might be disk or SSD or network storage, depending on your environment.
@@ -6872,7 +7030,7 @@ against your Container's memory limit.
 
 ---
 
-###### `size_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.EmptyDirVolumeOptions.parameter.size_limit"></a>
+###### `size_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.EmptyDirVolumeOptions.parameter.size_limit"></a>
 
 - *Type:* [`cdk8s.Size`](#cdk8s.Size)
 - *Default:* limit is undefined
@@ -6888,7 +7046,7 @@ here and the sum of memory limits of all containers in a pod.
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.property.name"></a>
 
 ```python
 name: str
@@ -6901,18 +7059,18 @@ name: str
 
 ## Protocols <a name="Protocols"></a>
 
-### IConfigMap <a name="cdk8s_plus_21.IConfigMap"></a>
+### IConfigMap <a name="cdk8s_plus_22.IConfigMap"></a>
 
-- *Extends:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
+- *Extends:* [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource)
 
-- *Implemented By:* [`cdk8s_plus_21.ConfigMap`](#cdk8s_plus_21.ConfigMap), [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
+- *Implemented By:* [`cdk8s_plus_22.ConfigMap`](#cdk8s_plus_22.ConfigMap), [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap)
 
 Represents a config map.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.IConfigMap.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.IConfigMap.property.name"></a>
 
 ```python
 name: str
@@ -6924,9 +7082,9 @@ The Kubernetes name of this resource.
 
 ---
 
-### IPodSpec <a name="cdk8s_plus_21.IPodSpec"></a>
+### IPodSpec <a name="cdk8s_plus_22.IPodSpec"></a>
 
-- *Implemented By:* [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment), [`cdk8s_plus_21.Job`](#cdk8s_plus_21.Job), [`cdk8s_plus_21.Pod`](#cdk8s_plus_21.Pod), [`cdk8s_plus_21.PodSpec`](#cdk8s_plus_21.PodSpec), [`cdk8s_plus_21.PodTemplate`](#cdk8s_plus_21.PodTemplate), [`cdk8s_plus_21.StatefulSet`](#cdk8s_plus_21.StatefulSet), [`cdk8s_plus_21.IPodSpec`](#cdk8s_plus_21.IPodSpec), [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
+- *Implemented By:* [`cdk8s_plus_22.Deployment`](#cdk8s_plus_22.Deployment), [`cdk8s_plus_22.Job`](#cdk8s_plus_22.Job), [`cdk8s_plus_22.Pod`](#cdk8s_plus_22.Pod), [`cdk8s_plus_22.PodSpec`](#cdk8s_plus_22.PodSpec), [`cdk8s_plus_22.PodTemplate`](#cdk8s_plus_22.PodTemplate), [`cdk8s_plus_22.StatefulSet`](#cdk8s_plus_22.StatefulSet), [`cdk8s_plus_22.IPodSpec`](#cdk8s_plus_22.IPodSpec), [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod spec. (e.g `Deployment`, `Job`, `Pod`, ...).
 
@@ -6934,7 +7092,7 @@ Use the `PodSpec` class as an implementation helper.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_21.IPodSpec.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_22.IPodSpec.add_container"></a>
 
 ```python
 def add_container(
@@ -6953,7 +7111,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -6961,7 +7119,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -6980,7 +7138,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -6994,9 +7152,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -7005,18 +7163,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -7025,7 +7183,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -7036,7 +7194,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -7047,18 +7205,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
+- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -7067,9 +7225,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -7077,7 +7235,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -7088,7 +7246,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_21.IPodSpec.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_22.IPodSpec.add_volume"></a>
 
 ```python
 def add_volume(
@@ -7096,9 +7254,9 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.IPodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.IPodSpec.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
 
 The volume.
 
@@ -7106,13 +7264,13 @@ The volume.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.IPodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.IPodSpec.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
+- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
 
 The containers belonging to the pod.
 
@@ -7120,13 +7278,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.IPodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.IPodSpec.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 
 The volumes associated with this pod.
 
@@ -7134,35 +7292,35 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.IPodSpec.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.IPodSpec.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.IPodSpec.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.IPodSpec.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-### IPodTemplate <a name="cdk8s_plus_21.IPodTemplate"></a>
+### IPodTemplate <a name="cdk8s_plus_22.IPodTemplate"></a>
 
-- *Extends:* [`cdk8s_plus_21.IPodSpec`](#cdk8s_plus_21.IPodSpec)
+- *Extends:* [`cdk8s_plus_22.IPodSpec`](#cdk8s_plus_22.IPodSpec)
 
-- *Implemented By:* [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment), [`cdk8s_plus_21.Job`](#cdk8s_plus_21.Job), [`cdk8s_plus_21.PodTemplate`](#cdk8s_plus_21.PodTemplate), [`cdk8s_plus_21.StatefulSet`](#cdk8s_plus_21.StatefulSet), [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
+- *Implemented By:* [`cdk8s_plus_22.Deployment`](#cdk8s_plus_22.Deployment), [`cdk8s_plus_22.Job`](#cdk8s_plus_22.Job), [`cdk8s_plus_22.PodTemplate`](#cdk8s_plus_22.PodTemplate), [`cdk8s_plus_22.StatefulSet`](#cdk8s_plus_22.StatefulSet), [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod template. (e.g `Deployment`, `Job`, ...).
 
@@ -7171,13 +7329,13 @@ Use the `PodTemplate` class as an implementation helper.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.IPodTemplate.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.IPodTemplate.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
+- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
 
 The containers belonging to the pod.
 
@@ -7185,13 +7343,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.IPodTemplate.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.IPodTemplate.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
 
 The volumes associated with this pod.
 
@@ -7199,31 +7357,31 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.IPodTemplate.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.IPodTemplate.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
+- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.IPodTemplate.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.IPodTemplate.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.IPodTemplate.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.IPodTemplate.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -7235,16 +7393,16 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-### IResource <a name="cdk8s_plus_21.IResource"></a>
+### IResource <a name="cdk8s_plus_22.IResource"></a>
 
-- *Implemented By:* [`cdk8s_plus_21.ConfigMap`](#cdk8s_plus_21.ConfigMap), [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment), [`cdk8s_plus_21.IngressV1Beta1`](#cdk8s_plus_21.IngressV1Beta1), [`cdk8s_plus_21.Job`](#cdk8s_plus_21.Job), [`cdk8s_plus_21.Pod`](#cdk8s_plus_21.Pod), [`cdk8s_plus_21.Resource`](#cdk8s_plus_21.Resource), [`cdk8s_plus_21.Secret`](#cdk8s_plus_21.Secret), [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service), [`cdk8s_plus_21.ServiceAccount`](#cdk8s_plus_21.ServiceAccount), [`cdk8s_plus_21.StatefulSet`](#cdk8s_plus_21.StatefulSet), [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap), [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource), [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret), [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Implemented By:* [`cdk8s_plus_22.ConfigMap`](#cdk8s_plus_22.ConfigMap), [`cdk8s_plus_22.Deployment`](#cdk8s_plus_22.Deployment), [`cdk8s_plus_22.Ingress`](#cdk8s_plus_22.Ingress), [`cdk8s_plus_22.Job`](#cdk8s_plus_22.Job), [`cdk8s_plus_22.Pod`](#cdk8s_plus_22.Pod), [`cdk8s_plus_22.Resource`](#cdk8s_plus_22.Resource), [`cdk8s_plus_22.Secret`](#cdk8s_plus_22.Secret), [`cdk8s_plus_22.Service`](#cdk8s_plus_22.Service), [`cdk8s_plus_22.ServiceAccount`](#cdk8s_plus_22.ServiceAccount), [`cdk8s_plus_22.StatefulSet`](#cdk8s_plus_22.StatefulSet), [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap), [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource), [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret), [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 Represents a resource.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.IResource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.IResource.property.name"></a>
 
 ```python
 name: str
@@ -7256,16 +7414,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### ISecret <a name="cdk8s_plus_21.ISecret"></a>
+### ISecret <a name="cdk8s_plus_22.ISecret"></a>
 
-- *Extends:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
+- *Extends:* [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource)
 
-- *Implemented By:* [`cdk8s_plus_21.Secret`](#cdk8s_plus_21.Secret), [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
+- *Implemented By:* [`cdk8s_plus_22.Secret`](#cdk8s_plus_22.Secret), [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.ISecret.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.ISecret.property.name"></a>
 
 ```python
 name: str
@@ -7277,16 +7435,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### IServiceAccount <a name="cdk8s_plus_21.IServiceAccount"></a>
+### IServiceAccount <a name="cdk8s_plus_22.IServiceAccount"></a>
 
-- *Extends:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
+- *Extends:* [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource)
 
-- *Implemented By:* [`cdk8s_plus_21.ServiceAccount`](#cdk8s_plus_21.ServiceAccount), [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Implemented By:* [`cdk8s_plus_22.ServiceAccount`](#cdk8s_plus_22.ServiceAccount), [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.IServiceAccount.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.IServiceAccount.property.name"></a>
 
 ```python
 name: str
@@ -7304,14 +7462,14 @@ The Kubernetes name of this resource.
 
 The medium on which to store the volume.
 
-#### `DEFAULT` <a name="cdk8s_plus_21.EmptyDirMedium.DEFAULT"></a>
+#### `DEFAULT` <a name="cdk8s_plus_22.EmptyDirMedium.DEFAULT"></a>
 
 The default volume of the backing node.
 
 ---
 
 
-#### `MEMORY` <a name="cdk8s_plus_21.EmptyDirMedium.MEMORY"></a>
+#### `MEMORY` <a name="cdk8s_plus_22.EmptyDirMedium.MEMORY"></a>
 
 Mount a tmpfs (RAM-backed filesystem) for you instead.
 
@@ -7322,9 +7480,36 @@ files you write will count against your Container's memory limit.
 ---
 
 
+### HttpIngressPathType <a name="HttpIngressPathType"></a>
+
+Specify how the path is matched against request paths.
+
+> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+
+#### `PREFIX` <a name="cdk8s_plus_22.HttpIngressPathType.PREFIX"></a>
+
+Matches the URL path exactly.
+
+---
+
+
+#### `EXACT` <a name="cdk8s_plus_22.HttpIngressPathType.EXACT"></a>
+
+Matches based on a URL path prefix split by '/'.
+
+---
+
+
+#### `IMPLEMENTATION_SPECIFIC` <a name="cdk8s_plus_22.HttpIngressPathType.IMPLEMENTATION_SPECIFIC"></a>
+
+Matching is specified by the underlying IngressClass.
+
+---
+
+
 ### ImagePullPolicy <a name="ImagePullPolicy"></a>
 
-#### `ALWAYS` <a name="cdk8s_plus_21.ImagePullPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="cdk8s_plus_22.ImagePullPolicy.ALWAYS"></a>
 
 Every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest.
 
@@ -7338,7 +7523,7 @@ the image tag is omitted.
 ---
 
 
-#### `IF_NOT_PRESENT` <a name="cdk8s_plus_21.ImagePullPolicy.IF_NOT_PRESENT"></a>
+#### `IF_NOT_PRESENT` <a name="cdk8s_plus_22.ImagePullPolicy.IF_NOT_PRESENT"></a>
 
 The image is pulled only if it is not already present locally.
 
@@ -7348,7 +7533,7 @@ not :latest
 ---
 
 
-#### `NEVER` <a name="cdk8s_plus_21.ImagePullPolicy.NEVER"></a>
+#### `NEVER` <a name="cdk8s_plus_22.ImagePullPolicy.NEVER"></a>
 
 The image is assumed to exist locally.
 
@@ -7359,7 +7544,7 @@ No attempt is made to pull the image.
 
 ### MountPropagation <a name="MountPropagation"></a>
 
-#### `NONE` <a name="cdk8s_plus_21.MountPropagation.NONE"></a>
+#### `NONE` <a name="cdk8s_plus_22.MountPropagation.NONE"></a>
 
 This volume mount will not receive any subsequent mounts that are mounted to this volume or any of its subdirectories by the host.
 
@@ -7374,7 +7559,7 @@ kernel documentation
 ---
 
 
-#### `HOST_TO_CONTAINER` <a name="cdk8s_plus_21.MountPropagation.HOST_TO_CONTAINER"></a>
+#### `HOST_TO_CONTAINER` <a name="cdk8s_plus_22.MountPropagation.HOST_TO_CONTAINER"></a>
 
 This volume mount will receive all subsequent mounts that are mounted to this volume or any of its subdirectories.
 
@@ -7391,7 +7576,7 @@ kernel documentation
 ---
 
 
-#### `BIDIRECTIONAL` <a name="cdk8s_plus_21.MountPropagation.BIDIRECTIONAL"></a>
+#### `BIDIRECTIONAL` <a name="cdk8s_plus_22.MountPropagation.BIDIRECTIONAL"></a>
 
 This volume mount behaves the same the HostToContainer mount.
 
@@ -7425,29 +7610,29 @@ continuing. When scaling down, the pods are removed in the opposite order.
 The alternative policy is `Parallel` which will create pods in parallel to match the
 desired scale without waiting, and on scale down will delete all pods at once.
 
-#### `ORDERED_READY` <a name="cdk8s_plus_21.PodManagementPolicy.ORDERED_READY"></a>
+#### `ORDERED_READY` <a name="cdk8s_plus_22.PodManagementPolicy.ORDERED_READY"></a>
 
 ---
 
 
-#### `PARALLEL` <a name="cdk8s_plus_21.PodManagementPolicy.PARALLEL"></a>
+#### `PARALLEL` <a name="cdk8s_plus_22.PodManagementPolicy.PARALLEL"></a>
 
 ---
 
 
 ### Protocol <a name="Protocol"></a>
 
-#### `TCP` <a name="cdk8s_plus_21.Protocol.TCP"></a>
+#### `TCP` <a name="cdk8s_plus_22.Protocol.TCP"></a>
 
 ---
 
 
-#### `UDP` <a name="cdk8s_plus_21.Protocol.UDP"></a>
+#### `UDP` <a name="cdk8s_plus_22.Protocol.UDP"></a>
 
 ---
 
 
-#### `SCTP` <a name="cdk8s_plus_21.Protocol.SCTP"></a>
+#### `SCTP` <a name="cdk8s_plus_22.Protocol.SCTP"></a>
 
 ---
 
@@ -7456,21 +7641,21 @@ desired scale without waiting, and on scale down will delete all pods at once.
 
 Restart policy for all containers within the pod.
 
-#### `ALWAYS` <a name="cdk8s_plus_21.RestartPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="cdk8s_plus_22.RestartPolicy.ALWAYS"></a>
 
 Always restart the pod after it exits.
 
 ---
 
 
-#### `ON_FAILURE` <a name="cdk8s_plus_21.RestartPolicy.ON_FAILURE"></a>
+#### `ON_FAILURE` <a name="cdk8s_plus_22.RestartPolicy.ON_FAILURE"></a>
 
 Only restart if the pod exits with a non-zero exit code.
 
 ---
 
 
-#### `NEVER` <a name="cdk8s_plus_21.RestartPolicy.NEVER"></a>
+#### `NEVER` <a name="cdk8s_plus_22.RestartPolicy.NEVER"></a>
 
 Never restart the pod.
 
@@ -7484,7 +7669,7 @@ For some parts of your application (for example, frontends) you may want to expo
 Kubernetes ServiceTypes allow you to specify what kind of Service you want.
 The default is ClusterIP.
 
-#### `CLUSTER_IP` <a name="cdk8s_plus_21.ServiceType.CLUSTER_IP"></a>
+#### `CLUSTER_IP` <a name="cdk8s_plus_22.ServiceType.CLUSTER_IP"></a>
 
 Exposes the Service on a cluster-internal IP.
 
@@ -7494,7 +7679,7 @@ This is the default ServiceType
 ---
 
 
-#### `NODE_PORT` <a name="cdk8s_plus_21.ServiceType.NODE_PORT"></a>
+#### `NODE_PORT` <a name="cdk8s_plus_22.ServiceType.NODE_PORT"></a>
 
 Exposes the Service on each Node's IP at a static port (the NodePort).
 
@@ -7505,7 +7690,7 @@ by requesting <NodeIP>:<NodePort>.
 ---
 
 
-#### `LOAD_BALANCER` <a name="cdk8s_plus_21.ServiceType.LOAD_BALANCER"></a>
+#### `LOAD_BALANCER` <a name="cdk8s_plus_22.ServiceType.LOAD_BALANCER"></a>
 
 Exposes the Service externally using a cloud provider's load balancer.
 
@@ -7515,7 +7700,7 @@ are automatically created.
 ---
 
 
-#### `EXTERNAL_NAME` <a name="cdk8s_plus_21.ServiceType.EXTERNAL_NAME"></a>
+#### `EXTERNAL_NAME` <a name="cdk8s_plus_22.ServiceType.EXTERNAL_NAME"></a>
 
 Maps the Service to the contents of the externalName field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -2,18 +2,18 @@
 
 ## Constructs <a name="Constructs"></a>
 
-### ConfigMap <a name="cdk8s_plus_22.ConfigMap"></a>
+### ConfigMap <a name="cdk8s_plus_21.ConfigMap"></a>
 
-- *Implements:* [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap)
+- *Implements:* [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
 
 ConfigMap holds configuration data for pods to consume.
 
-#### Initializers <a name="cdk8s_plus_22.ConfigMap.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.ConfigMap.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ConfigMap(
+cdk8s_plus_21.ConfigMap(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -22,19 +22,19 @@ cdk8s_plus_22.ConfigMap(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -42,7 +42,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binary_data`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.parameter.binary_data"></a>
+##### `binary_data`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.parameter.binary_data"></a>
 
 - *Type:* typing.Mapping[`str`]
 
@@ -58,7 +58,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.parameter.data"></a>
+##### `data`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.parameter.data"></a>
 
 - *Type:* typing.Mapping[`str`]
 
@@ -75,7 +75,7 @@ You can also add data using `configMap.addData()`.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_binary_data` <a name="cdk8s_plus_22.ConfigMap.add_binary_data"></a>
+##### `add_binary_data` <a name="cdk8s_plus_21.ConfigMap.add_binary_data"></a>
 
 ```python
 def add_binary_data(
@@ -84,7 +84,7 @@ def add_binary_data(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -92,7 +92,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -100,7 +100,7 @@ The value.
 
 ---
 
-##### `add_data` <a name="cdk8s_plus_22.ConfigMap.add_data"></a>
+##### `add_data` <a name="cdk8s_plus_21.ConfigMap.add_data"></a>
 
 ```python
 def add_data(
@@ -109,7 +109,7 @@ def add_data(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -117,7 +117,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -125,7 +125,7 @@ The value.
 
 ---
 
-##### `add_directory` <a name="cdk8s_plus_22.ConfigMap.add_directory"></a>
+##### `add_directory` <a name="cdk8s_plus_21.ConfigMap.add_directory"></a>
 
 ```python
 def add_directory(
@@ -135,7 +135,7 @@ def add_directory(
 )
 ```
 
-###### `local_dir`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.local_dir"></a>
+###### `local_dir`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.local_dir"></a>
 
 - *Type:* `str`
 
@@ -143,7 +143,7 @@ A path to a local directory.
 
 ---
 
-###### `exclude`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDirectoryOptions.parameter.exclude"></a>
+###### `exclude`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDirectoryOptions.parameter.exclude"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* include all files
@@ -152,7 +152,7 @@ Glob patterns to exclude when adding files.
 
 ---
 
-###### `key_prefix`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDirectoryOptions.parameter.key_prefix"></a>
+###### `key_prefix`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDirectoryOptions.parameter.key_prefix"></a>
 
 - *Type:* `str`
 - *Default:* ""
@@ -161,7 +161,7 @@ A prefix to add to all keys in the config map.
 
 ---
 
-##### `add_file` <a name="cdk8s_plus_22.ConfigMap.add_file"></a>
+##### `add_file` <a name="cdk8s_plus_21.ConfigMap.add_file"></a>
 
 ```python
 def add_file(
@@ -170,7 +170,7 @@ def add_file(
 )
 ```
 
-###### `local_file`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.local_file"></a>
+###### `local_file`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.local_file"></a>
 
 - *Type:* `str`
 
@@ -178,7 +178,7 @@ The path to the local file.
 
 ---
 
-###### `key`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -188,17 +188,17 @@ The ConfigMap key (default to the file name).
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_config_map_name` <a name="cdk8s_plus_22.ConfigMap.from_config_map_name"></a>
+##### `from_config_map_name` <a name="cdk8s_plus_21.ConfigMap.from_config_map_name"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ConfigMap.from_config_map_name(
+cdk8s_plus_21.ConfigMap.from_config_map_name(
   name: str
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -208,7 +208,7 @@ The name of the config map to import.
 
 #### Properties <a name="Properties"></a>
 
-##### `binary_data`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.property.binary_data"></a>
+##### `binary_data`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.property.binary_data"></a>
 
 ```python
 binary_data: typing.Mapping[str]
@@ -222,7 +222,7 @@ Returns a copy. To add data records, use `addBinaryData()` or `addData()`.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.property.data"></a>
+##### `data`<sup>Required</sup> <a name="cdk8s_plus_21.ConfigMap.property.data"></a>
 
 ```python
 data: typing.Mapping[str]
@@ -237,9 +237,9 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 ---
 
 
-### Deployment <a name="cdk8s_plus_22.Deployment"></a>
+### Deployment <a name="cdk8s_plus_21.Deployment"></a>
 
-- *Implements:* [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
+- *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
 
 A Deployment provides declarative updates for Pods and ReplicaSets.
 
@@ -266,12 +266,12 @@ The following are typical use cases for Deployments:
 - Use the status of the Deployment as an indicator that a rollout has stuck.
 - Clean up older ReplicaSets that you don't need anymore.
 
-#### Initializers <a name="cdk8s_plus_22.Deployment.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Deployment.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Deployment(
+cdk8s_plus_21.Deployment(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -285,19 +285,19 @@ cdk8s_plus_22.Deployment(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -305,9 +305,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -319,9 +319,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -330,9 +330,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -348,9 +348,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -361,7 +361,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.pod_metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -369,7 +369,7 @@ The pod metadata.
 
 ---
 
-##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.default_selector"></a>
+##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.default_selector"></a>
 
 - *Type:* `bool`
 - *Default:* true
@@ -381,7 +381,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.replicas"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 1
@@ -392,7 +392,7 @@ Number of desired pods.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_22.Deployment.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_21.Deployment.add_container"></a>
 
 ```python
 def add_container(
@@ -411,7 +411,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -419,7 +419,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -438,7 +438,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -452,9 +452,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -463,18 +463,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -483,7 +483,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -494,7 +494,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -505,18 +505,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -525,9 +525,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -535,7 +535,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -546,7 +546,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_22.Deployment.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_21.Deployment.add_volume"></a>
 
 ```python
 def add_volume(
@@ -554,13 +554,13 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
+- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
 
 ---
 
-##### `expose` <a name="cdk8s_plus_22.Deployment.expose"></a>
+##### `expose` <a name="cdk8s_plus_21.Deployment.expose"></a>
 
 ```python
 def expose(
@@ -572,7 +572,7 @@ def expose(
 )
 ```
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* undefined Uses the system generated name.
@@ -583,7 +583,7 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
@@ -592,9 +592,9 @@ The port that the service should serve on.
 
 ---
 
-###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.protocol"></a>
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.protocol"></a>
 
-- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
+- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -603,16 +603,16 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-###### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.service_type"></a>
+###### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.service_type"></a>
 
-- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
+- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
 - *Default:* ClusterIP.
 
 The type of the exposed service.
 
 ---
 
-###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.parameter.target_port"></a>
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.parameter.target_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* The port of the first container in the deployment (ie. containers[0].port)
@@ -621,7 +621,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `select_by_label` <a name="cdk8s_plus_22.Deployment.select_by_label"></a>
+##### `select_by_label` <a name="cdk8s_plus_21.Deployment.select_by_label"></a>
 
 ```python
 def select_by_label(
@@ -630,7 +630,7 @@ def select_by_label(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -638,7 +638,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -649,13 +649,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
+- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
 
 The containers belonging to the pod.
 
@@ -663,7 +663,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.label_selector"></a>
+##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.label_selector"></a>
 
 ```python
 label_selector: typing.Mapping[str]
@@ -677,7 +677,7 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -689,7 +689,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.replicas"></a>
 
 ```python
 replicas: typing.Union[int, float]
@@ -701,13 +701,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 
 The volumes associated with this pod.
 
@@ -715,32 +715,32 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.Deployment.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.Deployment.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.Deployment.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.Deployment.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Ingress <a name="cdk8s_plus_22.Ingress"></a>
+### IngressV1Beta1 <a name="cdk8s_plus_21.IngressV1Beta1"></a>
 
 Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend.
 
@@ -748,34 +748,34 @@ An Ingress can be configured to give services
 externally-reachable urls, load balance traffic, terminate SSL, offer name
 based virtual hosting etc.
 
-#### Initializers <a name="cdk8s_plus_22.Ingress.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.IngressV1Beta1.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Ingress(
+cdk8s_plus_21.IngressV1Beta1(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
-  default_backend: IngressBackend = None,
-  rules: typing.List[IngressRule] = None,
-  tls: typing.List[IngressTls] = None
+  default_backend: IngressV1Beta1Backend = None,
+  rules: typing.List[IngressV1Beta1Rule] = None,
+  tls: typing.List[IngressV1Beta1Tls] = None
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -783,9 +783,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `default_backend`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.parameter.default_backend"></a>
+##### `default_backend`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.parameter.default_backend"></a>
 
-- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
+- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
 
 The default backend services requests that do not match any rule.
 
@@ -794,9 +794,9 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.parameter.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.parameter.rules"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.IngressRule`](#cdk8s_plus_22.IngressRule)]
+- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Rule`](#cdk8s_plus_21.IngressV1Beta1Rule)]
 
 Routing rules for this ingress.
 
@@ -809,9 +809,9 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.parameter.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.parameter.tls"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.IngressTls`](#cdk8s_plus_22.IngressTls)]
+- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Tls`](#cdk8s_plus_21.IngressV1Beta1Tls)]
 
 TLS settings for this ingress.
 
@@ -825,32 +825,32 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_default_backend` <a name="cdk8s_plus_22.Ingress.add_default_backend"></a>
+##### `add_default_backend` <a name="cdk8s_plus_21.IngressV1Beta1.add_default_backend"></a>
 
 ```python
 def add_default_backend(
-  backend: IngressBackend
+  backend: IngressV1Beta1Backend
 )
 ```
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
+- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
 
 The backend to use for requests that do not match any rule.
 
 ---
 
-##### `add_host_default_backend` <a name="cdk8s_plus_22.Ingress.add_host_default_backend"></a>
+##### `add_host_default_backend` <a name="cdk8s_plus_21.IngressV1Beta1.add_host_default_backend"></a>
 
 ```python
 def add_host_default_backend(
   host: str,
-  backend: IngressBackend
+  backend: IngressV1Beta1Backend
 )
 ```
 
-###### `host`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.host"></a>
 
 - *Type:* `str`
 
@@ -858,26 +858,25 @@ The host name to match.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
+- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
 
 The backend to route to.
 
 ---
 
-##### `add_host_rule` <a name="cdk8s_plus_22.Ingress.add_host_rule"></a>
+##### `add_host_rule` <a name="cdk8s_plus_21.IngressV1Beta1.add_host_rule"></a>
 
 ```python
 def add_host_rule(
   host: str,
   path: str,
-  backend: IngressBackend,
-  path_type: HttpIngressPathType = None
+  backend: IngressV1Beta1Backend
 )
 ```
 
-###### `host`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.host"></a>
 
 - *Type:* `str`
 
@@ -885,7 +884,7 @@ The host name.
 
 ---
 
-###### `path`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.path"></a>
 
 - *Type:* `str`
 
@@ -893,33 +892,24 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
+- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
 
 The backend to route requests to.
 
 ---
 
-###### `path_type`<sup>Optional</sup> <a name="cdk8s_plus_22.Ingress.parameter.path_type"></a>
-
-- *Type:* [`cdk8s_plus_22.HttpIngressPathType`](#cdk8s_plus_22.HttpIngressPathType)
-
-How the path is matched against request paths.
-
----
-
-##### `add_rule` <a name="cdk8s_plus_22.Ingress.add_rule"></a>
+##### `add_rule` <a name="cdk8s_plus_21.IngressV1Beta1.add_rule"></a>
 
 ```python
 def add_rule(
   path: str,
-  backend: IngressBackend,
-  path_type: HttpIngressPathType = None
+  backend: IngressV1Beta1Backend
 )
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.path"></a>
 
 - *Type:* `str`
 
@@ -927,42 +917,33 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
+- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
 
 The backend to route requests to.
 
 ---
 
-###### `path_type`<sup>Optional</sup> <a name="cdk8s_plus_22.Ingress.parameter.path_type"></a>
-
-- *Type:* [`cdk8s_plus_22.HttpIngressPathType`](#cdk8s_plus_22.HttpIngressPathType)
-
-How the path is matched against request paths.
-
----
-
-##### `add_rules` <a name="cdk8s_plus_22.Ingress.add_rules"></a>
+##### `add_rules` <a name="cdk8s_plus_21.IngressV1Beta1.add_rules"></a>
 
 ```python
 def add_rules(
-  backend: IngressBackend,
+  backend: IngressV1Beta1Backend,
   host: str = None,
-  path: str = None,
-  path_type: HttpIngressPathType = None
+  path: str = None
 )
 ```
 
-###### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.IngressRule.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.parameter.backend"></a>
 
-- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
+- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
 
 Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ---
 
-###### `host`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.parameter.host"></a>
+###### `host`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.parameter.host"></a>
 
 - *Type:* `str`
 - *Default:* If the host is unspecified, the Ingress routes all traffic based
@@ -980,7 +961,7 @@ host before the IngressRuleValue.
 
 ---
 
-###### `path`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.parameter.path"></a>
+###### `path`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.parameter.path"></a>
 
 - *Type:* `str`
 - *Default:* If unspecified, the path defaults to a catch all sending traffic
@@ -990,39 +971,26 @@ Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows
 
 ---
 
-###### `path_type`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.parameter.path_type"></a>
-
-- *Type:* [`cdk8s_plus_22.HttpIngressPathType`](#cdk8s_plus_22.HttpIngressPathType)
-
-Specify how the path is matched against request paths.
-
-By default, path
-types will be matched by prefix.
-
-> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-
----
-
-##### `add_tls` <a name="cdk8s_plus_22.Ingress.add_tls"></a>
+##### `add_tls` <a name="cdk8s_plus_21.IngressV1Beta1.add_tls"></a>
 
 ```python
 def add_tls(
-  tls: typing.List[IngressTls]
+  tls: typing.List[IngressV1Beta1Tls]
 )
 ```
 
-###### `tls`<sup>Required</sup> <a name="cdk8s_plus_22.Ingress.parameter.tls"></a>
+###### `tls`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1.parameter.tls"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.IngressTls`](#cdk8s_plus_22.IngressTls)]
+- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Tls`](#cdk8s_plus_21.IngressV1Beta1Tls)]
 
 ---
 
 
 
 
-### Job <a name="cdk8s_plus_22.Job"></a>
+### Job <a name="cdk8s_plus_21.Job"></a>
 
-- *Implements:* [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
+- *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
 
 A Job creates one or more Pods and ensures that a specified number of them successfully terminate.
 
@@ -1032,12 +1000,12 @@ Deleting a Job will clean up the Pods it created. A simple case is to create one
 The Job object will start a new Pod if the first Pod fails or is deleted (for example due to a node hardware failure or a node reboot).
 You can also use a Job to run multiple Pods in parallel.
 
-#### Initializers <a name="cdk8s_plus_22.Job.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Job.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Job(
+cdk8s_plus_21.Job(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -1052,19 +1020,19 @@ cdk8s_plus_22.Job(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Job.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Job.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Job.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Job.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -1072,9 +1040,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1086,9 +1054,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -1097,9 +1065,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -1115,9 +1083,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -1128,7 +1096,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.pod_metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -1136,7 +1104,7 @@ The pod metadata.
 
 ---
 
-##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.active_deadline"></a>
+##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.active_deadline"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* If unset, then there is no deadline.
@@ -1145,7 +1113,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.backoff_limit"></a>
+##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.backoff_limit"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* If not set, system defaults to 6.
@@ -1154,7 +1122,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.ttl_after_finished"></a>
+##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.ttl_after_finished"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* If this field is unset, the Job won't be automatically deleted.
@@ -1172,7 +1140,7 @@ field is alpha-level and is only honored by servers that enable the
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_22.Job.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_21.Job.add_container"></a>
 
 ```python
 def add_container(
@@ -1191,7 +1159,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -1199,7 +1167,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -1218,7 +1186,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -1232,9 +1200,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -1243,18 +1211,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -1263,7 +1231,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -1274,7 +1242,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -1285,18 +1253,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -1305,9 +1273,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -1315,7 +1283,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -1326,7 +1294,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_22.Job.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_21.Job.add_volume"></a>
 
 ```python
 def add_volume(
@@ -1334,22 +1302,22 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.Job.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Job.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
+- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.Job.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.Job.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
+- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
 
 The containers belonging to the pod.
 
@@ -1357,7 +1325,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.Job.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.Job.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -1369,13 +1337,13 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.Job.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.Job.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 
 The volumes associated with this pod.
 
@@ -1383,7 +1351,7 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.active_deadline"></a>
+##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.active_deadline"></a>
 
 ```python
 active_deadline: Duration
@@ -1397,7 +1365,7 @@ If undefined, there is no deadline.
 
 ---
 
-##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.backoff_limit"></a>
+##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.backoff_limit"></a>
 
 ```python
 backoff_limit: typing.Union[int, float]
@@ -1409,31 +1377,31 @@ Number of retries before marking failed.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_22.Job.property.ttl_after_finished"></a>
+##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_21.Job.property.ttl_after_finished"></a>
 
 ```python
 ttl_after_finished: Duration
@@ -1446,21 +1414,21 @@ TTL before the job is deleted after it is finished.
 ---
 
 
-### Pod <a name="cdk8s_plus_22.Pod"></a>
+### Pod <a name="cdk8s_plus_21.Pod"></a>
 
-- *Implements:* [`cdk8s_plus_22.IPodSpec`](#cdk8s_plus_22.IPodSpec)
+- *Implements:* [`cdk8s_plus_21.IPodSpec`](#cdk8s_plus_21.IPodSpec)
 
 Pod is a collection of containers that can run on a host.
 
 This resource is
 created by clients and scheduled onto hosts.
 
-#### Initializers <a name="cdk8s_plus_22.Pod.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Pod.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Pod(
+cdk8s_plus_21.Pod(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -1471,19 +1439,19 @@ cdk8s_plus_22.Pod(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -1491,9 +1459,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1505,9 +1473,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -1516,9 +1484,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -1534,9 +1502,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -1549,7 +1517,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_22.Pod.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_21.Pod.add_container"></a>
 
 ```python
 def add_container(
@@ -1568,7 +1536,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -1576,7 +1544,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -1595,7 +1563,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -1609,9 +1577,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -1620,18 +1588,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -1640,7 +1608,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -1651,7 +1619,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -1662,18 +1630,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -1682,9 +1650,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -1692,7 +1660,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -1703,7 +1671,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_22.Pod.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_21.Pod.add_volume"></a>
 
 ```python
 def add_volume(
@@ -1711,22 +1679,22 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
+- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
+- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
 
 The containers belonging to the pod.
 
@@ -1734,13 +1702,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.Pod.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 
 The volumes associated with this pod.
 
@@ -1748,53 +1716,53 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.Pod.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.Pod.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.Pod.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.Pod.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Resource <a name="cdk8s_plus_22.Resource"></a>
+### Resource <a name="cdk8s_plus_21.Resource"></a>
 
-- *Implements:* [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource)
+- *Implements:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
 
 Base class for all Kubernetes objects in stdk8s.
 
 Represents a single
 resource.
 
-#### Initializers <a name="cdk8s_plus_22.Resource.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Resource.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Resource(
+cdk8s_plus_21.Resource(
   scope: Construct,
   id: str,
   node_factory: INodeFactory = None
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Resource.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Resource.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
@@ -1802,7 +1770,7 @@ The scope in which to define this construct.
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Resource.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Resource.parameter.id"></a>
 
 - *Type:* `str`
 
@@ -1827,7 +1795,7 @@ A factory for attaching `Node`s to the construct.
 
 #### Properties <a name="Properties"></a>
 
-##### `metadata`<sup>Required</sup> <a name="cdk8s_plus_22.Resource.property.metadata"></a>
+##### `metadata`<sup>Required</sup> <a name="cdk8s_plus_21.Resource.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadataDefinition
@@ -1837,7 +1805,7 @@ metadata: ApiObjectMetadataDefinition
 
 ---
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Resource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Resource.property.name"></a>
 
 ```python
 name: str
@@ -1850,9 +1818,9 @@ The name of this API object.
 ---
 
 
-### Secret <a name="cdk8s_plus_22.Secret"></a>
+### Secret <a name="cdk8s_plus_21.Secret"></a>
 
-- *Implements:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
+- *Implements:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
 
 Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 
@@ -1862,12 +1830,12 @@ definition or in a container image.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
 
-#### Initializers <a name="cdk8s_plus_22.Secret.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Secret.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Secret(
+cdk8s_plus_21.Secret(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -1876,19 +1844,19 @@ cdk8s_plus_22.Secret(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -1896,7 +1864,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.string_data"></a>
+##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.string_data"></a>
 
 - *Type:* typing.Mapping[`str`]
 
@@ -1909,7 +1877,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.type"></a>
 
 - *Type:* `str`
 - *Default:* undefined - Don't set a type.
@@ -1923,7 +1891,7 @@ handling of secret data by various controllers.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_string_data` <a name="cdk8s_plus_22.Secret.add_string_data"></a>
+##### `add_string_data` <a name="cdk8s_plus_21.Secret.add_string_data"></a>
 
 ```python
 def add_string_data(
@@ -1932,7 +1900,7 @@ def add_string_data(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -1940,7 +1908,7 @@ Key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -1948,7 +1916,7 @@ Value.
 
 ---
 
-##### `get_string_data` <a name="cdk8s_plus_22.Secret.get_string_data"></a>
+##### `get_string_data` <a name="cdk8s_plus_21.Secret.get_string_data"></a>
 
 ```python
 def get_string_data(
@@ -1956,7 +1924,7 @@ def get_string_data(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -1966,17 +1934,17 @@ Key.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_secret_name` <a name="cdk8s_plus_22.Secret.from_secret_name"></a>
+##### `from_secret_name` <a name="cdk8s_plus_21.Secret.from_secret_name"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Secret.from_secret_name(
+cdk8s_plus_21.Secret.from_secret_name(
   name: str
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -1986,7 +1954,7 @@ The name of the secret to reference.
 
 
 
-### Service <a name="cdk8s_plus_22.Service"></a>
+### Service <a name="cdk8s_plus_21.Service"></a>
 
 An abstract way to expose an application running on a set of Pods as a network service.
 
@@ -2002,12 +1970,12 @@ If you're able to use Kubernetes APIs for service discovery in your application,
 that get updated whenever the set of Pods in a Service changes. For non-native applications, Kubernetes offers ways to place a network port
 or load balancer in between your application and the backend Pods.
 
-#### Initializers <a name="cdk8s_plus_22.Service.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Service.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Service(
+cdk8s_plus_21.Service(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -2020,19 +1988,19 @@ cdk8s_plus_22.Service(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -2040,7 +2008,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.cluster_i_p"></a>
+##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.cluster_i_p"></a>
 
 - *Type:* `str`
 - *Default:* Automatically assigned.
@@ -2058,7 +2026,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `external_i_ps`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.external_i_ps"></a>
+##### `external_i_ps`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.external_i_ps"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* No external IPs.
@@ -2072,7 +2040,7 @@ Kubernetes system.
 
 ---
 
-##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.external_name"></a>
+##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.external_name"></a>
 
 - *Type:* `str`
 - *Default:* No external name.
@@ -2081,7 +2049,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `load_balancer_source_ranges`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.load_balancer_source_ranges"></a>
+##### `load_balancer_source_ranges`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.load_balancer_source_ranges"></a>
 
 - *Type:* typing.List[`str`]
 
@@ -2091,9 +2059,9 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.ports"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.ServicePort`](#cdk8s_plus_22.ServicePort)]
+- *Type:* typing.List[[`cdk8s_plus_21.ServicePort`](#cdk8s_plus_21.ServicePort)]
 
 The port exposed by this service.
 
@@ -2101,9 +2069,9 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.parameter.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.parameter.type"></a>
 
-- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
+- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -2114,7 +2082,7 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 #### Methods <a name="Methods"></a>
 
-##### `add_deployment` <a name="cdk8s_plus_22.Service.add_deployment"></a>
+##### `add_deployment` <a name="cdk8s_plus_21.Service.add_deployment"></a>
 
 ```python
 def add_deployment(
@@ -2127,15 +2095,15 @@ def add_deployment(
 )
 ```
 
-###### `deployment`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.deployment"></a>
+###### `deployment`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.deployment"></a>
 
-- *Type:* [`cdk8s_plus_22.Deployment`](#cdk8s_plus_22.Deployment)
+- *Type:* [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment)
 
 The deployment to expose.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -2148,7 +2116,7 @@ on this service.
 
 ---
 
-###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.node_port"></a>
+###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.parameter.node_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* auto-allocate a port if the ServiceType of this Service requires one.
@@ -2164,9 +2132,9 @@ requires one.
 
 ---
 
-###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.protocol"></a>
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.parameter.protocol"></a>
 
-- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
+- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -2175,7 +2143,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.target_port"></a>
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.parameter.target_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* The value of `port` will be used.
@@ -2184,7 +2152,7 @@ The port number the service will redirect to.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* Copied from the first container of the deployment.
@@ -2193,7 +2161,7 @@ The port number the service will bind to.
 
 ---
 
-##### `add_selector` <a name="cdk8s_plus_22.Service.add_selector"></a>
+##### `add_selector` <a name="cdk8s_plus_21.Service.add_selector"></a>
 
 ```python
 def add_selector(
@@ -2202,7 +2170,7 @@ def add_selector(
 )
 ```
 
-###### `label`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.label"></a>
+###### `label`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.label"></a>
 
 - *Type:* `str`
 
@@ -2210,7 +2178,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -2218,7 +2186,7 @@ The label value.
 
 ---
 
-##### `serve` <a name="cdk8s_plus_22.Service.serve"></a>
+##### `serve` <a name="cdk8s_plus_21.Service.serve"></a>
 
 ```python
 def serve(
@@ -2230,7 +2198,7 @@ def serve(
 )
 ```
 
-###### `port`<sup>Required</sup> <a name="cdk8s_plus_22.Service.parameter.port"></a>
+###### `port`<sup>Required</sup> <a name="cdk8s_plus_21.Service.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 
@@ -2238,7 +2206,7 @@ The port definition.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -2251,7 +2219,7 @@ on this service.
 
 ---
 
-###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.parameter.node_port"></a>
+###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.node_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* auto-allocate a port if the ServiceType of this Service requires one.
@@ -2267,9 +2235,9 @@ requires one.
 
 ---
 
-###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.parameter.protocol"></a>
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.protocol"></a>
 
-- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
+- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -2278,7 +2246,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.parameter.target_port"></a>
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.parameter.target_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* The value of `port` will be used.
@@ -2290,13 +2258,13 @@ The port number the service will redirect to.
 
 #### Properties <a name="Properties"></a>
 
-##### `ports`<sup>Required</sup> <a name="cdk8s_plus_22.Service.property.ports"></a>
+##### `ports`<sup>Required</sup> <a name="cdk8s_plus_21.Service.property.ports"></a>
 
 ```python
 ports: typing.List[ServicePort]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ServicePort`](#cdk8s_plus_22.ServicePort)]
+- *Type:* typing.List[[`cdk8s_plus_21.ServicePort`](#cdk8s_plus_21.ServicePort)]
 
 Ports for this service.
 
@@ -2304,7 +2272,7 @@ Use `serve()` to expose additional service ports.
 
 ---
 
-##### `selector`<sup>Required</sup> <a name="cdk8s_plus_22.Service.property.selector"></a>
+##### `selector`<sup>Required</sup> <a name="cdk8s_plus_21.Service.property.selector"></a>
 
 ```python
 selector: typing.Mapping[str]
@@ -2316,19 +2284,19 @@ Returns the labels which are used to select pods for this service.
 
 ---
 
-##### `type`<sup>Required</sup> <a name="cdk8s_plus_22.Service.property.type"></a>
+##### `type`<sup>Required</sup> <a name="cdk8s_plus_21.Service.property.type"></a>
 
 ```python
 type: ServiceType
 ```
 
-- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
+- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
 
 Determines how the Service is exposed.
 
 ---
 
-##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_22.Service.property.cluster_i_p"></a>
+##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_21.Service.property.cluster_i_p"></a>
 
 ```python
 cluster_i_p: str
@@ -2340,7 +2308,7 @@ The IP address of the service and is usually assigned randomly by the master.
 
 ---
 
-##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_22.Service.property.external_name"></a>
+##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_21.Service.property.external_name"></a>
 
 ```python
 external_name: str
@@ -2353,9 +2321,9 @@ The externalName to be used for EXTERNAL_NAME types.
 ---
 
 
-### ServiceAccount <a name="cdk8s_plus_22.ServiceAccount"></a>
+### ServiceAccount <a name="cdk8s_plus_21.ServiceAccount"></a>
 
-- *Implements:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Implements:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 A service account provides an identity for processes that run in a Pod.
 
@@ -2368,12 +2336,12 @@ example, default).
 
 > https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account
 
-#### Initializers <a name="cdk8s_plus_22.ServiceAccount.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.ServiceAccount.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ServiceAccount(
+cdk8s_plus_21.ServiceAccount(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -2381,19 +2349,19 @@ cdk8s_plus_22.ServiceAccount(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -2401,9 +2369,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountProps.parameter.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountProps.parameter.secrets"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)]
+- *Type:* typing.List[[`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)]
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -2413,7 +2381,7 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_secret` <a name="cdk8s_plus_22.ServiceAccount.add_secret"></a>
+##### `add_secret` <a name="cdk8s_plus_21.ServiceAccount.add_secret"></a>
 
 ```python
 def add_secret(
@@ -2421,9 +2389,9 @@ def add_secret(
 )
 ```
 
-###### `secret`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.parameter.secret"></a>
+###### `secret`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.parameter.secret"></a>
 
-- *Type:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
+- *Type:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
 
 The secret.
 
@@ -2431,17 +2399,17 @@ The secret.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_service_account_name` <a name="cdk8s_plus_22.ServiceAccount.from_service_account_name"></a>
+##### `from_service_account_name` <a name="cdk8s_plus_21.ServiceAccount.from_service_account_name"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ServiceAccount.from_service_account_name(
+cdk8s_plus_21.ServiceAccount.from_service_account_name(
   name: str
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -2451,13 +2419,13 @@ The name of the service account resource.
 
 #### Properties <a name="Properties"></a>
 
-##### `secrets`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccount.property.secrets"></a>
+##### `secrets`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccount.property.secrets"></a>
 
 ```python
 secrets: typing.List[ISecret]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)]
+- *Type:* typing.List[[`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)]
 
 List of secrets allowed to be used by pods running using this service account.
 
@@ -2466,9 +2434,9 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
-### StatefulSet <a name="cdk8s_plus_22.StatefulSet"></a>
+### StatefulSet <a name="cdk8s_plus_21.StatefulSet"></a>
 
-- *Implements:* [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
+- *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
 
 StatefulSet is the workload API object used to manage stateful applications.
 
@@ -2495,12 +2463,12 @@ StatefulSets are valuable for applications that require one or more of the follo
 - Ordered, graceful deployment and scaling.
 - Ordered, automated rolling updates.
 
-#### Initializers <a name="cdk8s_plus_22.StatefulSet.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.StatefulSet.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.StatefulSet(
+cdk8s_plus_21.StatefulSet(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
@@ -2516,19 +2484,19 @@ cdk8s_plus_22.StatefulSet(
 )
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.id"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -2536,9 +2504,9 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2550,9 +2518,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2561,9 +2529,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2579,9 +2547,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2592,7 +2560,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.pod_metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -2600,15 +2568,15 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.service"></a>
+##### `service`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.service"></a>
 
-- *Type:* [`cdk8s_plus_22.Service`](#cdk8s_plus_22.Service)
+- *Type:* [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.default_selector"></a>
+##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.default_selector"></a>
 
 - *Type:* `bool`
 - *Default:* true
@@ -2620,16 +2588,16 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `pod_management_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.pod_management_policy"></a>
+##### `pod_management_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.pod_management_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.PodManagementPolicy`](#cdk8s_plus_22.PodManagementPolicy)
+- *Type:* [`cdk8s_plus_21.PodManagementPolicy`](#cdk8s_plus_21.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.replicas"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 1
@@ -2640,7 +2608,7 @@ Number of desired pods.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_22.StatefulSet.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_21.StatefulSet.add_container"></a>
 
 ```python
 def add_container(
@@ -2659,7 +2627,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -2667,7 +2635,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -2686,7 +2654,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -2700,9 +2668,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -2711,18 +2679,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -2731,7 +2699,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -2742,7 +2710,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -2753,18 +2721,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -2773,9 +2741,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -2783,7 +2751,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -2794,7 +2762,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_22.StatefulSet.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_21.StatefulSet.add_volume"></a>
 
 ```python
 def add_volume(
@@ -2802,13 +2770,13 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
+- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
 
 ---
 
-##### `select_by_label` <a name="cdk8s_plus_22.StatefulSet.select_by_label"></a>
+##### `select_by_label` <a name="cdk8s_plus_21.StatefulSet.select_by_label"></a>
 
 ```python
 def select_by_label(
@@ -2817,7 +2785,7 @@ def select_by_label(
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -2825,7 +2793,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -2836,13 +2804,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
+- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
 
 The containers belonging to the pod.
 
@@ -2850,7 +2818,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.label_selector"></a>
+##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.label_selector"></a>
 
 ```python
 label_selector: typing.Mapping[str]
@@ -2864,19 +2832,19 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `pod_management_policy`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.pod_management_policy"></a>
+##### `pod_management_policy`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.pod_management_policy"></a>
 
 ```python
 pod_management_policy: PodManagementPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.PodManagementPolicy`](#cdk8s_plus_22.PodManagementPolicy)
+- *Type:* [`cdk8s_plus_21.PodManagementPolicy`](#cdk8s_plus_21.PodManagementPolicy)
 
 Management policy to use for the set.
 
 ---
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -2888,7 +2856,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.replicas"></a>
 
 ```python
 replicas: typing.Union[int, float]
@@ -2900,13 +2868,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 
 The volumes associated with this pod.
 
@@ -2914,25 +2882,25 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSet.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSet.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSet.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSet.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 The service account used to run this pod.
 
@@ -2941,16 +2909,16 @@ The service account used to run this pod.
 
 ## Structs <a name="Structs"></a>
 
-### AddDeploymentOptions <a name="cdk8s_plus_22.AddDeploymentOptions"></a>
+### AddDeploymentOptions <a name="cdk8s_plus_21.AddDeploymentOptions"></a>
 
 Options to add a deployment to a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.AddDeploymentOptions(
+cdk8s_plus_21.AddDeploymentOptions(
   name: str = None,
   node_port: typing.Union[int, float] = None,
   protocol: Protocol = None,
@@ -2959,7 +2927,7 @@ cdk8s_plus_22.AddDeploymentOptions(
 )
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.property.name"></a>
 
 ```python
 name: str
@@ -2976,7 +2944,7 @@ on this service.
 
 ---
 
-##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.node_port"></a>
+##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.property.node_port"></a>
 
 ```python
 node_port: typing.Union[int, float]
@@ -2996,13 +2964,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.property.protocol"></a>
 
 ```python
 protocol: Protocol
 ```
 
-- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
+- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -3011,7 +2979,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.target_port"></a>
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.property.target_port"></a>
 
 ```python
 target_port: typing.Union[int, float]
@@ -3024,7 +2992,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDeploymentOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDeploymentOptions.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -3037,22 +3005,22 @@ The port number the service will bind to.
 
 ---
 
-### AddDirectoryOptions <a name="cdk8s_plus_22.AddDirectoryOptions"></a>
+### AddDirectoryOptions <a name="cdk8s_plus_21.AddDirectoryOptions"></a>
 
 Options for `configmap.addDirectory()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.AddDirectoryOptions(
+cdk8s_plus_21.AddDirectoryOptions(
   exclude: typing.List[str] = None,
   key_prefix: str = None
 )
 ```
 
-##### `exclude`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDirectoryOptions.property.exclude"></a>
+##### `exclude`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDirectoryOptions.property.exclude"></a>
 
 ```python
 exclude: typing.List[str]
@@ -3065,7 +3033,7 @@ Glob patterns to exclude when adding files.
 
 ---
 
-##### `key_prefix`<sup>Optional</sup> <a name="cdk8s_plus_22.AddDirectoryOptions.property.key_prefix"></a>
+##### `key_prefix`<sup>Optional</sup> <a name="cdk8s_plus_21.AddDirectoryOptions.property.key_prefix"></a>
 
 ```python
 key_prefix: str
@@ -3078,16 +3046,16 @@ A prefix to add to all keys in the config map.
 
 ---
 
-### CommandProbeOptions <a name="cdk8s_plus_22.CommandProbeOptions"></a>
+### CommandProbeOptions <a name="cdk8s_plus_21.CommandProbeOptions"></a>
 
 Options for `Probe.fromCommand()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.CommandProbeOptions(
+cdk8s_plus_21.CommandProbeOptions(
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
   period_seconds: Duration = None,
@@ -3096,7 +3064,7 @@ cdk8s_plus_22.CommandProbeOptions(
 )
 ```
 
-##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.failure_threshold"></a>
+##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.failure_threshold"></a>
 
 ```python
 failure_threshold: typing.Union[int, float]
@@ -3111,7 +3079,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.initial_delay_seconds"></a>
+##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.initial_delay_seconds"></a>
 
 ```python
 initial_delay_seconds: Duration
@@ -3126,7 +3094,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.period_seconds"></a>
+##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.period_seconds"></a>
 
 ```python
 period_seconds: Duration
@@ -3141,7 +3109,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.success_threshold"></a>
+##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.success_threshold"></a>
 
 ```python
 success_threshold: typing.Union[int, float]
@@ -3156,7 +3124,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.property.timeout_seconds"></a>
+##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.property.timeout_seconds"></a>
 
 ```python
 timeout_seconds: Duration
@@ -3173,23 +3141,23 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="cdk8s_plus_22.ConfigMapProps"></a>
+### ConfigMapProps <a name="cdk8s_plus_21.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ConfigMapProps(
+cdk8s_plus_21.ConfigMapProps(
   metadata: ApiObjectMetadata = None,
   binary_data: typing.Mapping[str] = None,
   data: typing.Mapping[str] = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -3201,7 +3169,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binary_data`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.property.binary_data"></a>
+##### `binary_data`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.property.binary_data"></a>
 
 ```python
 binary_data: typing.Mapping[str]
@@ -3221,7 +3189,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.property.data"></a>
+##### `data`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapProps.property.data"></a>
 
 ```python
 data: typing.Mapping[str]
@@ -3240,16 +3208,16 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="cdk8s_plus_22.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="cdk8s_plus_21.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ConfigMapVolumeOptions(
+cdk8s_plus_21.ConfigMapVolumeOptions(
   default_mode: typing.Union[int, float] = None,
   items: typing.Mapping[PathMapping] = None,
   name: str = None,
@@ -3257,7 +3225,7 @@ cdk8s_plus_22.ConfigMapVolumeOptions(
 )
 ```
 
-##### `default_mode`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.property.default_mode"></a>
+##### `default_mode`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.property.default_mode"></a>
 
 ```python
 default_mode: typing.Union[int, float]
@@ -3277,13 +3245,13 @@ file mode, like fsGroup, and the result can be other mode bits set.
 
 ---
 
-##### `items`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.property.items"></a>
+##### `items`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.property.items"></a>
 
 ```python
 items: typing.Mapping[PathMapping]
 ```
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.PathMapping`](#cdk8s_plus_22.PathMapping)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.PathMapping`](#cdk8s_plus_21.PathMapping)]
 - *Default:* no mapping
 
 If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value.
@@ -3296,7 +3264,7 @@ contain the '..' path or start with '..'.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.property.name"></a>
 
 ```python
 name: str
@@ -3309,7 +3277,7 @@ The volume name.
 
 ---
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.property.optional"></a>
 
 ```python
 optional: bool
@@ -3322,16 +3290,16 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
-### ContainerProps <a name="cdk8s_plus_22.ContainerProps"></a>
+### ContainerProps <a name="cdk8s_plus_21.ContainerProps"></a>
 
 Properties for creating a container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ContainerProps(
+cdk8s_plus_21.ContainerProps(
   image: str,
   args: typing.List[str] = None,
   command: typing.List[str] = None,
@@ -3347,7 +3315,7 @@ cdk8s_plus_22.ContainerProps(
 )
 ```
 
-##### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.property.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.property.image"></a>
 
 ```python
 image: str
@@ -3359,7 +3327,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.args"></a>
 
 ```python
 args: typing.List[str]
@@ -3382,7 +3350,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.command"></a>
 
 ```python
 command: typing.List[str]
@@ -3400,13 +3368,13 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.env"></a>
+##### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.env"></a>
 
 ```python
 env: typing.Mapping[EnvValue]
 ```
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -3415,26 +3383,26 @@ Cannot be updated.
 
 ---
 
-##### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.image_pull_policy"></a>
+##### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.image_pull_policy"></a>
 
 ```python
 image_pull_policy: ImagePullPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.liveness"></a>
 
 ```python
 liveness: Probe
 ```
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -3443,7 +3411,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.name"></a>
 
 ```python
 name: str
@@ -3458,7 +3426,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -3473,26 +3441,26 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.readiness"></a>
 
 ```python
 readiness: Probe
 ```
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.startup"></a>
 
 ```python
 startup: Probe
 ```
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -3501,13 +3469,13 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.volume_mounts"></a>
+##### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.volume_mounts"></a>
 
 ```python
 volume_mounts: typing.List[VolumeMount]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -3515,7 +3483,7 @@ Cannot be updated.
 
 ---
 
-##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.property.working_dir"></a>
+##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.property.working_dir"></a>
 
 ```python
 working_dir: str
@@ -3530,16 +3498,16 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-### DeploymentProps <a name="cdk8s_plus_22.DeploymentProps"></a>
+### DeploymentProps <a name="cdk8s_plus_21.DeploymentProps"></a>
 
 Properties for initialization of `Deployment`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.DeploymentProps(
+cdk8s_plus_21.DeploymentProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -3551,7 +3519,7 @@ cdk8s_plus_22.DeploymentProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -3563,13 +3531,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3581,13 +3549,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3596,13 +3564,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3618,13 +3586,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3635,7 +3603,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadata
@@ -3647,7 +3615,7 @@ The pod metadata.
 
 ---
 
-##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.default_selector"></a>
+##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.default_selector"></a>
 
 ```python
 default_selector: bool
@@ -3663,7 +3631,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.replicas"></a>
 
 ```python
 replicas: typing.Union[int, float]
@@ -3676,28 +3644,28 @@ Number of desired pods.
 
 ---
 
-### EmptyDirVolumeOptions <a name="cdk8s_plus_22.EmptyDirVolumeOptions"></a>
+### EmptyDirVolumeOptions <a name="cdk8s_plus_21.EmptyDirVolumeOptions"></a>
 
 Options for volumes populated with an empty directory.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.EmptyDirVolumeOptions(
+cdk8s_plus_21.EmptyDirVolumeOptions(
   medium: EmptyDirMedium = None,
   size_limit: Size = None
 )
 ```
 
-##### `medium`<sup>Optional</sup> <a name="cdk8s_plus_22.EmptyDirVolumeOptions.property.medium"></a>
+##### `medium`<sup>Optional</sup> <a name="cdk8s_plus_21.EmptyDirVolumeOptions.property.medium"></a>
 
 ```python
 medium: EmptyDirMedium
 ```
 
-- *Type:* [`cdk8s_plus_22.EmptyDirMedium`](#cdk8s_plus_22.EmptyDirMedium)
+- *Type:* [`cdk8s_plus_21.EmptyDirMedium`](#cdk8s_plus_21.EmptyDirMedium)
 - *Default:* EmptyDirMedium.DEFAULT
 
 By default, emptyDir volumes are stored on whatever medium is backing the node - that might be disk or SSD or network storage, depending on your environment.
@@ -3710,7 +3678,7 @@ against your Container's memory limit.
 
 ---
 
-##### `size_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.EmptyDirVolumeOptions.property.size_limit"></a>
+##### `size_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.EmptyDirVolumeOptions.property.size_limit"></a>
 
 ```python
 size_limit: Size
@@ -3728,21 +3696,21 @@ here and the sum of memory limits of all containers in a pod.
 
 ---
 
-### EnvValueFromConfigMapOptions <a name="cdk8s_plus_22.EnvValueFromConfigMapOptions"></a>
+### EnvValueFromConfigMapOptions <a name="cdk8s_plus_21.EnvValueFromConfigMapOptions"></a>
 
 Options to specify an envionment variable value from a ConfigMap key.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.EnvValueFromConfigMapOptions(
+cdk8s_plus_21.EnvValueFromConfigMapOptions(
   optional: bool = None
 )
 ```
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromConfigMapOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromConfigMapOptions.property.optional"></a>
 
 ```python
 optional: bool
@@ -3755,21 +3723,21 @@ Specify whether the ConfigMap or its key must be defined.
 
 ---
 
-### EnvValueFromProcessOptions <a name="cdk8s_plus_22.EnvValueFromProcessOptions"></a>
+### EnvValueFromProcessOptions <a name="cdk8s_plus_21.EnvValueFromProcessOptions"></a>
 
 Options to specify an environment variable value from the process environment.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.EnvValueFromProcessOptions(
+cdk8s_plus_21.EnvValueFromProcessOptions(
   required: bool = None
 )
 ```
 
-##### `required`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromProcessOptions.property.required"></a>
+##### `required`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromProcessOptions.property.required"></a>
 
 ```python
 required: bool
@@ -3784,21 +3752,21 @@ If this is set to true, and the key does not exist, an error will thrown.
 
 ---
 
-### EnvValueFromSecretOptions <a name="cdk8s_plus_22.EnvValueFromSecretOptions"></a>
+### EnvValueFromSecretOptions <a name="cdk8s_plus_21.EnvValueFromSecretOptions"></a>
 
 Options to specify an environment variable value from a Secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.EnvValueFromSecretOptions(
+cdk8s_plus_21.EnvValueFromSecretOptions(
   optional: bool = None
 )
 ```
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromSecretOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromSecretOptions.property.optional"></a>
 
 ```python
 optional: bool
@@ -3811,16 +3779,16 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="cdk8s_plus_22.ExposeOptions"></a>
+### ExposeOptions <a name="cdk8s_plus_21.ExposeOptions"></a>
 
 Options for exposing a deployment via a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ExposeOptions(
+cdk8s_plus_21.ExposeOptions(
   name: str = None,
   port: typing.Union[int, float] = None,
   protocol: Protocol = None,
@@ -3829,7 +3797,7 @@ cdk8s_plus_22.ExposeOptions(
 )
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.name"></a>
 
 ```python
 name: str
@@ -3844,7 +3812,7 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -3857,13 +3825,13 @@ The port that the service should serve on.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.protocol"></a>
 
 ```python
 protocol: Protocol
 ```
 
-- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
+- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -3872,20 +3840,20 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.service_type"></a>
+##### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.service_type"></a>
 
 ```python
 service_type: ServiceType
 ```
 
-- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
+- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
 - *Default:* ClusterIP.
 
 The type of the exposed service.
 
 ---
 
-##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ExposeOptions.property.target_port"></a>
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ExposeOptions.property.target_port"></a>
 
 ```python
 target_port: typing.Union[int, float]
@@ -3898,16 +3866,16 @@ The port number the service will redirect to.
 
 ---
 
-### HttpGetProbeOptions <a name="cdk8s_plus_22.HttpGetProbeOptions"></a>
+### HttpGetProbeOptions <a name="cdk8s_plus_21.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.HttpGetProbeOptions(
+cdk8s_plus_21.HttpGetProbeOptions(
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
   period_seconds: Duration = None,
@@ -3917,7 +3885,7 @@ cdk8s_plus_22.HttpGetProbeOptions(
 )
 ```
 
-##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.failure_threshold"></a>
+##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.failure_threshold"></a>
 
 ```python
 failure_threshold: typing.Union[int, float]
@@ -3932,7 +3900,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.initial_delay_seconds"></a>
+##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.initial_delay_seconds"></a>
 
 ```python
 initial_delay_seconds: Duration
@@ -3947,7 +3915,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.period_seconds"></a>
+##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.period_seconds"></a>
 
 ```python
 period_seconds: Duration
@@ -3962,7 +3930,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.success_threshold"></a>
+##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.success_threshold"></a>
 
 ```python
 success_threshold: typing.Union[int, float]
@@ -3977,7 +3945,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.timeout_seconds"></a>
+##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.timeout_seconds"></a>
 
 ```python
 timeout_seconds: Duration
@@ -3994,7 +3962,7 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -4007,24 +3975,24 @@ The TCP port to use when sending the GET request.
 
 ---
 
-### IngressProps <a name="cdk8s_plus_22.IngressProps"></a>
+### IngressV1Beta1Props <a name="cdk8s_plus_21.IngressV1Beta1Props"></a>
 
 Properties for `Ingress`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.IngressProps(
+cdk8s_plus_21.IngressV1Beta1Props(
   metadata: ApiObjectMetadata = None,
-  default_backend: IngressBackend = None,
-  rules: typing.List[IngressRule] = None,
-  tls: typing.List[IngressTls] = None
+  default_backend: IngressV1Beta1Backend = None,
+  rules: typing.List[IngressV1Beta1Rule] = None,
+  tls: typing.List[IngressV1Beta1Tls] = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4036,13 +4004,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `default_backend`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.property.default_backend"></a>
+##### `default_backend`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.property.default_backend"></a>
 
 ```python
-default_backend: IngressBackend
+default_backend: IngressV1Beta1Backend
 ```
 
-- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
+- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
 
 The default backend services requests that do not match any rule.
 
@@ -4051,13 +4019,13 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.property.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.property.rules"></a>
 
 ```python
-rules: typing.List[IngressRule]
+rules: typing.List[IngressV1Beta1Rule]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.IngressRule`](#cdk8s_plus_22.IngressRule)]
+- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Rule`](#cdk8s_plus_21.IngressV1Beta1Rule)]
 
 Routing rules for this ingress.
 
@@ -4070,13 +4038,13 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressProps.property.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Props.property.tls"></a>
 
 ```python
-tls: typing.List[IngressTls]
+tls: typing.List[IngressV1Beta1Tls]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.IngressTls`](#cdk8s_plus_22.IngressTls)]
+- *Type:* typing.List[[`cdk8s_plus_21.IngressV1Beta1Tls`](#cdk8s_plus_21.IngressV1Beta1Tls)]
 
 TLS settings for this ingress.
 
@@ -4088,7 +4056,7 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 ---
 
-### IngressRule <a name="cdk8s_plus_22.IngressRule"></a>
+### IngressV1Beta1Rule <a name="cdk8s_plus_21.IngressV1Beta1Rule"></a>
 
 Represents the rules mapping the paths under a specified host to the related backend services.
 
@@ -4098,29 +4066,28 @@ then routed to the backend associated with the matching path.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.IngressRule(
-  backend: IngressBackend,
+cdk8s_plus_21.IngressV1Beta1Rule(
+  backend: IngressV1Beta1Backend,
   host: str = None,
-  path: str = None,
-  path_type: HttpIngressPathType = None
+  path: str = None
 )
 ```
 
-##### `backend`<sup>Required</sup> <a name="cdk8s_plus_22.IngressRule.property.backend"></a>
+##### `backend`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.property.backend"></a>
 
 ```python
-backend: IngressBackend
+backend: IngressV1Beta1Backend
 ```
 
-- *Type:* [`cdk8s_plus_22.IngressBackend`](#cdk8s_plus_22.IngressBackend)
+- *Type:* [`cdk8s_plus_21.IngressV1Beta1Backend`](#cdk8s_plus_21.IngressV1Beta1Backend)
 
 Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ---
 
-##### `host`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.property.host"></a>
+##### `host`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.property.host"></a>
 
 ```python
 host: str
@@ -4142,7 +4109,7 @@ host before the IngressRuleValue.
 
 ---
 
-##### `path`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.property.path"></a>
+##### `path`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Rule.property.path"></a>
 
 ```python
 path: str
@@ -4156,39 +4123,22 @@ Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows
 
 ---
 
-##### `path_type`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressRule.property.path_type"></a>
-
-```python
-path_type: HttpIngressPathType
-```
-
-- *Type:* [`cdk8s_plus_22.HttpIngressPathType`](#cdk8s_plus_22.HttpIngressPathType)
-
-Specify how the path is matched against request paths.
-
-By default, path
-types will be matched by prefix.
-
-> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-
----
-
-### IngressTls <a name="cdk8s_plus_22.IngressTls"></a>
+### IngressV1Beta1Tls <a name="cdk8s_plus_21.IngressV1Beta1Tls"></a>
 
 Represents the TLS configuration mapping that is passed to the ingress controller for SSL termination.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.IngressTls(
+cdk8s_plus_21.IngressV1Beta1Tls(
   hosts: typing.List[str] = None,
   secret: ISecret = None
 )
 ```
 
-##### `hosts`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressTls.property.hosts"></a>
+##### `hosts`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Tls.property.hosts"></a>
 
 ```python
 hosts: typing.List[str]
@@ -4205,13 +4155,13 @@ this list must match the name/s used in the TLS Secret.
 
 ---
 
-##### `secret`<sup>Optional</sup> <a name="cdk8s_plus_22.IngressTls.property.secret"></a>
+##### `secret`<sup>Optional</sup> <a name="cdk8s_plus_21.IngressV1Beta1Tls.property.secret"></a>
 
 ```python
 secret: ISecret
 ```
 
-- *Type:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
+- *Type:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
 - *Default:* If unspecified, it allows SSL routing based on SNI hostname.
 
 Secret is the secret that contains the certificate and key used to terminate SSL traffic on 443.
@@ -4222,16 +4172,16 @@ termination and value of the Host header is used for routing.
 
 ---
 
-### JobProps <a name="cdk8s_plus_22.JobProps"></a>
+### JobProps <a name="cdk8s_plus_21.JobProps"></a>
 
 Properties for initialization of `Job`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.JobProps(
+cdk8s_plus_21.JobProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -4244,7 +4194,7 @@ cdk8s_plus_22.JobProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4256,13 +4206,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4274,13 +4224,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4289,13 +4239,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4311,13 +4261,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4328,7 +4278,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadata
@@ -4340,7 +4290,7 @@ The pod metadata.
 
 ---
 
-##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.active_deadline"></a>
+##### `active_deadline`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.active_deadline"></a>
 
 ```python
 active_deadline: Duration
@@ -4353,7 +4303,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.backoff_limit"></a>
+##### `backoff_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.backoff_limit"></a>
 
 ```python
 backoff_limit: typing.Union[int, float]
@@ -4366,7 +4316,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.ttl_after_finished"></a>
+##### `ttl_after_finished`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.ttl_after_finished"></a>
 
 ```python
 ttl_after_finished: Duration
@@ -4386,16 +4336,16 @@ field is alpha-level and is only honored by servers that enable the
 
 ---
 
-### MountOptions <a name="cdk8s_plus_22.MountOptions"></a>
+### MountOptions <a name="cdk8s_plus_21.MountOptions"></a>
 
 Options for mounts.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.MountOptions(
+cdk8s_plus_21.MountOptions(
   propagation: MountPropagation = None,
   read_only: bool = None,
   sub_path: str = None,
@@ -4403,13 +4353,13 @@ cdk8s_plus_22.MountOptions(
 )
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.propagation"></a>
 
 ```python
 propagation: MountPropagation
 ```
 
-- *Type:* [`cdk8s_plus_22.MountPropagation`](#cdk8s_plus_22.MountPropagation)
+- *Type:* [`cdk8s_plus_21.MountPropagation`](#cdk8s_plus_21.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -4423,7 +4373,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.read_only"></a>
+##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.read_only"></a>
 
 ```python
 read_only: bool
@@ -4438,7 +4388,7 @@ Defaults to false.
 
 ---
 
-##### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.sub_path"></a>
+##### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.sub_path"></a>
 
 ```python
 sub_path: str
@@ -4451,7 +4401,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.sub_path_expr"></a>
+##### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.sub_path_expr"></a>
 
 ```python
 sub_path_expr: str
@@ -4472,22 +4422,22 @@ is beta in 1.15.
 
 ---
 
-### PathMapping <a name="cdk8s_plus_22.PathMapping"></a>
+### PathMapping <a name="cdk8s_plus_21.PathMapping"></a>
 
 Maps a string key to a path within a volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.PathMapping(
+cdk8s_plus_21.PathMapping(
   path: str,
   mode: typing.Union[int, float] = None
 )
 ```
 
-##### `path`<sup>Required</sup> <a name="cdk8s_plus_22.PathMapping.property.path"></a>
+##### `path`<sup>Required</sup> <a name="cdk8s_plus_21.PathMapping.property.path"></a>
 
 ```python
 path: str
@@ -4503,7 +4453,7 @@ path. May not contain the path element '..'. May not start with the string
 
 ---
 
-##### `mode`<sup>Optional</sup> <a name="cdk8s_plus_22.PathMapping.property.mode"></a>
+##### `mode`<sup>Optional</sup> <a name="cdk8s_plus_21.PathMapping.property.mode"></a>
 
 ```python
 mode: typing.Union[int, float]
@@ -4519,16 +4469,16 @@ the result can be other mode bits set.
 
 ---
 
-### PodProps <a name="cdk8s_plus_22.PodProps"></a>
+### PodProps <a name="cdk8s_plus_21.PodProps"></a>
 
 Properties for initialization of `Pod`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.PodProps(
+cdk8s_plus_21.PodProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -4537,7 +4487,7 @@ cdk8s_plus_22.PodProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4549,13 +4499,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4567,13 +4517,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4582,13 +4532,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4604,13 +4554,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4621,16 +4571,16 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodSpecProps <a name="cdk8s_plus_22.PodSpecProps"></a>
+### PodSpecProps <a name="cdk8s_plus_21.PodSpecProps"></a>
 
 Properties of a `PodSpec`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.PodSpecProps(
+cdk8s_plus_21.PodSpecProps(
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
@@ -4638,13 +4588,13 @@ cdk8s_plus_22.PodSpecProps(
 )
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4656,13 +4606,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4671,13 +4621,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4693,13 +4643,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4710,7 +4660,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodTemplateProps <a name="cdk8s_plus_22.PodTemplateProps"></a>
+### PodTemplateProps <a name="cdk8s_plus_21.PodTemplateProps"></a>
 
 Properties of a `PodTemplate`.
 
@@ -4719,9 +4669,9 @@ Adds metadata information on top of the spec.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.PodTemplateProps(
+cdk8s_plus_21.PodTemplateProps(
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
@@ -4730,13 +4680,13 @@ cdk8s_plus_22.PodTemplateProps(
 )
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -4748,13 +4698,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -4763,13 +4713,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -4785,13 +4735,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -4802,7 +4752,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadata
@@ -4814,16 +4764,16 @@ The pod metadata.
 
 ---
 
-### ProbeOptions <a name="cdk8s_plus_22.ProbeOptions"></a>
+### ProbeOptions <a name="cdk8s_plus_21.ProbeOptions"></a>
 
 Probe options.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ProbeOptions(
+cdk8s_plus_21.ProbeOptions(
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
   period_seconds: Duration = None,
@@ -4832,7 +4782,7 @@ cdk8s_plus_22.ProbeOptions(
 )
 ```
 
-##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.failure_threshold"></a>
+##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.failure_threshold"></a>
 
 ```python
 failure_threshold: typing.Union[int, float]
@@ -4847,7 +4797,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.initial_delay_seconds"></a>
+##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.initial_delay_seconds"></a>
 
 ```python
 initial_delay_seconds: Duration
@@ -4862,7 +4812,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.period_seconds"></a>
+##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.period_seconds"></a>
 
 ```python
 period_seconds: Duration
@@ -4877,7 +4827,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.success_threshold"></a>
+##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.success_threshold"></a>
 
 ```python
 success_threshold: typing.Union[int, float]
@@ -4892,7 +4842,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.ProbeOptions.property.timeout_seconds"></a>
+##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.ProbeOptions.property.timeout_seconds"></a>
 
 ```python
 timeout_seconds: Duration
@@ -4909,21 +4859,21 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ResourceProps <a name="cdk8s_plus_22.ResourceProps"></a>
+### ResourceProps <a name="cdk8s_plus_21.ResourceProps"></a>
 
 Initialization properties for resources.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ResourceProps(
+cdk8s_plus_21.ResourceProps(
   metadata: ApiObjectMetadata = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ResourceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ResourceProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4935,21 +4885,21 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-### SecretProps <a name="cdk8s_plus_22.SecretProps"></a>
+### SecretProps <a name="cdk8s_plus_21.SecretProps"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.SecretProps(
+cdk8s_plus_21.SecretProps(
   metadata: ApiObjectMetadata = None,
   string_data: typing.Mapping[str] = None,
   type: str = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -4961,7 +4911,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.string_data"></a>
+##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.string_data"></a>
 
 ```python
 string_data: typing.Mapping[str]
@@ -4978,7 +4928,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.type"></a>
 
 ```python
 type: str
@@ -4994,22 +4944,22 @@ handling of secret data by various controllers.
 
 ---
 
-### SecretValue <a name="cdk8s_plus_22.SecretValue"></a>
+### SecretValue <a name="cdk8s_plus_21.SecretValue"></a>
 
 Represents a specific value in JSON secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.SecretValue(
+cdk8s_plus_21.SecretValue(
   key: str,
   secret: ISecret
 )
 ```
 
-##### `key`<sup>Required</sup> <a name="cdk8s_plus_22.SecretValue.property.key"></a>
+##### `key`<sup>Required</sup> <a name="cdk8s_plus_21.SecretValue.property.key"></a>
 
 ```python
 key: str
@@ -5021,19 +4971,19 @@ The JSON key.
 
 ---
 
-##### `secret`<sup>Required</sup> <a name="cdk8s_plus_22.SecretValue.property.secret"></a>
+##### `secret`<sup>Required</sup> <a name="cdk8s_plus_21.SecretValue.property.secret"></a>
 
 ```python
 secret: ISecret
 ```
 
-- *Type:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
+- *Type:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
 
 The secret.
 
 ---
 
-### ServiceAccountProps <a name="cdk8s_plus_22.ServiceAccountProps"></a>
+### ServiceAccountProps <a name="cdk8s_plus_21.ServiceAccountProps"></a>
 
 Properties for initialization of `ServiceAccount`.
 
@@ -5042,15 +4992,15 @@ Properties for initialization of `ServiceAccount`.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ServiceAccountProps(
+cdk8s_plus_21.ServiceAccountProps(
   metadata: ApiObjectMetadata = None,
   secrets: typing.List[ISecret] = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -5062,13 +5012,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountProps.property.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountProps.property.secrets"></a>
 
 ```python
 secrets: typing.List[ISecret]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)]
+- *Type:* typing.List[[`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)]
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -5076,21 +5026,21 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 ---
 
-### ServiceIngressBackendOptions <a name="cdk8s_plus_22.ServiceIngressBackendOptions"></a>
+### ServiceIngressV1BetaBackendOptions <a name="cdk8s_plus_21.ServiceIngressV1BetaBackendOptions"></a>
 
 Options for setting up backends for ingress rules.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ServiceIngressBackendOptions(
+cdk8s_plus_21.ServiceIngressV1BetaBackendOptions(
   port: typing.Union[int, float] = None
 )
 ```
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceIngressBackendOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceIngressV1BetaBackendOptions.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -5108,16 +5058,16 @@ This option will fail if the service does not expose any ports.
 
 ---
 
-### ServicePort <a name="cdk8s_plus_22.ServicePort"></a>
+### ServicePort <a name="cdk8s_plus_21.ServicePort"></a>
 
 Definition of a service port.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ServicePort(
+cdk8s_plus_21.ServicePort(
   name: str = None,
   node_port: typing.Union[int, float] = None,
   protocol: Protocol = None,
@@ -5126,7 +5076,7 @@ cdk8s_plus_22.ServicePort(
 )
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePort.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePort.property.name"></a>
 
 ```python
 name: str
@@ -5143,7 +5093,7 @@ on this service.
 
 ---
 
-##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePort.property.node_port"></a>
+##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePort.property.node_port"></a>
 
 ```python
 node_port: typing.Union[int, float]
@@ -5163,13 +5113,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePort.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePort.property.protocol"></a>
 
 ```python
 protocol: Protocol
 ```
 
-- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
+- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -5178,7 +5128,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePort.property.target_port"></a>
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePort.property.target_port"></a>
 
 ```python
 target_port: typing.Union[int, float]
@@ -5191,7 +5141,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Required</sup> <a name="cdk8s_plus_22.ServicePort.property.port"></a>
+##### `port`<sup>Required</sup> <a name="cdk8s_plus_21.ServicePort.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -5203,14 +5153,14 @@ The port number the service will bind to.
 
 ---
 
-### ServicePortOptions <a name="cdk8s_plus_22.ServicePortOptions"></a>
+### ServicePortOptions <a name="cdk8s_plus_21.ServicePortOptions"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ServicePortOptions(
+cdk8s_plus_21.ServicePortOptions(
   name: str = None,
   node_port: typing.Union[int, float] = None,
   protocol: Protocol = None,
@@ -5218,7 +5168,7 @@ cdk8s_plus_22.ServicePortOptions(
 )
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.property.name"></a>
 
 ```python
 name: str
@@ -5235,7 +5185,7 @@ on this service.
 
 ---
 
-##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.property.node_port"></a>
+##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.property.node_port"></a>
 
 ```python
 node_port: typing.Union[int, float]
@@ -5255,13 +5205,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.property.protocol"></a>
 
 ```python
 protocol: Protocol
 ```
 
-- *Type:* [`cdk8s_plus_22.Protocol`](#cdk8s_plus_22.Protocol)
+- *Type:* [`cdk8s_plus_21.Protocol`](#cdk8s_plus_21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -5270,7 +5220,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServicePortOptions.property.target_port"></a>
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServicePortOptions.property.target_port"></a>
 
 ```python
 target_port: typing.Union[int, float]
@@ -5283,16 +5233,16 @@ The port number the service will redirect to.
 
 ---
 
-### ServiceProps <a name="cdk8s_plus_22.ServiceProps"></a>
+### ServiceProps <a name="cdk8s_plus_21.ServiceProps"></a>
 
 Properties for initialization of `Service`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.ServiceProps(
+cdk8s_plus_21.ServiceProps(
   metadata: ApiObjectMetadata = None,
   cluster_i_p: str = None,
   external_i_ps: typing.List[str] = None,
@@ -5303,7 +5253,7 @@ cdk8s_plus_22.ServiceProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -5315,7 +5265,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.cluster_i_p"></a>
+##### `cluster_i_p`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.cluster_i_p"></a>
 
 ```python
 cluster_i_p: str
@@ -5337,7 +5287,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `external_i_ps`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.external_i_ps"></a>
+##### `external_i_ps`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.external_i_ps"></a>
 
 ```python
 external_i_ps: typing.List[str]
@@ -5355,7 +5305,7 @@ Kubernetes system.
 
 ---
 
-##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.external_name"></a>
+##### `external_name`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.external_name"></a>
 
 ```python
 external_name: str
@@ -5368,7 +5318,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `load_balancer_source_ranges`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.load_balancer_source_ranges"></a>
+##### `load_balancer_source_ranges`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.load_balancer_source_ranges"></a>
 
 ```python
 load_balancer_source_ranges: typing.List[str]
@@ -5382,13 +5332,13 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.ports"></a>
 
 ```python
 ports: typing.List[ServicePort]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ServicePort`](#cdk8s_plus_22.ServicePort)]
+- *Type:* typing.List[[`cdk8s_plus_21.ServicePort`](#cdk8s_plus_21.ServicePort)]
 
 The port exposed by this service.
 
@@ -5396,13 +5346,13 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceProps.property.type"></a>
 
 ```python
 type: ServiceType
 ```
 
-- *Type:* [`cdk8s_plus_22.ServiceType`](#cdk8s_plus_22.ServiceType)
+- *Type:* [`cdk8s_plus_21.ServiceType`](#cdk8s_plus_21.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -5411,16 +5361,16 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 ---
 
-### StatefulSetProps <a name="cdk8s_plus_22.StatefulSetProps"></a>
+### StatefulSetProps <a name="cdk8s_plus_21.StatefulSetProps"></a>
 
 Properties for initialization of `StatefulSet`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.StatefulSetProps(
+cdk8s_plus_21.StatefulSetProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -5434,7 +5384,7 @@ cdk8s_plus_22.StatefulSetProps(
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -5446,13 +5396,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.containers"></a>
 
 ```python
 containers: typing.List[ContainerProps]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -5464,13 +5414,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -5479,13 +5429,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -5501,13 +5451,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -5518,7 +5468,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadata
@@ -5530,19 +5480,19 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.service"></a>
+##### `service`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.service"></a>
 
 ```python
 service: Service
 ```
 
-- *Type:* [`cdk8s_plus_22.Service`](#cdk8s_plus_22.Service)
+- *Type:* [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.default_selector"></a>
+##### `default_selector`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.default_selector"></a>
 
 ```python
 default_selector: bool
@@ -5558,20 +5508,20 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `pod_management_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.pod_management_policy"></a>
+##### `pod_management_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.pod_management_policy"></a>
 
 ```python
 pod_management_policy: PodManagementPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.PodManagementPolicy`](#cdk8s_plus_22.PodManagementPolicy)
+- *Type:* [`cdk8s_plus_21.PodManagementPolicy`](#cdk8s_plus_21.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.replicas"></a>
 
 ```python
 replicas: typing.Union[int, float]
@@ -5584,16 +5534,16 @@ Number of desired pods.
 
 ---
 
-### VolumeMount <a name="cdk8s_plus_22.VolumeMount"></a>
+### VolumeMount <a name="cdk8s_plus_21.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.VolumeMount(
+cdk8s_plus_21.VolumeMount(
   propagation: MountPropagation = None,
   read_only: bool = None,
   sub_path: str = None,
@@ -5603,13 +5553,13 @@ cdk8s_plus_22.VolumeMount(
 )
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.propagation"></a>
 
 ```python
 propagation: MountPropagation
 ```
 
-- *Type:* [`cdk8s_plus_22.MountPropagation`](#cdk8s_plus_22.MountPropagation)
+- *Type:* [`cdk8s_plus_21.MountPropagation`](#cdk8s_plus_21.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -5623,7 +5573,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.read_only"></a>
+##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.read_only"></a>
 
 ```python
 read_only: bool
@@ -5638,7 +5588,7 @@ Defaults to false.
 
 ---
 
-##### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.sub_path"></a>
+##### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.sub_path"></a>
 
 ```python
 sub_path: str
@@ -5651,7 +5601,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.sub_path_expr"></a>
+##### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.sub_path_expr"></a>
 
 ```python
 sub_path_expr: str
@@ -5672,7 +5622,7 @@ is beta in 1.15.
 
 ---
 
-##### `path`<sup>Required</sup> <a name="cdk8s_plus_22.VolumeMount.property.path"></a>
+##### `path`<sup>Required</sup> <a name="cdk8s_plus_21.VolumeMount.property.path"></a>
 
 ```python
 path: str
@@ -5687,13 +5637,13 @@ contain ':'.
 
 ---
 
-##### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.VolumeMount.property.volume"></a>
+##### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.VolumeMount.property.volume"></a>
 
 ```python
 volume: Volume
 ```
 
-- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
+- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
 
 The volume to mount.
 
@@ -5701,16 +5651,16 @@ The volume to mount.
 
 ## Classes <a name="Classes"></a>
 
-### Container <a name="cdk8s_plus_22.Container"></a>
+### Container <a name="cdk8s_plus_21.Container"></a>
 
 A single application container that you want to run within a pod.
 
-#### Initializers <a name="cdk8s_plus_22.Container.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Container.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Container(
+cdk8s_plus_21.Container(
   image: str,
   args: typing.List[str] = None,
   command: typing.List[str] = None,
@@ -5726,7 +5676,7 @@ cdk8s_plus_22.Container(
 )
 ```
 
-##### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -5734,7 +5684,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -5753,7 +5703,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -5767,9 +5717,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
+##### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -5778,18 +5728,18 @@ Cannot be updated.
 
 ---
 
-##### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
+##### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -5798,7 +5748,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -5809,7 +5759,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -5820,18 +5770,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -5840,9 +5790,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
+##### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -5850,7 +5800,7 @@ Cannot be updated.
 
 ---
 
-##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
+##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -5863,7 +5813,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 #### Methods <a name="Methods"></a>
 
-##### `add_env` <a name="cdk8s_plus_22.Container.add_env"></a>
+##### `add_env` <a name="cdk8s_plus_21.Container.add_env"></a>
 
 ```python
 def add_env(
@@ -5872,7 +5822,7 @@ def add_env(
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Container.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -5880,15 +5830,15 @@ The variable name.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.Container.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.value"></a>
 
-- *Type:* [`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)
+- *Type:* [`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)
 
 The variable value.
 
 ---
 
-##### `mount` <a name="cdk8s_plus_22.Container.mount"></a>
+##### `mount` <a name="cdk8s_plus_21.Container.mount"></a>
 
 ```python
 def mount(
@@ -5901,7 +5851,7 @@ def mount(
 )
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s_plus_22.Container.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.path"></a>
 
 - *Type:* `str`
 
@@ -5909,17 +5859,17 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.Container.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
+- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
 
 The volume to mount.
 
 ---
 
-###### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.propagation"></a>
+###### `propagation`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.propagation"></a>
 
-- *Type:* [`cdk8s_plus_22.MountPropagation`](#cdk8s_plus_22.MountPropagation)
+- *Type:* [`cdk8s_plus_21.MountPropagation`](#cdk8s_plus_21.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -5933,7 +5883,7 @@ This field is beta in 1.10.
 
 ---
 
-###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.read_only"></a>
+###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.read_only"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -5944,7 +5894,7 @@ Defaults to false.
 
 ---
 
-###### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.sub_path"></a>
+###### `sub_path`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.sub_path"></a>
 
 - *Type:* `str`
 - *Default:* "" the volume's root
@@ -5953,7 +5903,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-###### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.sub_path_expr"></a>
+###### `sub_path_expr`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.sub_path_expr"></a>
 
 - *Type:* `str`
 - *Default:* "" volume's root.
@@ -5973,13 +5923,13 @@ is beta in 1.15.
 
 #### Properties <a name="Properties"></a>
 
-##### `env`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.env"></a>
+##### `env`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.env"></a>
 
 ```python
 env: typing.Mapping[EnvValue]
 ```
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 
 The environment variables for this container.
 
@@ -5987,7 +5937,7 @@ Returns a copy. To add environment variables use `addEnv()`.
 
 ---
 
-##### `image`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.image"></a>
 
 ```python
 image: str
@@ -5999,31 +5949,31 @@ The container image.
 
 ---
 
-##### `image_pull_policy`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.image_pull_policy"></a>
+##### `image_pull_policy`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.image_pull_policy"></a>
 
 ```python
 image_pull_policy: ImagePullPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 
 Image pull policy for this container.
 
 ---
 
-##### `mounts`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.mounts"></a>
+##### `mounts`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.mounts"></a>
 
 ```python
 mounts: typing.List[VolumeMount]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Volume mounts configured for this container.
 
 ---
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Container.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Container.property.name"></a>
 
 ```python
 name: str
@@ -6035,7 +5985,7 @@ The name of the container.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.Container.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.Container.property.args"></a>
 
 ```python
 args: typing.List[str]
@@ -6047,7 +5997,7 @@ Arguments to the entrypoint.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.Container.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.Container.property.command"></a>
 
 ```python
 command: typing.List[str]
@@ -6059,7 +6009,7 @@ Entrypoint array (the command to execute when the container starts).
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.Container.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.Container.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -6071,7 +6021,7 @@ The port this container exposes.
 
 ---
 
-##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.Container.property.working_dir"></a>
+##### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.Container.property.working_dir"></a>
 
 ```python
 working_dir: str
@@ -6084,34 +6034,34 @@ The working directory inside the container.
 ---
 
 
-### EnvValue <a name="cdk8s_plus_22.EnvValue"></a>
+### EnvValue <a name="cdk8s_plus_21.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_config_map` <a name="cdk8s_plus_22.EnvValue.from_config_map"></a>
+##### `from_config_map` <a name="cdk8s_plus_21.EnvValue.from_config_map"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.EnvValue.from_config_map(
+cdk8s_plus_21.EnvValue.from_config_map(
   config_map: IConfigMap,
   key: str,
   optional: bool = None
 )
 ```
 
-###### `config_map`<sup>Required</sup> <a name="cdk8s_plus_22.EnvValue.parameter.config_map"></a>
+###### `config_map`<sup>Required</sup> <a name="cdk8s_plus_21.EnvValue.parameter.config_map"></a>
 
-- *Type:* [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap)
+- *Type:* [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
 
 The config map.
 
 ---
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.EnvValue.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -6119,7 +6069,7 @@ The key to extract the value from.
 
 ---
 
-###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromConfigMapOptions.parameter.optional"></a>
+###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromConfigMapOptions.parameter.optional"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -6128,18 +6078,18 @@ Specify whether the ConfigMap or its key must be defined.
 
 ---
 
-##### `from_process` <a name="cdk8s_plus_22.EnvValue.from_process"></a>
+##### `from_process` <a name="cdk8s_plus_21.EnvValue.from_process"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.EnvValue.from_process(
+cdk8s_plus_21.EnvValue.from_process(
   key: str,
   required: bool = None
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.EnvValue.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -6147,7 +6097,7 @@ The key to read.
 
 ---
 
-###### `required`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromProcessOptions.parameter.required"></a>
+###### `required`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromProcessOptions.parameter.required"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -6158,19 +6108,19 @@ If this is set to true, and the key does not exist, an error will thrown.
 
 ---
 
-##### `from_secret_value` <a name="cdk8s_plus_22.EnvValue.from_secret_value"></a>
+##### `from_secret_value` <a name="cdk8s_plus_21.EnvValue.from_secret_value"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.EnvValue.from_secret_value(
+cdk8s_plus_21.EnvValue.from_secret_value(
   key: str,
   secret: ISecret,
   optional: bool = None
 )
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s_plus_22.SecretValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s_plus_21.SecretValue.parameter.key"></a>
 
 - *Type:* `str`
 
@@ -6178,15 +6128,15 @@ The JSON key.
 
 ---
 
-###### `secret`<sup>Required</sup> <a name="cdk8s_plus_22.SecretValue.parameter.secret"></a>
+###### `secret`<sup>Required</sup> <a name="cdk8s_plus_21.SecretValue.parameter.secret"></a>
 
-- *Type:* [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
+- *Type:* [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
 
 The secret.
 
 ---
 
-###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValueFromSecretOptions.parameter.optional"></a>
+###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValueFromSecretOptions.parameter.optional"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -6195,17 +6145,17 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-##### `from_value` <a name="cdk8s_plus_22.EnvValue.from_value"></a>
+##### `from_value` <a name="cdk8s_plus_21.EnvValue.from_value"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.EnvValue.from_value(
+cdk8s_plus_21.EnvValue.from_value(
   value: str
 )
 ```
 
-###### `value`<sup>Required</sup> <a name="cdk8s_plus_22.EnvValue.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s_plus_21.EnvValue.parameter.value"></a>
 
 - *Type:* `str`
 
@@ -6215,7 +6165,7 @@ The value.
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValue.property.value"></a>
+##### `value`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValue.property.value"></a>
 
 ```python
 value: typing.Any
@@ -6225,7 +6175,7 @@ value: typing.Any
 
 ---
 
-##### `value_from`<sup>Optional</sup> <a name="cdk8s_plus_22.EnvValue.property.value_from"></a>
+##### `value_from`<sup>Optional</sup> <a name="cdk8s_plus_21.EnvValue.property.value_from"></a>
 
 ```python
 value_from: typing.Any
@@ -6236,33 +6186,33 @@ value_from: typing.Any
 ---
 
 
-### IngressBackend <a name="cdk8s_plus_22.IngressBackend"></a>
+### IngressV1Beta1Backend <a name="cdk8s_plus_21.IngressV1Beta1Backend"></a>
 
 The backend for an ingress path.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_service` <a name="cdk8s_plus_22.IngressBackend.from_service"></a>
+##### `from_service` <a name="cdk8s_plus_21.IngressV1Beta1Backend.from_service"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.IngressBackend.from_service(
+cdk8s_plus_21.IngressV1Beta1Backend.from_service(
   service: Service,
   port: typing.Union[int, float] = None
 )
 ```
 
-###### `service`<sup>Required</sup> <a name="cdk8s_plus_22.IngressBackend.parameter.service"></a>
+###### `service`<sup>Required</sup> <a name="cdk8s_plus_21.IngressV1Beta1Backend.parameter.service"></a>
 
-- *Type:* [`cdk8s_plus_22.Service`](#cdk8s_plus_22.Service)
+- *Type:* [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service)
 
 The service object.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceIngressBackendOptions.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceIngressV1BetaBackendOptions.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* if the service exposes a single port, this port will be used.
@@ -6278,18 +6228,18 @@ This option will fail if the service does not expose any ports.
 
 
 
-### PodSpec <a name="cdk8s_plus_22.PodSpec"></a>
+### PodSpec <a name="cdk8s_plus_21.PodSpec"></a>
 
-- *Implements:* [`cdk8s_plus_22.IPodSpec`](#cdk8s_plus_22.IPodSpec)
+- *Implements:* [`cdk8s_plus_21.IPodSpec`](#cdk8s_plus_21.IPodSpec)
 
 Provides read/write capabilities ontop of a `PodSpecProps`.
 
-#### Initializers <a name="cdk8s_plus_22.PodSpec.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.PodSpec.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.PodSpec(
+cdk8s_plus_21.PodSpec(
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
@@ -6297,9 +6247,9 @@ cdk8s_plus_22.PodSpec(
 )
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -6311,9 +6261,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -6322,9 +6272,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -6340,9 +6290,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -6355,7 +6305,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_22.PodSpec.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_21.PodSpec.add_container"></a>
 
 ```python
 def add_container(
@@ -6374,7 +6324,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -6382,7 +6332,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -6401,7 +6351,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -6415,9 +6365,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -6426,18 +6376,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -6446,7 +6396,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -6457,7 +6407,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -6468,18 +6418,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -6488,9 +6438,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -6498,7 +6448,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -6509,7 +6459,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_22.PodSpec.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_21.PodSpec.add_volume"></a>
 
 ```python
 def add_volume(
@@ -6517,22 +6467,22 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.PodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.PodSpec.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
+- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.PodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.PodSpec.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
+- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
 
 The containers belonging to the pod.
 
@@ -6540,13 +6490,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.PodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.PodSpec.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 
 The volumes associated with this pod.
 
@@ -6554,43 +6504,43 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpec.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpec.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpec.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpec.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### PodTemplate <a name="cdk8s_plus_22.PodTemplate"></a>
+### PodTemplate <a name="cdk8s_plus_21.PodTemplate"></a>
 
-- *Implements:* [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
+- *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
 
 Provides read/write capabilities ontop of a `PodTemplateProps`.
 
-#### Initializers <a name="cdk8s_plus_22.PodTemplate.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.PodTemplate.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.PodTemplate(
+cdk8s_plus_21.PodTemplate(
   containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
@@ -6599,9 +6549,9 @@ cdk8s_plus_22.PodTemplate(
 )
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.containers"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.ContainerProps`](#cdk8s_plus_22.ContainerProps)]
+- *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -6613,9 +6563,9 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.restart_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -6624,9 +6574,9 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.service_account"></a>
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -6642,9 +6592,9 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.volumes"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -6655,7 +6605,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.pod_metadata"></a>
+##### `pod_metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.pod_metadata"></a>
 
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
@@ -6667,7 +6617,7 @@ The pod metadata.
 
 #### Properties <a name="Properties"></a>
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.PodTemplate.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.PodTemplate.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -6680,27 +6630,27 @@ Provides read/write access to the underlying pod metadata of the resource.
 ---
 
 
-### Probe <a name="cdk8s_plus_22.Probe"></a>
+### Probe <a name="cdk8s_plus_21.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 
-#### Initializers <a name="cdk8s_plus_22.Probe.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Probe.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Probe()
+cdk8s_plus_21.Probe()
 ```
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_command` <a name="cdk8s_plus_22.Probe.from_command"></a>
+##### `from_command` <a name="cdk8s_plus_21.Probe.from_command"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Probe.from_command(
+cdk8s_plus_21.Probe.from_command(
   command: typing.List[str],
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
@@ -6710,7 +6660,7 @@ cdk8s_plus_22.Probe.from_command(
 )
 ```
 
-###### `command`<sup>Required</sup> <a name="cdk8s_plus_22.Probe.parameter.command"></a>
+###### `command`<sup>Required</sup> <a name="cdk8s_plus_21.Probe.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 
@@ -6718,7 +6668,7 @@ The command to execute.
 
 ---
 
-###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.failure_threshold"></a>
+###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.failure_threshold"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 3
@@ -6729,7 +6679,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.initial_delay_seconds"></a>
+###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.initial_delay_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* immediate
@@ -6740,7 +6690,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.period_seconds"></a>
+###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.period_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* Duration.seconds(10) Minimum value is 1.
@@ -6751,7 +6701,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.success_threshold"></a>
+###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.success_threshold"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 1 Must be 1 for liveness and startup. Minimum value is 1.
@@ -6762,7 +6712,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.CommandProbeOptions.parameter.timeout_seconds"></a>
+###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.CommandProbeOptions.parameter.timeout_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* Duration.seconds(1)
@@ -6775,12 +6725,12 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-##### `from_http_get` <a name="cdk8s_plus_22.Probe.from_http_get"></a>
+##### `from_http_get` <a name="cdk8s_plus_21.Probe.from_http_get"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Probe.from_http_get(
+cdk8s_plus_21.Probe.from_http_get(
   path: str,
   failure_threshold: typing.Union[int, float] = None,
   initial_delay_seconds: Duration = None,
@@ -6791,7 +6741,7 @@ cdk8s_plus_22.Probe.from_http_get(
 )
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s_plus_22.Probe.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_21.Probe.parameter.path"></a>
 
 - *Type:* `str`
 
@@ -6799,7 +6749,7 @@ The URL path to hit.
 
 ---
 
-###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.failure_threshold"></a>
+###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.failure_threshold"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 3
@@ -6810,7 +6760,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.initial_delay_seconds"></a>
+###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.initial_delay_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* immediate
@@ -6821,7 +6771,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.period_seconds"></a>
+###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.period_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* Duration.seconds(10) Minimum value is 1.
@@ -6832,7 +6782,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.success_threshold"></a>
+###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.success_threshold"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 1 Must be 1 for liveness and startup. Minimum value is 1.
@@ -6843,7 +6793,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.timeout_seconds"></a>
+###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.timeout_seconds"></a>
 
 - *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
 - *Default:* Duration.seconds(1)
@@ -6856,7 +6806,7 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.HttpGetProbeOptions.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.HttpGetProbeOptions.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* defaults to `container.port`.
@@ -6867,7 +6817,7 @@ The TCP port to use when sending the GET request.
 
 
 
-### Volume <a name="cdk8s_plus_22.Volume"></a>
+### Volume <a name="cdk8s_plus_21.Volume"></a>
 
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
@@ -6900,24 +6850,24 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
-#### Initializers <a name="cdk8s_plus_22.Volume.Initializer"></a>
+#### Initializers <a name="cdk8s_plus_21.Volume.Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Volume(
+cdk8s_plus_21.Volume(
   name: str,
   config: typing.Any
 )
 ```
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.parameter.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.name"></a>
 
 - *Type:* `str`
 
 ---
 
-##### `config`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.parameter.config"></a>
+##### `config`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.config"></a>
 
 - *Type:* `typing.Any`
 
@@ -6926,12 +6876,12 @@ cdk8s_plus_22.Volume(
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `from_config_map` <a name="cdk8s_plus_22.Volume.from_config_map"></a>
+##### `from_config_map` <a name="cdk8s_plus_21.Volume.from_config_map"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Volume.from_config_map(
+cdk8s_plus_21.Volume.from_config_map(
   config_map: IConfigMap,
   default_mode: typing.Union[int, float] = None,
   items: typing.Mapping[PathMapping] = None,
@@ -6940,15 +6890,15 @@ cdk8s_plus_22.Volume.from_config_map(
 )
 ```
 
-###### `config_map`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.parameter.config_map"></a>
+###### `config_map`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.config_map"></a>
 
-- *Type:* [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap)
+- *Type:* [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
 
 The config map to use to populate the volume.
 
 ---
 
-###### `default_mode`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.parameter.default_mode"></a>
+###### `default_mode`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.parameter.default_mode"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 0644. Directories within the path are not affected by this
@@ -6964,9 +6914,9 @@ file mode, like fsGroup, and the result can be other mode bits set.
 
 ---
 
-###### `items`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.parameter.items"></a>
+###### `items`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.parameter.items"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.PathMapping`](#cdk8s_plus_22.PathMapping)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.PathMapping`](#cdk8s_plus_21.PathMapping)]
 - *Default:* no mapping
 
 If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value.
@@ -6979,7 +6929,7 @@ contain the '..' path or start with '..'.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* auto-generated
@@ -6988,7 +6938,7 @@ The volume name.
 
 ---
 
-###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapVolumeOptions.parameter.optional"></a>
+###### `optional`<sup>Optional</sup> <a name="cdk8s_plus_21.ConfigMapVolumeOptions.parameter.optional"></a>
 
 - *Type:* `bool`
 - *Default:* undocumented
@@ -6997,27 +6947,27 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
-##### `from_empty_dir` <a name="cdk8s_plus_22.Volume.from_empty_dir"></a>
+##### `from_empty_dir` <a name="cdk8s_plus_21.Volume.from_empty_dir"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.Volume.from_empty_dir(
+cdk8s_plus_21.Volume.from_empty_dir(
   name: str,
   medium: EmptyDirMedium = None,
   size_limit: Size = None
 )
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.name"></a>
 
 - *Type:* `str`
 
 ---
 
-###### `medium`<sup>Optional</sup> <a name="cdk8s_plus_22.EmptyDirVolumeOptions.parameter.medium"></a>
+###### `medium`<sup>Optional</sup> <a name="cdk8s_plus_21.EmptyDirVolumeOptions.parameter.medium"></a>
 
-- *Type:* [`cdk8s_plus_22.EmptyDirMedium`](#cdk8s_plus_22.EmptyDirMedium)
+- *Type:* [`cdk8s_plus_21.EmptyDirMedium`](#cdk8s_plus_21.EmptyDirMedium)
 - *Default:* EmptyDirMedium.DEFAULT
 
 By default, emptyDir volumes are stored on whatever medium is backing the node - that might be disk or SSD or network storage, depending on your environment.
@@ -7030,7 +6980,7 @@ against your Container's memory limit.
 
 ---
 
-###### `size_limit`<sup>Optional</sup> <a name="cdk8s_plus_22.EmptyDirVolumeOptions.parameter.size_limit"></a>
+###### `size_limit`<sup>Optional</sup> <a name="cdk8s_plus_21.EmptyDirVolumeOptions.parameter.size_limit"></a>
 
 - *Type:* [`cdk8s.Size`](#cdk8s.Size)
 - *Default:* limit is undefined
@@ -7046,7 +6996,7 @@ here and the sum of memory limits of all containers in a pod.
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.Volume.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.property.name"></a>
 
 ```python
 name: str
@@ -7059,18 +7009,18 @@ name: str
 
 ## Protocols <a name="Protocols"></a>
 
-### IConfigMap <a name="cdk8s_plus_22.IConfigMap"></a>
+### IConfigMap <a name="cdk8s_plus_21.IConfigMap"></a>
 
-- *Extends:* [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource)
+- *Extends:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
 
-- *Implemented By:* [`cdk8s_plus_22.ConfigMap`](#cdk8s_plus_22.ConfigMap), [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap)
+- *Implemented By:* [`cdk8s_plus_21.ConfigMap`](#cdk8s_plus_21.ConfigMap), [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
 
 Represents a config map.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.IConfigMap.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.IConfigMap.property.name"></a>
 
 ```python
 name: str
@@ -7082,9 +7032,9 @@ The Kubernetes name of this resource.
 
 ---
 
-### IPodSpec <a name="cdk8s_plus_22.IPodSpec"></a>
+### IPodSpec <a name="cdk8s_plus_21.IPodSpec"></a>
 
-- *Implemented By:* [`cdk8s_plus_22.Deployment`](#cdk8s_plus_22.Deployment), [`cdk8s_plus_22.Job`](#cdk8s_plus_22.Job), [`cdk8s_plus_22.Pod`](#cdk8s_plus_22.Pod), [`cdk8s_plus_22.PodSpec`](#cdk8s_plus_22.PodSpec), [`cdk8s_plus_22.PodTemplate`](#cdk8s_plus_22.PodTemplate), [`cdk8s_plus_22.StatefulSet`](#cdk8s_plus_22.StatefulSet), [`cdk8s_plus_22.IPodSpec`](#cdk8s_plus_22.IPodSpec), [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
+- *Implemented By:* [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment), [`cdk8s_plus_21.Job`](#cdk8s_plus_21.Job), [`cdk8s_plus_21.Pod`](#cdk8s_plus_21.Pod), [`cdk8s_plus_21.PodSpec`](#cdk8s_plus_21.PodSpec), [`cdk8s_plus_21.PodTemplate`](#cdk8s_plus_21.PodTemplate), [`cdk8s_plus_21.StatefulSet`](#cdk8s_plus_21.StatefulSet), [`cdk8s_plus_21.IPodSpec`](#cdk8s_plus_21.IPodSpec), [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod spec. (e.g `Deployment`, `Job`, `Pod`, ...).
 
@@ -7092,7 +7042,7 @@ Use the `PodSpec` class as an implementation helper.
 
 #### Methods <a name="Methods"></a>
 
-##### `add_container` <a name="cdk8s_plus_22.IPodSpec.add_container"></a>
+##### `add_container` <a name="cdk8s_plus_21.IPodSpec.add_container"></a>
 
 ```python
 def add_container(
@@ -7111,7 +7061,7 @@ def add_container(
 )
 ```
 
-###### `image`<sup>Required</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image"></a>
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image"></a>
 
 - *Type:* `str`
 
@@ -7119,7 +7069,7 @@ Docker image name.
 
 ---
 
-###### `args`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.args"></a>
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.args"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* []
@@ -7138,7 +7088,7 @@ Cannot be updated.
 
 ---
 
-###### `command`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.command"></a>
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.command"></a>
 
 - *Type:* typing.List[`str`]
 - *Default:* The docker image's ENTRYPOINT.
@@ -7152,9 +7102,9 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-###### `env`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.env"></a>
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.env"></a>
 
-- *Type:* typing.Mapping[[`cdk8s_plus_22.EnvValue`](#cdk8s_plus_22.EnvValue)]
+- *Type:* typing.Mapping[[`cdk8s_plus_21.EnvValue`](#cdk8s_plus_21.EnvValue)]
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -7163,18 +7113,18 @@ Cannot be updated.
 
 ---
 
-###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.image_pull_policy"></a>
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.image_pull_policy"></a>
 
-- *Type:* [`cdk8s_plus_22.ImagePullPolicy`](#cdk8s_plus_22.ImagePullPolicy)
+- *Type:* [`cdk8s_plus_21.ImagePullPolicy`](#cdk8s_plus_21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.liveness"></a>
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.liveness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -7183,7 +7133,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* 'main'
@@ -7194,7 +7144,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* No port is exposed.
@@ -7205,18 +7155,18 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.readiness"></a>
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.readiness"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.startup"></a>
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.startup"></a>
 
-- *Type:* [`cdk8s_plus_22.Probe`](#cdk8s_plus_22.Probe)
+- *Type:* [`cdk8s_plus_21.Probe`](#cdk8s_plus_21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -7225,9 +7175,9 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.volume_mounts"></a>
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.volume_mounts"></a>
 
-- *Type:* typing.List[[`cdk8s_plus_22.VolumeMount`](#cdk8s_plus_22.VolumeMount)]
+- *Type:* typing.List[[`cdk8s_plus_21.VolumeMount`](#cdk8s_plus_21.VolumeMount)]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -7235,7 +7185,7 @@ Cannot be updated.
 
 ---
 
-###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_22.ContainerProps.parameter.working_dir"></a>
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_21.ContainerProps.parameter.working_dir"></a>
 
 - *Type:* `str`
 - *Default:* The container runtime's default.
@@ -7246,7 +7196,7 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-##### `add_volume` <a name="cdk8s_plus_22.IPodSpec.add_volume"></a>
+##### `add_volume` <a name="cdk8s_plus_21.IPodSpec.add_volume"></a>
 
 ```python
 def add_volume(
@@ -7254,9 +7204,9 @@ def add_volume(
 )
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_22.IPodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.IPodSpec.parameter.volume"></a>
 
-- *Type:* [`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)
+- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
 
 The volume.
 
@@ -7264,13 +7214,13 @@ The volume.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.IPodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.IPodSpec.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
+- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
 
 The containers belonging to the pod.
 
@@ -7278,13 +7228,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.IPodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.IPodSpec.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 
 The volumes associated with this pod.
 
@@ -7292,35 +7242,35 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.IPodSpec.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.IPodSpec.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.IPodSpec.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.IPodSpec.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-### IPodTemplate <a name="cdk8s_plus_22.IPodTemplate"></a>
+### IPodTemplate <a name="cdk8s_plus_21.IPodTemplate"></a>
 
-- *Extends:* [`cdk8s_plus_22.IPodSpec`](#cdk8s_plus_22.IPodSpec)
+- *Extends:* [`cdk8s_plus_21.IPodSpec`](#cdk8s_plus_21.IPodSpec)
 
-- *Implemented By:* [`cdk8s_plus_22.Deployment`](#cdk8s_plus_22.Deployment), [`cdk8s_plus_22.Job`](#cdk8s_plus_22.Job), [`cdk8s_plus_22.PodTemplate`](#cdk8s_plus_22.PodTemplate), [`cdk8s_plus_22.StatefulSet`](#cdk8s_plus_22.StatefulSet), [`cdk8s_plus_22.IPodTemplate`](#cdk8s_plus_22.IPodTemplate)
+- *Implemented By:* [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment), [`cdk8s_plus_21.Job`](#cdk8s_plus_21.Job), [`cdk8s_plus_21.PodTemplate`](#cdk8s_plus_21.PodTemplate), [`cdk8s_plus_21.StatefulSet`](#cdk8s_plus_21.StatefulSet), [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod template. (e.g `Deployment`, `Job`, ...).
 
@@ -7329,13 +7279,13 @@ Use the `PodTemplate` class as an implementation helper.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s_plus_22.IPodTemplate.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s_plus_21.IPodTemplate.property.containers"></a>
 
 ```python
 containers: typing.List[Container]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Container`](#cdk8s_plus_22.Container)]
+- *Type:* typing.List[[`cdk8s_plus_21.Container`](#cdk8s_plus_21.Container)]
 
 The containers belonging to the pod.
 
@@ -7343,13 +7293,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.IPodTemplate.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_21.IPodTemplate.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
 ```
 
-- *Type:* typing.List[[`cdk8s_plus_22.Volume`](#cdk8s_plus_22.Volume)]
+- *Type:* typing.List[[`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)]
 
 The volumes associated with this pod.
 
@@ -7357,31 +7307,31 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.IPodTemplate.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_21.IPodTemplate.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
 ```
 
-- *Type:* [`cdk8s_plus_22.RestartPolicy`](#cdk8s_plus_22.RestartPolicy)
+- *Type:* [`cdk8s_plus_21.RestartPolicy`](#cdk8s_plus_21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_22.IPodTemplate.property.service_account"></a>
+##### `service_account`<sup>Optional</sup> <a name="cdk8s_plus_21.IPodTemplate.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
 ```
 
-- *Type:* [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_22.IPodTemplate.property.pod_metadata"></a>
+##### `pod_metadata`<sup>Required</sup> <a name="cdk8s_plus_21.IPodTemplate.property.pod_metadata"></a>
 
 ```python
 pod_metadata: ApiObjectMetadataDefinition
@@ -7393,16 +7343,16 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-### IResource <a name="cdk8s_plus_22.IResource"></a>
+### IResource <a name="cdk8s_plus_21.IResource"></a>
 
-- *Implemented By:* [`cdk8s_plus_22.ConfigMap`](#cdk8s_plus_22.ConfigMap), [`cdk8s_plus_22.Deployment`](#cdk8s_plus_22.Deployment), [`cdk8s_plus_22.Ingress`](#cdk8s_plus_22.Ingress), [`cdk8s_plus_22.Job`](#cdk8s_plus_22.Job), [`cdk8s_plus_22.Pod`](#cdk8s_plus_22.Pod), [`cdk8s_plus_22.Resource`](#cdk8s_plus_22.Resource), [`cdk8s_plus_22.Secret`](#cdk8s_plus_22.Secret), [`cdk8s_plus_22.Service`](#cdk8s_plus_22.Service), [`cdk8s_plus_22.ServiceAccount`](#cdk8s_plus_22.ServiceAccount), [`cdk8s_plus_22.StatefulSet`](#cdk8s_plus_22.StatefulSet), [`cdk8s_plus_22.IConfigMap`](#cdk8s_plus_22.IConfigMap), [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource), [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret), [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Implemented By:* [`cdk8s_plus_21.ConfigMap`](#cdk8s_plus_21.ConfigMap), [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment), [`cdk8s_plus_21.IngressV1Beta1`](#cdk8s_plus_21.IngressV1Beta1), [`cdk8s_plus_21.Job`](#cdk8s_plus_21.Job), [`cdk8s_plus_21.Pod`](#cdk8s_plus_21.Pod), [`cdk8s_plus_21.Resource`](#cdk8s_plus_21.Resource), [`cdk8s_plus_21.Secret`](#cdk8s_plus_21.Secret), [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service), [`cdk8s_plus_21.ServiceAccount`](#cdk8s_plus_21.ServiceAccount), [`cdk8s_plus_21.StatefulSet`](#cdk8s_plus_21.StatefulSet), [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap), [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource), [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret), [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 Represents a resource.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.IResource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.IResource.property.name"></a>
 
 ```python
 name: str
@@ -7414,16 +7364,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### ISecret <a name="cdk8s_plus_22.ISecret"></a>
+### ISecret <a name="cdk8s_plus_21.ISecret"></a>
 
-- *Extends:* [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource)
+- *Extends:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
 
-- *Implemented By:* [`cdk8s_plus_22.Secret`](#cdk8s_plus_22.Secret), [`cdk8s_plus_22.ISecret`](#cdk8s_plus_22.ISecret)
+- *Implemented By:* [`cdk8s_plus_21.Secret`](#cdk8s_plus_21.Secret), [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.ISecret.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.ISecret.property.name"></a>
 
 ```python
 name: str
@@ -7435,16 +7385,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### IServiceAccount <a name="cdk8s_plus_22.IServiceAccount"></a>
+### IServiceAccount <a name="cdk8s_plus_21.IServiceAccount"></a>
 
-- *Extends:* [`cdk8s_plus_22.IResource`](#cdk8s_plus_22.IResource)
+- *Extends:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
 
-- *Implemented By:* [`cdk8s_plus_22.ServiceAccount`](#cdk8s_plus_22.ServiceAccount), [`cdk8s_plus_22.IServiceAccount`](#cdk8s_plus_22.IServiceAccount)
+- *Implemented By:* [`cdk8s_plus_21.ServiceAccount`](#cdk8s_plus_21.ServiceAccount), [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s_plus_22.IServiceAccount.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_21.IServiceAccount.property.name"></a>
 
 ```python
 name: str
@@ -7462,14 +7412,14 @@ The Kubernetes name of this resource.
 
 The medium on which to store the volume.
 
-#### `DEFAULT` <a name="cdk8s_plus_22.EmptyDirMedium.DEFAULT"></a>
+#### `DEFAULT` <a name="cdk8s_plus_21.EmptyDirMedium.DEFAULT"></a>
 
 The default volume of the backing node.
 
 ---
 
 
-#### `MEMORY` <a name="cdk8s_plus_22.EmptyDirMedium.MEMORY"></a>
+#### `MEMORY` <a name="cdk8s_plus_21.EmptyDirMedium.MEMORY"></a>
 
 Mount a tmpfs (RAM-backed filesystem) for you instead.
 
@@ -7480,36 +7430,9 @@ files you write will count against your Container's memory limit.
 ---
 
 
-### HttpIngressPathType <a name="HttpIngressPathType"></a>
-
-Specify how the path is matched against request paths.
-
-> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-
-#### `PREFIX` <a name="cdk8s_plus_22.HttpIngressPathType.PREFIX"></a>
-
-Matches the URL path exactly.
-
----
-
-
-#### `EXACT` <a name="cdk8s_plus_22.HttpIngressPathType.EXACT"></a>
-
-Matches based on a URL path prefix split by '/'.
-
----
-
-
-#### `IMPLEMENTATION_SPECIFIC` <a name="cdk8s_plus_22.HttpIngressPathType.IMPLEMENTATION_SPECIFIC"></a>
-
-Matching is specified by the underlying IngressClass.
-
----
-
-
 ### ImagePullPolicy <a name="ImagePullPolicy"></a>
 
-#### `ALWAYS` <a name="cdk8s_plus_22.ImagePullPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="cdk8s_plus_21.ImagePullPolicy.ALWAYS"></a>
 
 Every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest.
 
@@ -7523,7 +7446,7 @@ the image tag is omitted.
 ---
 
 
-#### `IF_NOT_PRESENT` <a name="cdk8s_plus_22.ImagePullPolicy.IF_NOT_PRESENT"></a>
+#### `IF_NOT_PRESENT` <a name="cdk8s_plus_21.ImagePullPolicy.IF_NOT_PRESENT"></a>
 
 The image is pulled only if it is not already present locally.
 
@@ -7533,7 +7456,7 @@ not :latest
 ---
 
 
-#### `NEVER` <a name="cdk8s_plus_22.ImagePullPolicy.NEVER"></a>
+#### `NEVER` <a name="cdk8s_plus_21.ImagePullPolicy.NEVER"></a>
 
 The image is assumed to exist locally.
 
@@ -7544,7 +7467,7 @@ No attempt is made to pull the image.
 
 ### MountPropagation <a name="MountPropagation"></a>
 
-#### `NONE` <a name="cdk8s_plus_22.MountPropagation.NONE"></a>
+#### `NONE` <a name="cdk8s_plus_21.MountPropagation.NONE"></a>
 
 This volume mount will not receive any subsequent mounts that are mounted to this volume or any of its subdirectories by the host.
 
@@ -7559,7 +7482,7 @@ kernel documentation
 ---
 
 
-#### `HOST_TO_CONTAINER` <a name="cdk8s_plus_22.MountPropagation.HOST_TO_CONTAINER"></a>
+#### `HOST_TO_CONTAINER` <a name="cdk8s_plus_21.MountPropagation.HOST_TO_CONTAINER"></a>
 
 This volume mount will receive all subsequent mounts that are mounted to this volume or any of its subdirectories.
 
@@ -7576,7 +7499,7 @@ kernel documentation
 ---
 
 
-#### `BIDIRECTIONAL` <a name="cdk8s_plus_22.MountPropagation.BIDIRECTIONAL"></a>
+#### `BIDIRECTIONAL` <a name="cdk8s_plus_21.MountPropagation.BIDIRECTIONAL"></a>
 
 This volume mount behaves the same the HostToContainer mount.
 
@@ -7610,29 +7533,29 @@ continuing. When scaling down, the pods are removed in the opposite order.
 The alternative policy is `Parallel` which will create pods in parallel to match the
 desired scale without waiting, and on scale down will delete all pods at once.
 
-#### `ORDERED_READY` <a name="cdk8s_plus_22.PodManagementPolicy.ORDERED_READY"></a>
+#### `ORDERED_READY` <a name="cdk8s_plus_21.PodManagementPolicy.ORDERED_READY"></a>
 
 ---
 
 
-#### `PARALLEL` <a name="cdk8s_plus_22.PodManagementPolicy.PARALLEL"></a>
+#### `PARALLEL` <a name="cdk8s_plus_21.PodManagementPolicy.PARALLEL"></a>
 
 ---
 
 
 ### Protocol <a name="Protocol"></a>
 
-#### `TCP` <a name="cdk8s_plus_22.Protocol.TCP"></a>
+#### `TCP` <a name="cdk8s_plus_21.Protocol.TCP"></a>
 
 ---
 
 
-#### `UDP` <a name="cdk8s_plus_22.Protocol.UDP"></a>
+#### `UDP` <a name="cdk8s_plus_21.Protocol.UDP"></a>
 
 ---
 
 
-#### `SCTP` <a name="cdk8s_plus_22.Protocol.SCTP"></a>
+#### `SCTP` <a name="cdk8s_plus_21.Protocol.SCTP"></a>
 
 ---
 
@@ -7641,21 +7564,21 @@ desired scale without waiting, and on scale down will delete all pods at once.
 
 Restart policy for all containers within the pod.
 
-#### `ALWAYS` <a name="cdk8s_plus_22.RestartPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="cdk8s_plus_21.RestartPolicy.ALWAYS"></a>
 
 Always restart the pod after it exits.
 
 ---
 
 
-#### `ON_FAILURE` <a name="cdk8s_plus_22.RestartPolicy.ON_FAILURE"></a>
+#### `ON_FAILURE` <a name="cdk8s_plus_21.RestartPolicy.ON_FAILURE"></a>
 
 Only restart if the pod exits with a non-zero exit code.
 
 ---
 
 
-#### `NEVER` <a name="cdk8s_plus_22.RestartPolicy.NEVER"></a>
+#### `NEVER` <a name="cdk8s_plus_21.RestartPolicy.NEVER"></a>
 
 Never restart the pod.
 
@@ -7669,7 +7592,7 @@ For some parts of your application (for example, frontends) you may want to expo
 Kubernetes ServiceTypes allow you to specify what kind of Service you want.
 The default is ClusterIP.
 
-#### `CLUSTER_IP` <a name="cdk8s_plus_22.ServiceType.CLUSTER_IP"></a>
+#### `CLUSTER_IP` <a name="cdk8s_plus_21.ServiceType.CLUSTER_IP"></a>
 
 Exposes the Service on a cluster-internal IP.
 
@@ -7679,7 +7602,7 @@ This is the default ServiceType
 ---
 
 
-#### `NODE_PORT` <a name="cdk8s_plus_22.ServiceType.NODE_PORT"></a>
+#### `NODE_PORT` <a name="cdk8s_plus_21.ServiceType.NODE_PORT"></a>
 
 Exposes the Service on each Node's IP at a static port (the NodePort).
 
@@ -7690,7 +7613,7 @@ by requesting <NodeIP>:<NodePort>.
 ---
 
 
-#### `LOAD_BALANCER` <a name="cdk8s_plus_22.ServiceType.LOAD_BALANCER"></a>
+#### `LOAD_BALANCER` <a name="cdk8s_plus_21.ServiceType.LOAD_BALANCER"></a>
 
 Exposes the Service externally using a cloud provider's load balancer.
 
@@ -7700,7 +7623,7 @@ are automatically created.
 ---
 
 
-#### `EXTERNAL_NAME` <a name="cdk8s_plus_22.ServiceType.EXTERNAL_NAME"></a>
+#### `EXTERNAL_NAME` <a name="cdk8s_plus_21.ServiceType.EXTERNAL_NAME"></a>
 
 Maps the Service to the contents of the externalName field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,47 +2,47 @@
 
 ## Constructs <a name="Constructs"></a>
 
-### ConfigMap <a name="cdk8s-plus-21.ConfigMap"></a>
+### ConfigMap <a name="cdk8s-plus-22.ConfigMap"></a>
 
-- *Implements:* [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
+- *Implements:* [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap)
 
 ConfigMap holds configuration data for pods to consume.
 
-#### Initializers <a name="cdk8s-plus-21.ConfigMap.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.ConfigMap.Initializer"></a>
 
 ```typescript
-import { ConfigMap } from 'cdk8s-plus-21'
+import { ConfigMap } from 'cdk8s-plus-22'
 
 new ConfigMap(scope: Construct, id: string, props?: ConfigMapProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.ConfigMapProps`](#cdk8s-plus-21.ConfigMapProps)
+- *Type:* [`cdk8s-plus-22.ConfigMapProps`](#cdk8s-plus-22.ConfigMapProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addBinaryData` <a name="cdk8s-plus-21.ConfigMap.addBinaryData"></a>
+##### `addBinaryData` <a name="cdk8s-plus-22.ConfigMap.addBinaryData"></a>
 
 ```typescript
 public addBinaryData(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -50,7 +50,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -58,13 +58,13 @@ The value.
 
 ---
 
-##### `addData` <a name="cdk8s-plus-21.ConfigMap.addData"></a>
+##### `addData` <a name="cdk8s-plus-22.ConfigMap.addData"></a>
 
 ```typescript
 public addData(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -72,7 +72,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -80,13 +80,13 @@ The value.
 
 ---
 
-##### `addDirectory` <a name="cdk8s-plus-21.ConfigMap.addDirectory"></a>
+##### `addDirectory` <a name="cdk8s-plus-22.ConfigMap.addDirectory"></a>
 
 ```typescript
 public addDirectory(localDir: string, options?: AddDirectoryOptions)
 ```
 
-###### `localDir`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.localDir"></a>
+###### `localDir`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.localDir"></a>
 
 - *Type:* `string`
 
@@ -94,21 +94,21 @@ A path to a local directory.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.AddDirectoryOptions`](#cdk8s-plus-21.AddDirectoryOptions)
+- *Type:* [`cdk8s-plus-22.AddDirectoryOptions`](#cdk8s-plus-22.AddDirectoryOptions)
 
 Options.
 
 ---
 
-##### `addFile` <a name="cdk8s-plus-21.ConfigMap.addFile"></a>
+##### `addFile` <a name="cdk8s-plus-22.ConfigMap.addFile"></a>
 
 ```typescript
 public addFile(localFile: string, key?: string)
 ```
 
-###### `localFile`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.localFile"></a>
+###### `localFile`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.localFile"></a>
 
 - *Type:* `string`
 
@@ -116,7 +116,7 @@ The path to the local file.
 
 ---
 
-###### `key`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.key"></a>
+###### `key`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -126,15 +126,15 @@ The ConfigMap key (default to the file name).
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMapName` <a name="cdk8s-plus-21.ConfigMap.fromConfigMapName"></a>
+##### `fromConfigMapName` <a name="cdk8s-plus-22.ConfigMap.fromConfigMapName"></a>
 
 ```typescript
-import { ConfigMap } from 'cdk8s-plus-21'
+import { ConfigMap } from 'cdk8s-plus-22'
 
 ConfigMap.fromConfigMapName(name: string)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.name"></a>
 
 - *Type:* `string`
 
@@ -144,7 +144,7 @@ The name of the config map to import.
 
 #### Properties <a name="Properties"></a>
 
-##### `binaryData`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.property.binaryData"></a>
+##### `binaryData`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.property.binaryData"></a>
 
 ```typescript
 public readonly binaryData: {[ key: string ]: string};
@@ -158,7 +158,7 @@ Returns a copy. To add data records, use `addBinaryData()` or `addData()`.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.property.data"></a>
+##### `data`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.property.data"></a>
 
 ```typescript
 public readonly data: {[ key: string ]: string};
@@ -173,9 +173,9 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 ---
 
 
-### Deployment <a name="cdk8s-plus-21.Deployment"></a>
+### Deployment <a name="cdk8s-plus-22.Deployment"></a>
 
-- *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
+- *Implements:* [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
 
 A Deployment provides declarative updates for Pods and ReplicaSets.
 
@@ -202,87 +202,79 @@ The following are typical use cases for Deployments:
 - Use the status of the Deployment as an indicator that a rollout has stuck.
 - Clean up older ReplicaSets that you don't need anymore.
 
-#### Initializers <a name="cdk8s-plus-21.Deployment.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Deployment.Initializer"></a>
 
 ```typescript
-import { Deployment } from 'cdk8s-plus-21'
+import { Deployment } from 'cdk8s-plus-22'
 
 new Deployment(scope: Construct, id: string, props?: DeploymentProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Deployment.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Deployment.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.DeploymentProps`](#cdk8s-plus-21.DeploymentProps)
+- *Type:* [`cdk8s-plus-22.DeploymentProps`](#cdk8s-plus-22.DeploymentProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-21.Deployment.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-22.Deployment.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-21.Deployment.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-22.Deployment.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
 
 ---
 
-##### `expose` <a name="cdk8s-plus-21.Deployment.expose"></a>
+##### `expose` <a name="cdk8s-plus-22.Deployment.expose"></a>
 
 ```typescript
-public expose(port: number, options?: ExposeOptions)
+public expose(options?: ExposeOptions)
 ```
 
-###### `port`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.port"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Deployment.parameter.options"></a>
 
-- *Type:* `number`
-
-The port number the service will bind to.
-
----
-
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Deployment.parameter.options"></a>
-
-- *Type:* [`cdk8s-plus-21.ExposeOptions`](#cdk8s-plus-21.ExposeOptions)
+- *Type:* [`cdk8s-plus-22.ExposeOptions`](#cdk8s-plus-22.ExposeOptions)
 
 Options to determine details of the service and port exposed.
 
 ---
 
-##### `selectByLabel` <a name="cdk8s-plus-21.Deployment.selectByLabel"></a>
+##### `selectByLabel` <a name="cdk8s-plus-22.Deployment.selectByLabel"></a>
 
 ```typescript
 public selectByLabel(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -290,7 +282,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -301,13 +293,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
+- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
 
 The containers belonging to the pod.
 
@@ -315,7 +307,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `labelSelector`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.labelSelector"></a>
+##### `labelSelector`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.labelSelector"></a>
 
 ```typescript
 public readonly labelSelector: {[ key: string ]: string};
@@ -329,7 +321,7 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -341,7 +333,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.replicas"></a>
 
 ```typescript
 public readonly replicas: number;
@@ -353,13 +345,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 
 The volumes associated with this pod.
 
@@ -367,32 +359,32 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.Deployment.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.Deployment.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.Deployment.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.Deployment.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### IngressV1Beta1 <a name="cdk8s-plus-21.IngressV1Beta1"></a>
+### Ingress <a name="cdk8s-plus-22.Ingress"></a>
 
 Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend.
 
@@ -400,55 +392,55 @@ An Ingress can be configured to give services
 externally-reachable urls, load balance traffic, terminate SSL, offer name
 based virtual hosting etc.
 
-#### Initializers <a name="cdk8s-plus-21.IngressV1Beta1.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Ingress.Initializer"></a>
 
 ```typescript
-import { IngressV1Beta1 } from 'cdk8s-plus-21'
+import { Ingress } from 'cdk8s-plus-22'
 
-new IngressV1Beta1(scope: Construct, id: string, props?: IngressV1Beta1Props)
+new Ingress(scope: Construct, id: string, props?: IngressProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Ingress.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Props`](#cdk8s-plus-21.IngressV1Beta1Props)
+- *Type:* [`cdk8s-plus-22.IngressProps`](#cdk8s-plus-22.IngressProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addDefaultBackend` <a name="cdk8s-plus-21.IngressV1Beta1.addDefaultBackend"></a>
+##### `addDefaultBackend` <a name="cdk8s-plus-22.Ingress.addDefaultBackend"></a>
 
 ```typescript
-public addDefaultBackend(backend: IngressV1Beta1Backend)
+public addDefaultBackend(backend: IngressBackend)
 ```
 
-###### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.backend"></a>
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
 
 The backend to use for requests that do not match any rule.
 
 ---
 
-##### `addHostDefaultBackend` <a name="cdk8s-plus-21.IngressV1Beta1.addHostDefaultBackend"></a>
+##### `addHostDefaultBackend` <a name="cdk8s-plus-22.Ingress.addHostDefaultBackend"></a>
 
 ```typescript
-public addHostDefaultBackend(host: string, backend: IngressV1Beta1Backend)
+public addHostDefaultBackend(host: string, backend: IngressBackend)
 ```
 
-###### `host`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.host"></a>
 
 - *Type:* `string`
 
@@ -456,21 +448,21 @@ The host name to match.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.backend"></a>
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
 
 The backend to route to.
 
 ---
 
-##### `addHostRule` <a name="cdk8s-plus-21.IngressV1Beta1.addHostRule"></a>
+##### `addHostRule` <a name="cdk8s-plus-22.Ingress.addHostRule"></a>
 
 ```typescript
-public addHostRule(host: string, path: string, backend: IngressV1Beta1Backend)
+public addHostRule(host: string, path: string, backend: IngressBackend, pathType?: HttpIngressPathType)
 ```
 
-###### `host`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.host"></a>
 
 - *Type:* `string`
 
@@ -478,7 +470,7 @@ The host name.
 
 ---
 
-###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.path"></a>
 
 - *Type:* `string`
 
@@ -486,21 +478,29 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.backend"></a>
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
 
 The backend to route requests to.
 
 ---
 
-##### `addRule` <a name="cdk8s-plus-21.IngressV1Beta1.addRule"></a>
+###### `pathType`<sup>Optional</sup> <a name="cdk8s-plus-22.Ingress.parameter.pathType"></a>
+
+- *Type:* [`cdk8s-plus-22.HttpIngressPathType`](#cdk8s-plus-22.HttpIngressPathType)
+
+How the path is matched against request paths.
+
+---
+
+##### `addRule` <a name="cdk8s-plus-22.Ingress.addRule"></a>
 
 ```typescript
-public addRule(path: string, backend: IngressV1Beta1Backend)
+public addRule(path: string, backend: IngressBackend, pathType?: HttpIngressPathType)
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.path"></a>
 
 - *Type:* `string`
 
@@ -508,46 +508,54 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.backend"></a>
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
 
 The backend to route requests to.
 
 ---
 
-##### `addRules` <a name="cdk8s-plus-21.IngressV1Beta1.addRules"></a>
+###### `pathType`<sup>Optional</sup> <a name="cdk8s-plus-22.Ingress.parameter.pathType"></a>
+
+- *Type:* [`cdk8s-plus-22.HttpIngressPathType`](#cdk8s-plus-22.HttpIngressPathType)
+
+How the path is matched against request paths.
+
+---
+
+##### `addRules` <a name="cdk8s-plus-22.Ingress.addRules"></a>
 
 ```typescript
-public addRules(rules: IngressV1Beta1Rule)
+public addRules(rules: IngressRule)
 ```
 
-###### `rules`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.rules"></a>
+###### `rules`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.rules"></a>
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Rule`](#cdk8s-plus-21.IngressV1Beta1Rule)
+- *Type:* [`cdk8s-plus-22.IngressRule`](#cdk8s-plus-22.IngressRule)
 
 The rules to add.
 
 ---
 
-##### `addTls` <a name="cdk8s-plus-21.IngressV1Beta1.addTls"></a>
+##### `addTls` <a name="cdk8s-plus-22.Ingress.addTls"></a>
 
 ```typescript
-public addTls(tls: IngressV1Beta1Tls[])
+public addTls(tls: IngressTls[])
 ```
 
-###### `tls`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.tls"></a>
+###### `tls`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.tls"></a>
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Tls`](#cdk8s-plus-21.IngressV1Beta1Tls)[]
+- *Type:* [`cdk8s-plus-22.IngressTls`](#cdk8s-plus-22.IngressTls)[]
 
 ---
 
 
 
 
-### Job <a name="cdk8s-plus-21.Job"></a>
+### Job <a name="cdk8s-plus-22.Job"></a>
 
-- *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
+- *Implements:* [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
 
 A Job creates one or more Pods and ensures that a specified number of them successfully terminate.
 
@@ -557,68 +565,68 @@ Deleting a Job will clean up the Pods it created. A simple case is to create one
 The Job object will start a new Pod if the first Pod fails or is deleted (for example due to a node hardware failure or a node reboot).
 You can also use a Job to run multiple Pods in parallel.
 
-#### Initializers <a name="cdk8s-plus-21.Job.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Job.Initializer"></a>
 
 ```typescript
-import { Job } from 'cdk8s-plus-21'
+import { Job } from 'cdk8s-plus-22'
 
 new Job(scope: Construct, id: string, props?: JobProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Job.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Job.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.JobProps`](#cdk8s-plus-21.JobProps)
+- *Type:* [`cdk8s-plus-22.JobProps`](#cdk8s-plus-22.JobProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-21.Job.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-22.Job.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.Job.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-21.Job.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-22.Job.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.Job.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.Job.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.Job.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
+- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
 
 The containers belonging to the pod.
 
@@ -626,7 +634,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.Job.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.Job.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -638,13 +646,13 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.Job.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.Job.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 
 The volumes associated with this pod.
 
@@ -652,7 +660,7 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.activeDeadline"></a>
 
 ```typescript
 public readonly activeDeadline: Duration;
@@ -666,7 +674,7 @@ If undefined, there is no deadline.
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.backoffLimit"></a>
 
 ```typescript
 public readonly backoffLimit: number;
@@ -678,31 +686,31 @@ Number of retries before marking failed.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.ttlAfterFinished"></a>
 
 ```typescript
 public readonly ttlAfterFinished: Duration;
@@ -715,77 +723,77 @@ TTL before the job is deleted after it is finished.
 ---
 
 
-### Pod <a name="cdk8s-plus-21.Pod"></a>
+### Pod <a name="cdk8s-plus-22.Pod"></a>
 
-- *Implements:* [`cdk8s-plus-21.IPodSpec`](#cdk8s-plus-21.IPodSpec)
+- *Implements:* [`cdk8s-plus-22.IPodSpec`](#cdk8s-plus-22.IPodSpec)
 
 Pod is a collection of containers that can run on a host.
 
 This resource is
 created by clients and scheduled onto hosts.
 
-#### Initializers <a name="cdk8s-plus-21.Pod.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Pod.Initializer"></a>
 
 ```typescript
-import { Pod } from 'cdk8s-plus-21'
+import { Pod } from 'cdk8s-plus-22'
 
 new Pod(scope: Construct, id: string, props?: PodProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Pod.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Pod.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.PodProps`](#cdk8s-plus-21.PodProps)
+- *Type:* [`cdk8s-plus-22.PodProps`](#cdk8s-plus-22.PodProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-21.Pod.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-22.Pod.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-21.Pod.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-22.Pod.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
+- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
 
 The containers belonging to the pod.
 
@@ -793,13 +801,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 
 The volumes associated with this pod.
 
@@ -807,49 +815,49 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.Pod.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.Pod.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.Pod.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.Pod.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Resource <a name="cdk8s-plus-21.Resource"></a>
+### Resource <a name="cdk8s-plus-22.Resource"></a>
 
-- *Implements:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
+- *Implements:* [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource)
 
 Base class for all Kubernetes objects in stdk8s.
 
 Represents a single
 resource.
 
-#### Initializers <a name="cdk8s-plus-21.Resource.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Resource.Initializer"></a>
 
 ```typescript
-import { Resource } from 'cdk8s-plus-21'
+import { Resource } from 'cdk8s-plus-22'
 
 new Resource(scope: Construct, id: string, options?: ConstructOptions)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Resource.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Resource.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
@@ -857,7 +865,7 @@ The scope in which to define this construct.
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Resource.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Resource.parameter.id"></a>
 
 - *Type:* `string`
 
@@ -869,7 +877,7 @@ dash `--`.
 
 ---
 
-##### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Resource.parameter.options"></a>
+##### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Resource.parameter.options"></a>
 
 - *Type:* [`constructs.ConstructOptions`](#constructs.ConstructOptions)
 
@@ -881,7 +889,7 @@ Options.
 
 #### Properties <a name="Properties"></a>
 
-##### `metadata`<sup>Required</sup> <a name="cdk8s-plus-21.Resource.property.metadata"></a>
+##### `metadata`<sup>Required</sup> <a name="cdk8s-plus-22.Resource.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadataDefinition;
@@ -891,7 +899,7 @@ public readonly metadata: ApiObjectMetadataDefinition;
 
 ---
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Resource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Resource.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -904,9 +912,9 @@ The name of this API object.
 ---
 
 
-### Secret <a name="cdk8s-plus-21.Secret"></a>
+### Secret <a name="cdk8s-plus-22.Secret"></a>
 
-- *Implements:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
+- *Implements:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
 
 Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 
@@ -916,41 +924,41 @@ definition or in a container image.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
 
-#### Initializers <a name="cdk8s-plus-21.Secret.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Secret.Initializer"></a>
 
 ```typescript
-import { Secret } from 'cdk8s-plus-21'
+import { Secret } from 'cdk8s-plus-22'
 
 new Secret(scope: Construct, id: string, props?: SecretProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Secret.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Secret.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.SecretProps`](#cdk8s-plus-21.SecretProps)
+- *Type:* [`cdk8s-plus-22.SecretProps`](#cdk8s-plus-22.SecretProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addStringData` <a name="cdk8s-plus-21.Secret.addStringData"></a>
+##### `addStringData` <a name="cdk8s-plus-22.Secret.addStringData"></a>
 
 ```typescript
 public addStringData(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -958,7 +966,7 @@ Key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -966,13 +974,13 @@ Value.
 
 ---
 
-##### `getStringData` <a name="cdk8s-plus-21.Secret.getStringData"></a>
+##### `getStringData` <a name="cdk8s-plus-22.Secret.getStringData"></a>
 
 ```typescript
 public getStringData(key: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -982,15 +990,15 @@ Key.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromSecretName` <a name="cdk8s-plus-21.Secret.fromSecretName"></a>
+##### `fromSecretName` <a name="cdk8s-plus-22.Secret.fromSecretName"></a>
 
 ```typescript
-import { Secret } from 'cdk8s-plus-21'
+import { Secret } from 'cdk8s-plus-22'
 
 Secret.fromSecretName(name: string)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.name"></a>
 
 - *Type:* `string`
 
@@ -1000,7 +1008,7 @@ The name of the secret to reference.
 
 
 
-### Service <a name="cdk8s-plus-21.Service"></a>
+### Service <a name="cdk8s-plus-22.Service"></a>
 
 An abstract way to expose an application running on a set of Pods as a network service.
 
@@ -1016,71 +1024,63 @@ If you're able to use Kubernetes APIs for service discovery in your application,
 that get updated whenever the set of Pods in a Service changes. For non-native applications, Kubernetes offers ways to place a network port
 or load balancer in between your application and the backend Pods.
 
-#### Initializers <a name="cdk8s-plus-21.Service.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Service.Initializer"></a>
 
 ```typescript
-import { Service } from 'cdk8s-plus-21'
+import { Service } from 'cdk8s-plus-22'
 
 new Service(scope: Construct, id: string, props?: ServiceProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.ServiceProps`](#cdk8s-plus-21.ServiceProps)
+- *Type:* [`cdk8s-plus-22.ServiceProps`](#cdk8s-plus-22.ServiceProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addDeployment` <a name="cdk8s-plus-21.Service.addDeployment"></a>
+##### `addDeployment` <a name="cdk8s-plus-22.Service.addDeployment"></a>
 
 ```typescript
-public addDeployment(deployment: Deployment, port: number, options?: ServicePortOptions)
+public addDeployment(deployment: Deployment, options?: AddDeploymentOptions)
 ```
 
-###### `deployment`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.deployment"></a>
+###### `deployment`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.deployment"></a>
 
-- *Type:* [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment)
+- *Type:* [`cdk8s-plus-22.Deployment`](#cdk8s-plus-22.Deployment)
 
 The deployment to expose.
 
 ---
 
-###### `port`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.port"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.parameter.options"></a>
 
-- *Type:* `number`
-
-The external port.
-
----
-
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.parameter.options"></a>
-
-- *Type:* [`cdk8s-plus-21.ServicePortOptions`](#cdk8s-plus-21.ServicePortOptions)
+- *Type:* [`cdk8s-plus-22.AddDeploymentOptions`](#cdk8s-plus-22.AddDeploymentOptions)
 
 Optional settings for the port.
 
 ---
 
-##### `addSelector` <a name="cdk8s-plus-21.Service.addSelector"></a>
+##### `addSelector` <a name="cdk8s-plus-22.Service.addSelector"></a>
 
 ```typescript
 public addSelector(label: string, value: string)
 ```
 
-###### `label`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.label"></a>
+###### `label`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.label"></a>
 
 - *Type:* `string`
 
@@ -1088,7 +1088,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -1096,13 +1096,13 @@ The label value.
 
 ---
 
-##### `serve` <a name="cdk8s-plus-21.Service.serve"></a>
+##### `serve` <a name="cdk8s-plus-22.Service.serve"></a>
 
 ```typescript
 public serve(port: number, options?: ServicePortOptions)
 ```
 
-###### `port`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.port"></a>
+###### `port`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.port"></a>
 
 - *Type:* `number`
 
@@ -1110,22 +1110,22 @@ The port definition.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.ServicePortOptions`](#cdk8s-plus-21.ServicePortOptions)
+- *Type:* [`cdk8s-plus-22.ServicePortOptions`](#cdk8s-plus-22.ServicePortOptions)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `ports`<sup>Required</sup> <a name="cdk8s-plus-21.Service.property.ports"></a>
+##### `ports`<sup>Required</sup> <a name="cdk8s-plus-22.Service.property.ports"></a>
 
 ```typescript
 public readonly ports: ServicePort[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ServicePort`](#cdk8s-plus-21.ServicePort)[]
+- *Type:* [`cdk8s-plus-22.ServicePort`](#cdk8s-plus-22.ServicePort)[]
 
 Ports for this service.
 
@@ -1133,7 +1133,7 @@ Use `serve()` to expose additional service ports.
 
 ---
 
-##### `selector`<sup>Required</sup> <a name="cdk8s-plus-21.Service.property.selector"></a>
+##### `selector`<sup>Required</sup> <a name="cdk8s-plus-22.Service.property.selector"></a>
 
 ```typescript
 public readonly selector: {[ key: string ]: string};
@@ -1145,19 +1145,19 @@ Returns the labels which are used to select pods for this service.
 
 ---
 
-##### `type`<sup>Required</sup> <a name="cdk8s-plus-21.Service.property.type"></a>
+##### `type`<sup>Required</sup> <a name="cdk8s-plus-22.Service.property.type"></a>
 
 ```typescript
 public readonly type: ServiceType;
 ```
 
-- *Type:* [`cdk8s-plus-21.ServiceType`](#cdk8s-plus-21.ServiceType)
+- *Type:* [`cdk8s-plus-22.ServiceType`](#cdk8s-plus-22.ServiceType)
 
 Determines how the Service is exposed.
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.property.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.property.clusterIP"></a>
 
 ```typescript
 public readonly clusterIP: string;
@@ -1169,7 +1169,7 @@ The IP address of the service and is usually assigned randomly by the master.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.property.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.property.externalName"></a>
 
 ```typescript
 public readonly externalName: string;
@@ -1182,9 +1182,9 @@ The externalName to be used for EXTERNAL_NAME types.
 ---
 
 
-### ServiceAccount <a name="cdk8s-plus-21.ServiceAccount"></a>
+### ServiceAccount <a name="cdk8s-plus-22.ServiceAccount"></a>
 
-- *Implements:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Implements:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 A service account provides an identity for processes that run in a Pod.
 
@@ -1197,43 +1197,43 @@ example, default).
 
 > https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account
 
-#### Initializers <a name="cdk8s-plus-21.ServiceAccount.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.ServiceAccount.Initializer"></a>
 
 ```typescript
-import { ServiceAccount } from 'cdk8s-plus-21'
+import { ServiceAccount } from 'cdk8s-plus-22'
 
 new ServiceAccount(scope: Construct, id: string, props?: ServiceAccountProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.ServiceAccountProps`](#cdk8s-plus-21.ServiceAccountProps)
+- *Type:* [`cdk8s-plus-22.ServiceAccountProps`](#cdk8s-plus-22.ServiceAccountProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addSecret` <a name="cdk8s-plus-21.ServiceAccount.addSecret"></a>
+##### `addSecret` <a name="cdk8s-plus-22.ServiceAccount.addSecret"></a>
 
 ```typescript
 public addSecret(secret: ISecret)
 ```
 
-###### `secret`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.secret"></a>
+###### `secret`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.secret"></a>
 
-- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
+- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
 
 The secret.
 
@@ -1241,15 +1241,15 @@ The secret.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromServiceAccountName` <a name="cdk8s-plus-21.ServiceAccount.fromServiceAccountName"></a>
+##### `fromServiceAccountName` <a name="cdk8s-plus-22.ServiceAccount.fromServiceAccountName"></a>
 
 ```typescript
-import { ServiceAccount } from 'cdk8s-plus-21'
+import { ServiceAccount } from 'cdk8s-plus-22'
 
 ServiceAccount.fromServiceAccountName(name: string)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.name"></a>
 
 - *Type:* `string`
 
@@ -1259,13 +1259,13 @@ The name of the service account resource.
 
 #### Properties <a name="Properties"></a>
 
-##### `secrets`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.property.secrets"></a>
+##### `secrets`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.property.secrets"></a>
 
 ```typescript
 public readonly secrets: ISecret[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)[]
+- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)[]
 
 List of secrets allowed to be used by pods running using this service account.
 
@@ -1274,9 +1274,9 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
-### StatefulSet <a name="cdk8s-plus-21.StatefulSet"></a>
+### StatefulSet <a name="cdk8s-plus-22.StatefulSet"></a>
 
-- *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
+- *Implements:* [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
 
 StatefulSet is the workload API object used to manage stateful applications.
 
@@ -1303,65 +1303,65 @@ StatefulSets are valuable for applications that require one or more of the follo
 - Ordered, graceful deployment and scaling.
 - Ordered, automated rolling updates.
 
-#### Initializers <a name="cdk8s-plus-21.StatefulSet.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.StatefulSet.Initializer"></a>
 
 ```typescript
-import { StatefulSet } from 'cdk8s-plus-21'
+import { StatefulSet } from 'cdk8s-plus-22'
 
 new StatefulSet(scope: Construct, id: string, props: StatefulSetProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.StatefulSetProps`](#cdk8s-plus-21.StatefulSetProps)
+- *Type:* [`cdk8s-plus-22.StatefulSetProps`](#cdk8s-plus-22.StatefulSetProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-21.StatefulSet.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-22.StatefulSet.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-21.StatefulSet.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-22.StatefulSet.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
 
 ---
 
-##### `selectByLabel` <a name="cdk8s-plus-21.StatefulSet.selectByLabel"></a>
+##### `selectByLabel` <a name="cdk8s-plus-22.StatefulSet.selectByLabel"></a>
 
 ```typescript
 public selectByLabel(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -1369,7 +1369,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -1380,13 +1380,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
+- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
 
 The containers belonging to the pod.
 
@@ -1394,7 +1394,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `labelSelector`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.labelSelector"></a>
+##### `labelSelector`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.labelSelector"></a>
 
 ```typescript
 public readonly labelSelector: {[ key: string ]: string};
@@ -1408,19 +1408,19 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `podManagementPolicy`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.podManagementPolicy"></a>
 
 ```typescript
 public readonly podManagementPolicy: PodManagementPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.PodManagementPolicy`](#cdk8s-plus-21.PodManagementPolicy)
+- *Type:* [`cdk8s-plus-22.PodManagementPolicy`](#cdk8s-plus-22.PodManagementPolicy)
 
 Management policy to use for the set.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -1432,7 +1432,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.replicas"></a>
 
 ```typescript
 public readonly replicas: number;
@@ -1444,13 +1444,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 
 The volumes associated with this pod.
 
@@ -1458,25 +1458,25 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSet.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSet.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSet.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSet.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 The service account used to run this pod.
 
@@ -1485,19 +1485,109 @@ The service account used to run this pod.
 
 ## Structs <a name="Structs"></a>
 
-### AddDirectoryOptions <a name="cdk8s-plus-21.AddDirectoryOptions"></a>
+### AddDeploymentOptions <a name="cdk8s-plus-22.AddDeploymentOptions"></a>
+
+Options to add a deployment to a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { AddDeploymentOptions } from 'cdk8s-plus-22'
+
+const addDeploymentOptions: AddDeploymentOptions = { ... }
+```
+
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* `string`
+
+The name of this port within the service.
+
+This must be a DNS_LABEL. All
+ports within a ServiceSpec must have unique names. This maps to the 'Name'
+field in EndpointPort objects. Optional if only one ServicePort is defined
+on this service.
+
+---
+
+##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.nodePort"></a>
+
+```typescript
+public readonly nodePort: number;
+```
+
+- *Type:* `number`
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
+
+The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
+
+Usually assigned by the system. If specified, it will be
+allocated to the service if unused or else creation of the service will
+fail. Default is to auto-allocate a port if the ServiceType of this Service
+requires one.
+
+> https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.protocol"></a>
+
+```typescript
+public readonly protocol: Protocol;
+```
+
+- *Type:* [`cdk8s-plus-22.Protocol`](#cdk8s-plus-22.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.targetPort"></a>
+
+```typescript
+public readonly targetPort: number;
+```
+
+- *Type:* `number`
+- *Default:* The value of `port` will be used.
+
+The port number the service will redirect to.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.port"></a>
+
+```typescript
+public readonly port: number;
+```
+
+- *Type:* `number`
+- *Default:* Copied from the first container of the deployment.
+
+The port number the service will bind to.
+
+---
+
+### AddDirectoryOptions <a name="cdk8s-plus-22.AddDirectoryOptions"></a>
 
 Options for `configmap.addDirectory()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { AddDirectoryOptions } from 'cdk8s-plus-21'
+import { AddDirectoryOptions } from 'cdk8s-plus-22'
 
 const addDirectoryOptions: AddDirectoryOptions = { ... }
 ```
 
-##### `exclude`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDirectoryOptions.property.exclude"></a>
+##### `exclude`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDirectoryOptions.property.exclude"></a>
 
 ```typescript
 public readonly exclude: string[];
@@ -1510,7 +1600,7 @@ Glob patterns to exclude when adding files.
 
 ---
 
-##### `keyPrefix`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDirectoryOptions.property.keyPrefix"></a>
+##### `keyPrefix`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDirectoryOptions.property.keyPrefix"></a>
 
 ```typescript
 public readonly keyPrefix: string;
@@ -1523,19 +1613,19 @@ A prefix to add to all keys in the config map.
 
 ---
 
-### CommandProbeOptions <a name="cdk8s-plus-21.CommandProbeOptions"></a>
+### CommandProbeOptions <a name="cdk8s-plus-22.CommandProbeOptions"></a>
 
 Options for `Probe.fromCommand()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { CommandProbeOptions } from 'cdk8s-plus-21'
+import { CommandProbeOptions } from 'cdk8s-plus-22'
 
 const commandProbeOptions: CommandProbeOptions = { ... }
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.failureThreshold"></a>
 
 ```typescript
 public readonly failureThreshold: number;
@@ -1550,7 +1640,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.initialDelaySeconds"></a>
 
 ```typescript
 public readonly initialDelaySeconds: Duration;
@@ -1565,7 +1655,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.periodSeconds"></a>
 
 ```typescript
 public readonly periodSeconds: Duration;
@@ -1580,7 +1670,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.successThreshold"></a>
 
 ```typescript
 public readonly successThreshold: number;
@@ -1595,7 +1685,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.timeoutSeconds"></a>
 
 ```typescript
 public readonly timeoutSeconds: Duration;
@@ -1612,19 +1702,19 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="cdk8s-plus-21.ConfigMapProps"></a>
+### ConfigMapProps <a name="cdk8s-plus-22.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ConfigMapProps } from 'cdk8s-plus-21'
+import { ConfigMapProps } from 'cdk8s-plus-22'
 
 const configMapProps: ConfigMapProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -1636,7 +1726,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binaryData`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapProps.property.binaryData"></a>
+##### `binaryData`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapProps.property.binaryData"></a>
 
 ```typescript
 public readonly binaryData: {[ key: string ]: string};
@@ -1656,7 +1746,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapProps.property.data"></a>
+##### `data`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapProps.property.data"></a>
 
 ```typescript
 public readonly data: {[ key: string ]: string};
@@ -1675,19 +1765,19 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="cdk8s-plus-21.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="cdk8s-plus-22.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ConfigMapVolumeOptions } from 'cdk8s-plus-21'
+import { ConfigMapVolumeOptions } from 'cdk8s-plus-22'
 
 const configMapVolumeOptions: ConfigMapVolumeOptions = { ... }
 ```
 
-##### `defaultMode`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapVolumeOptions.property.defaultMode"></a>
+##### `defaultMode`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapVolumeOptions.property.defaultMode"></a>
 
 ```typescript
 public readonly defaultMode: number;
@@ -1707,13 +1797,13 @@ file mode, like fsGroup, and the result can be other mode bits set.
 
 ---
 
-##### `items`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapVolumeOptions.property.items"></a>
+##### `items`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapVolumeOptions.property.items"></a>
 
 ```typescript
 public readonly items: {[ key: string ]: PathMapping};
 ```
 
-- *Type:* {[ key: string ]: [`cdk8s-plus-21.PathMapping`](#cdk8s-plus-21.PathMapping)}
+- *Type:* {[ key: string ]: [`cdk8s-plus-22.PathMapping`](#cdk8s-plus-22.PathMapping)}
 - *Default:* no mapping
 
 If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value.
@@ -1726,7 +1816,7 @@ contain the '..' path or start with '..'.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapVolumeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapVolumeOptions.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -1739,7 +1829,7 @@ The volume name.
 
 ---
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapVolumeOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapVolumeOptions.property.optional"></a>
 
 ```typescript
 public readonly optional: boolean;
@@ -1752,19 +1842,19 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
-### ContainerProps <a name="cdk8s-plus-21.ContainerProps"></a>
+### ContainerProps <a name="cdk8s-plus-22.ContainerProps"></a>
 
 Properties for creating a container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ContainerProps } from 'cdk8s-plus-21'
+import { ContainerProps } from 'cdk8s-plus-22'
 
 const containerProps: ContainerProps = { ... }
 ```
 
-##### `image`<sup>Required</sup> <a name="cdk8s-plus-21.ContainerProps.property.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s-plus-22.ContainerProps.property.image"></a>
 
 ```typescript
 public readonly image: string;
@@ -1776,7 +1866,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.args"></a>
 
 ```typescript
 public readonly args: string[];
@@ -1799,7 +1889,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.command"></a>
 
 ```typescript
 public readonly command: string[];
@@ -1817,13 +1907,13 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.env"></a>
+##### `env`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.env"></a>
 
 ```typescript
 public readonly env: {[ key: string ]: EnvValue};
 ```
 
-- *Type:* {[ key: string ]: [`cdk8s-plus-21.EnvValue`](#cdk8s-plus-21.EnvValue)}
+- *Type:* {[ key: string ]: [`cdk8s-plus-22.EnvValue`](#cdk8s-plus-22.EnvValue)}
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -1832,26 +1922,26 @@ Cannot be updated.
 
 ---
 
-##### `imagePullPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.imagePullPolicy"></a>
 
 ```typescript
 public readonly imagePullPolicy: ImagePullPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.ImagePullPolicy`](#cdk8s-plus-21.ImagePullPolicy)
+- *Type:* [`cdk8s-plus-22.ImagePullPolicy`](#cdk8s-plus-22.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.liveness"></a>
 
 ```typescript
 public readonly liveness: Probe;
 ```
 
-- *Type:* [`cdk8s-plus-21.Probe`](#cdk8s-plus-21.Probe)
+- *Type:* [`cdk8s-plus-22.Probe`](#cdk8s-plus-22.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -1860,7 +1950,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -1875,7 +1965,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -1890,26 +1980,26 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.readiness"></a>
 
 ```typescript
 public readonly readiness: Probe;
 ```
 
-- *Type:* [`cdk8s-plus-21.Probe`](#cdk8s-plus-21.Probe)
+- *Type:* [`cdk8s-plus-22.Probe`](#cdk8s-plus-22.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.startup"></a>
 
 ```typescript
 public readonly startup: Probe;
 ```
 
-- *Type:* [`cdk8s-plus-21.Probe`](#cdk8s-plus-21.Probe)
+- *Type:* [`cdk8s-plus-22.Probe`](#cdk8s-plus-22.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -1918,13 +2008,13 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volumeMounts`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.volumeMounts"></a>
+##### `volumeMounts`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.volumeMounts"></a>
 
 ```typescript
 public readonly volumeMounts: VolumeMount[];
 ```
 
-- *Type:* [`cdk8s-plus-21.VolumeMount`](#cdk8s-plus-21.VolumeMount)[]
+- *Type:* [`cdk8s-plus-22.VolumeMount`](#cdk8s-plus-22.VolumeMount)[]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -1932,7 +2022,7 @@ Cannot be updated.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.workingDir"></a>
 
 ```typescript
 public readonly workingDir: string;
@@ -1947,19 +2037,19 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-### DeploymentProps <a name="cdk8s-plus-21.DeploymentProps"></a>
+### DeploymentProps <a name="cdk8s-plus-22.DeploymentProps"></a>
 
 Properties for initialization of `Deployment`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { DeploymentProps } from 'cdk8s-plus-21'
+import { DeploymentProps } from 'cdk8s-plus-22'
 
 const deploymentProps: DeploymentProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -1971,13 +2061,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -1989,13 +2079,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2004,13 +2094,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2026,13 +2116,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2043,7 +2133,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadata;
@@ -2055,7 +2145,7 @@ The pod metadata.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.defaultSelector"></a>
 
 ```typescript
 public readonly defaultSelector: boolean;
@@ -2071,7 +2161,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.replicas"></a>
 
 ```typescript
 public readonly replicas: number;
@@ -2084,25 +2174,25 @@ Number of desired pods.
 
 ---
 
-### EmptyDirVolumeOptions <a name="cdk8s-plus-21.EmptyDirVolumeOptions"></a>
+### EmptyDirVolumeOptions <a name="cdk8s-plus-22.EmptyDirVolumeOptions"></a>
 
 Options for volumes populated with an empty directory.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { EmptyDirVolumeOptions } from 'cdk8s-plus-21'
+import { EmptyDirVolumeOptions } from 'cdk8s-plus-22'
 
 const emptyDirVolumeOptions: EmptyDirVolumeOptions = { ... }
 ```
 
-##### `medium`<sup>Optional</sup> <a name="cdk8s-plus-21.EmptyDirVolumeOptions.property.medium"></a>
+##### `medium`<sup>Optional</sup> <a name="cdk8s-plus-22.EmptyDirVolumeOptions.property.medium"></a>
 
 ```typescript
 public readonly medium: EmptyDirMedium;
 ```
 
-- *Type:* [`cdk8s-plus-21.EmptyDirMedium`](#cdk8s-plus-21.EmptyDirMedium)
+- *Type:* [`cdk8s-plus-22.EmptyDirMedium`](#cdk8s-plus-22.EmptyDirMedium)
 - *Default:* EmptyDirMedium.DEFAULT
 
 By default, emptyDir volumes are stored on whatever medium is backing the node - that might be disk or SSD or network storage, depending on your environment.
@@ -2115,7 +2205,7 @@ against your Container's memory limit.
 
 ---
 
-##### `sizeLimit`<sup>Optional</sup> <a name="cdk8s-plus-21.EmptyDirVolumeOptions.property.sizeLimit"></a>
+##### `sizeLimit`<sup>Optional</sup> <a name="cdk8s-plus-22.EmptyDirVolumeOptions.property.sizeLimit"></a>
 
 ```typescript
 public readonly sizeLimit: Size;
@@ -2133,19 +2223,19 @@ here and the sum of memory limits of all containers in a pod.
 
 ---
 
-### EnvValueFromConfigMapOptions <a name="cdk8s-plus-21.EnvValueFromConfigMapOptions"></a>
+### EnvValueFromConfigMapOptions <a name="cdk8s-plus-22.EnvValueFromConfigMapOptions"></a>
 
 Options to specify an envionment variable value from a ConfigMap key.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { EnvValueFromConfigMapOptions } from 'cdk8s-plus-21'
+import { EnvValueFromConfigMapOptions } from 'cdk8s-plus-22'
 
 const envValueFromConfigMapOptions: EnvValueFromConfigMapOptions = { ... }
 ```
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValueFromConfigMapOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValueFromConfigMapOptions.property.optional"></a>
 
 ```typescript
 public readonly optional: boolean;
@@ -2158,19 +2248,19 @@ Specify whether the ConfigMap or its key must be defined.
 
 ---
 
-### EnvValueFromProcessOptions <a name="cdk8s-plus-21.EnvValueFromProcessOptions"></a>
+### EnvValueFromProcessOptions <a name="cdk8s-plus-22.EnvValueFromProcessOptions"></a>
 
 Options to specify an environment variable value from the process environment.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { EnvValueFromProcessOptions } from 'cdk8s-plus-21'
+import { EnvValueFromProcessOptions } from 'cdk8s-plus-22'
 
 const envValueFromProcessOptions: EnvValueFromProcessOptions = { ... }
 ```
 
-##### `required`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValueFromProcessOptions.property.required"></a>
+##### `required`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValueFromProcessOptions.property.required"></a>
 
 ```typescript
 public readonly required: boolean;
@@ -2185,19 +2275,19 @@ If this is set to true, and the key does not exist, an error will thrown.
 
 ---
 
-### EnvValueFromSecretOptions <a name="cdk8s-plus-21.EnvValueFromSecretOptions"></a>
+### EnvValueFromSecretOptions <a name="cdk8s-plus-22.EnvValueFromSecretOptions"></a>
 
 Options to specify an environment variable value from a Secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { EnvValueFromSecretOptions } from 'cdk8s-plus-21'
+import { EnvValueFromSecretOptions } from 'cdk8s-plus-22'
 
 const envValueFromSecretOptions: EnvValueFromSecretOptions = { ... }
 ```
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValueFromSecretOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValueFromSecretOptions.property.optional"></a>
 
 ```typescript
 public readonly optional: boolean;
@@ -2210,19 +2300,19 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="cdk8s-plus-21.ExposeOptions"></a>
+### ExposeOptions <a name="cdk8s-plus-22.ExposeOptions"></a>
 
 Options for exposing a deployment via a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ExposeOptions } from 'cdk8s-plus-21'
+import { ExposeOptions } from 'cdk8s-plus-22'
 
 const exposeOptions: ExposeOptions = { ... }
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -2237,13 +2327,26 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.protocol"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.port"></a>
+
+```typescript
+public readonly port: number;
+```
+
+- *Type:* `number`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.protocol"></a>
 
 ```typescript
 public readonly protocol: Protocol;
 ```
 
-- *Type:* [`cdk8s-plus-21.Protocol`](#cdk8s-plus-21.Protocol)
+- *Type:* [`cdk8s-plus-22.Protocol`](#cdk8s-plus-22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -2252,20 +2355,20 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `serviceType`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.serviceType"></a>
+##### `serviceType`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.serviceType"></a>
 
 ```typescript
 public readonly serviceType: ServiceType;
 ```
 
-- *Type:* [`cdk8s-plus-21.ServiceType`](#cdk8s-plus-21.ServiceType)
+- *Type:* [`cdk8s-plus-22.ServiceType`](#cdk8s-plus-22.ServiceType)
 - *Default:* ClusterIP.
 
 The type of the exposed service.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.targetPort"></a>
 
 ```typescript
 public readonly targetPort: number;
@@ -2278,19 +2381,19 @@ The port number the service will redirect to.
 
 ---
 
-### HttpGetProbeOptions <a name="cdk8s-plus-21.HttpGetProbeOptions"></a>
+### HttpGetProbeOptions <a name="cdk8s-plus-22.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { HttpGetProbeOptions } from 'cdk8s-plus-21'
+import { HttpGetProbeOptions } from 'cdk8s-plus-22'
 
 const httpGetProbeOptions: HttpGetProbeOptions = { ... }
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.failureThreshold"></a>
 
 ```typescript
 public readonly failureThreshold: number;
@@ -2305,7 +2408,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.initialDelaySeconds"></a>
 
 ```typescript
 public readonly initialDelaySeconds: Duration;
@@ -2320,7 +2423,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.periodSeconds"></a>
 
 ```typescript
 public readonly periodSeconds: Duration;
@@ -2335,7 +2438,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.successThreshold"></a>
 
 ```typescript
 public readonly successThreshold: number;
@@ -2350,7 +2453,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.timeoutSeconds"></a>
 
 ```typescript
 public readonly timeoutSeconds: Duration;
@@ -2367,7 +2470,7 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -2380,19 +2483,19 @@ The TCP port to use when sending the GET request.
 
 ---
 
-### IngressV1Beta1Props <a name="cdk8s-plus-21.IngressV1Beta1Props"></a>
+### IngressProps <a name="cdk8s-plus-22.IngressProps"></a>
 
 Properties for `Ingress`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { IngressV1Beta1Props } from 'cdk8s-plus-21'
+import { IngressProps } from 'cdk8s-plus-22'
 
-const ingressV1Beta1Props: IngressV1Beta1Props = { ... }
+const ingressProps: IngressProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Props.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -2404,13 +2507,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `defaultBackend`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Props.property.defaultBackend"></a>
+##### `defaultBackend`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressProps.property.defaultBackend"></a>
 
 ```typescript
-public readonly defaultBackend: IngressV1Beta1Backend;
+public readonly defaultBackend: IngressBackend;
 ```
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
 
 The default backend services requests that do not match any rule.
 
@@ -2419,13 +2522,13 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Props.property.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressProps.property.rules"></a>
 
 ```typescript
-public readonly rules: IngressV1Beta1Rule[];
+public readonly rules: IngressRule[];
 ```
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Rule`](#cdk8s-plus-21.IngressV1Beta1Rule)[]
+- *Type:* [`cdk8s-plus-22.IngressRule`](#cdk8s-plus-22.IngressRule)[]
 
 Routing rules for this ingress.
 
@@ -2438,13 +2541,13 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Props.property.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressProps.property.tls"></a>
 
 ```typescript
-public readonly tls: IngressV1Beta1Tls[];
+public readonly tls: IngressTls[];
 ```
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Tls`](#cdk8s-plus-21.IngressV1Beta1Tls)[]
+- *Type:* [`cdk8s-plus-22.IngressTls`](#cdk8s-plus-22.IngressTls)[]
 
 TLS settings for this ingress.
 
@@ -2456,7 +2559,7 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 ---
 
-### IngressV1Beta1Rule <a name="cdk8s-plus-21.IngressV1Beta1Rule"></a>
+### IngressRule <a name="cdk8s-plus-22.IngressRule"></a>
 
 Represents the rules mapping the paths under a specified host to the related backend services.
 
@@ -2466,24 +2569,24 @@ then routed to the backend associated with the matching path.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { IngressV1Beta1Rule } from 'cdk8s-plus-21'
+import { IngressRule } from 'cdk8s-plus-22'
 
-const ingressV1Beta1Rule: IngressV1Beta1Rule = { ... }
+const ingressRule: IngressRule = { ... }
 ```
 
-##### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1Rule.property.backend"></a>
+##### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.IngressRule.property.backend"></a>
 
 ```typescript
-public readonly backend: IngressV1Beta1Backend;
+public readonly backend: IngressBackend;
 ```
 
-- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
+- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
 
 Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ---
 
-##### `host`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Rule.property.host"></a>
+##### `host`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressRule.property.host"></a>
 
 ```typescript
 public readonly host: string;
@@ -2505,7 +2608,7 @@ host before the IngressRuleValue.
 
 ---
 
-##### `path`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Rule.property.path"></a>
+##### `path`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressRule.property.path"></a>
 
 ```typescript
 public readonly path: string;
@@ -2519,19 +2622,36 @@ Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows
 
 ---
 
-### IngressV1Beta1Tls <a name="cdk8s-plus-21.IngressV1Beta1Tls"></a>
+##### `pathType`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressRule.property.pathType"></a>
+
+```typescript
+public readonly pathType: HttpIngressPathType;
+```
+
+- *Type:* [`cdk8s-plus-22.HttpIngressPathType`](#cdk8s-plus-22.HttpIngressPathType)
+
+Specify how the path is matched against request paths.
+
+By default, path
+types will be matched by prefix.
+
+> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+
+---
+
+### IngressTls <a name="cdk8s-plus-22.IngressTls"></a>
 
 Represents the TLS configuration mapping that is passed to the ingress controller for SSL termination.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { IngressV1Beta1Tls } from 'cdk8s-plus-21'
+import { IngressTls } from 'cdk8s-plus-22'
 
-const ingressV1Beta1Tls: IngressV1Beta1Tls = { ... }
+const ingressTls: IngressTls = { ... }
 ```
 
-##### `hosts`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Tls.property.hosts"></a>
+##### `hosts`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressTls.property.hosts"></a>
 
 ```typescript
 public readonly hosts: string[];
@@ -2548,13 +2668,13 @@ this list must match the name/s used in the TLS Secret.
 
 ---
 
-##### `secret`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Tls.property.secret"></a>
+##### `secret`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressTls.property.secret"></a>
 
 ```typescript
 public readonly secret: ISecret;
 ```
 
-- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
+- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
 - *Default:* If unspecified, it allows SSL routing based on SNI hostname.
 
 Secret is the secret that contains the certificate and key used to terminate SSL traffic on 443.
@@ -2565,19 +2685,19 @@ termination and value of the Host header is used for routing.
 
 ---
 
-### JobProps <a name="cdk8s-plus-21.JobProps"></a>
+### JobProps <a name="cdk8s-plus-22.JobProps"></a>
 
 Properties for initialization of `Job`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { JobProps } from 'cdk8s-plus-21'
+import { JobProps } from 'cdk8s-plus-22'
 
 const jobProps: JobProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -2589,13 +2709,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2607,13 +2727,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2622,13 +2742,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2644,13 +2764,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2661,7 +2781,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadata;
@@ -2673,7 +2793,7 @@ The pod metadata.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.activeDeadline"></a>
 
 ```typescript
 public readonly activeDeadline: Duration;
@@ -2686,7 +2806,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.backoffLimit"></a>
 
 ```typescript
 public readonly backoffLimit: number;
@@ -2699,7 +2819,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.ttlAfterFinished"></a>
 
 ```typescript
 public readonly ttlAfterFinished: Duration;
@@ -2719,25 +2839,25 @@ field is alpha-level and is only honored by servers that enable the
 
 ---
 
-### MountOptions <a name="cdk8s-plus-21.MountOptions"></a>
+### MountOptions <a name="cdk8s-plus-22.MountOptions"></a>
 
 Options for mounts.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { MountOptions } from 'cdk8s-plus-21'
+import { MountOptions } from 'cdk8s-plus-22'
 
 const mountOptions: MountOptions = { ... }
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.propagation"></a>
 
 ```typescript
 public readonly propagation: MountPropagation;
 ```
 
-- *Type:* [`cdk8s-plus-21.MountPropagation`](#cdk8s-plus-21.MountPropagation)
+- *Type:* [`cdk8s-plus-22.MountPropagation`](#cdk8s-plus-22.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -2751,7 +2871,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.readOnly"></a>
+##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.readOnly"></a>
 
 ```typescript
 public readonly readOnly: boolean;
@@ -2766,7 +2886,7 @@ Defaults to false.
 
 ---
 
-##### `subPath`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.subPath"></a>
+##### `subPath`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.subPath"></a>
 
 ```typescript
 public readonly subPath: string;
@@ -2779,7 +2899,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `subPathExpr`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.subPathExpr"></a>
+##### `subPathExpr`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.subPathExpr"></a>
 
 ```typescript
 public readonly subPathExpr: string;
@@ -2800,19 +2920,19 @@ is beta in 1.15.
 
 ---
 
-### PathMapping <a name="cdk8s-plus-21.PathMapping"></a>
+### PathMapping <a name="cdk8s-plus-22.PathMapping"></a>
 
 Maps a string key to a path within a volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { PathMapping } from 'cdk8s-plus-21'
+import { PathMapping } from 'cdk8s-plus-22'
 
 const pathMapping: PathMapping = { ... }
 ```
 
-##### `path`<sup>Required</sup> <a name="cdk8s-plus-21.PathMapping.property.path"></a>
+##### `path`<sup>Required</sup> <a name="cdk8s-plus-22.PathMapping.property.path"></a>
 
 ```typescript
 public readonly path: string;
@@ -2828,7 +2948,7 @@ path. May not contain the path element '..'. May not start with the string
 
 ---
 
-##### `mode`<sup>Optional</sup> <a name="cdk8s-plus-21.PathMapping.property.mode"></a>
+##### `mode`<sup>Optional</sup> <a name="cdk8s-plus-22.PathMapping.property.mode"></a>
 
 ```typescript
 public readonly mode: number;
@@ -2844,19 +2964,19 @@ the result can be other mode bits set.
 
 ---
 
-### PodProps <a name="cdk8s-plus-21.PodProps"></a>
+### PodProps <a name="cdk8s-plus-22.PodProps"></a>
 
 Properties for initialization of `Pod`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { PodProps } from 'cdk8s-plus-21'
+import { PodProps } from 'cdk8s-plus-22'
 
 const podProps: PodProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -2868,13 +2988,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2886,13 +3006,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2901,13 +3021,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2923,13 +3043,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2940,25 +3060,25 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodSpecProps <a name="cdk8s-plus-21.PodSpecProps"></a>
+### PodSpecProps <a name="cdk8s-plus-22.PodSpecProps"></a>
 
 Properties of a `PodSpec`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { PodSpecProps } from 'cdk8s-plus-21'
+import { PodSpecProps } from 'cdk8s-plus-22'
 
 const podSpecProps: PodSpecProps = { ... }
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2970,13 +3090,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2985,13 +3105,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3007,13 +3127,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3024,7 +3144,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodTemplateProps <a name="cdk8s-plus-21.PodTemplateProps"></a>
+### PodTemplateProps <a name="cdk8s-plus-22.PodTemplateProps"></a>
 
 Properties of a `PodTemplate`.
 
@@ -3033,18 +3153,18 @@ Adds metadata information on top of the spec.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { PodTemplateProps } from 'cdk8s-plus-21'
+import { PodTemplateProps } from 'cdk8s-plus-22'
 
 const podTemplateProps: PodTemplateProps = { ... }
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3056,13 +3176,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3071,13 +3191,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3093,13 +3213,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3110,7 +3230,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadata;
@@ -3122,19 +3242,19 @@ The pod metadata.
 
 ---
 
-### ProbeOptions <a name="cdk8s-plus-21.ProbeOptions"></a>
+### ProbeOptions <a name="cdk8s-plus-22.ProbeOptions"></a>
 
 Probe options.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ProbeOptions } from 'cdk8s-plus-21'
+import { ProbeOptions } from 'cdk8s-plus-22'
 
 const probeOptions: ProbeOptions = { ... }
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.failureThreshold"></a>
 
 ```typescript
 public readonly failureThreshold: number;
@@ -3149,7 +3269,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.initialDelaySeconds"></a>
 
 ```typescript
 public readonly initialDelaySeconds: Duration;
@@ -3164,7 +3284,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.periodSeconds"></a>
 
 ```typescript
 public readonly periodSeconds: Duration;
@@ -3179,7 +3299,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.successThreshold"></a>
 
 ```typescript
 public readonly successThreshold: number;
@@ -3194,7 +3314,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.timeoutSeconds"></a>
 
 ```typescript
 public readonly timeoutSeconds: Duration;
@@ -3211,19 +3331,19 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ResourceProps <a name="cdk8s-plus-21.ResourceProps"></a>
+### ResourceProps <a name="cdk8s-plus-22.ResourceProps"></a>
 
 Initialization properties for resources.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ResourceProps } from 'cdk8s-plus-21'
+import { ResourceProps } from 'cdk8s-plus-22'
 
 const resourceProps: ResourceProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ResourceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.ResourceProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3235,17 +3355,17 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-### SecretProps <a name="cdk8s-plus-21.SecretProps"></a>
+### SecretProps <a name="cdk8s-plus-22.SecretProps"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { SecretProps } from 'cdk8s-plus-21'
+import { SecretProps } from 'cdk8s-plus-22'
 
 const secretProps: SecretProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3257,7 +3377,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.stringData"></a>
 
 ```typescript
 public readonly stringData: {[ key: string ]: string};
@@ -3274,7 +3394,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.type"></a>
 
 ```typescript
 public readonly type: string;
@@ -3290,19 +3410,19 @@ handling of secret data by various controllers.
 
 ---
 
-### SecretValue <a name="cdk8s-plus-21.SecretValue"></a>
+### SecretValue <a name="cdk8s-plus-22.SecretValue"></a>
 
 Represents a specific value in JSON secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { SecretValue } from 'cdk8s-plus-21'
+import { SecretValue } from 'cdk8s-plus-22'
 
 const secretValue: SecretValue = { ... }
 ```
 
-##### `key`<sup>Required</sup> <a name="cdk8s-plus-21.SecretValue.property.key"></a>
+##### `key`<sup>Required</sup> <a name="cdk8s-plus-22.SecretValue.property.key"></a>
 
 ```typescript
 public readonly key: string;
@@ -3314,19 +3434,19 @@ The JSON key.
 
 ---
 
-##### `secret`<sup>Required</sup> <a name="cdk8s-plus-21.SecretValue.property.secret"></a>
+##### `secret`<sup>Required</sup> <a name="cdk8s-plus-22.SecretValue.property.secret"></a>
 
 ```typescript
 public readonly secret: ISecret;
 ```
 
-- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
+- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
 
 The secret.
 
 ---
 
-### ServiceAccountProps <a name="cdk8s-plus-21.ServiceAccountProps"></a>
+### ServiceAccountProps <a name="cdk8s-plus-22.ServiceAccountProps"></a>
 
 Properties for initialization of `ServiceAccount`.
 
@@ -3335,12 +3455,12 @@ Properties for initialization of `ServiceAccount`.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServiceAccountProps } from 'cdk8s-plus-21'
+import { ServiceAccountProps } from 'cdk8s-plus-22'
 
 const serviceAccountProps: ServiceAccountProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceAccountProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceAccountProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3352,13 +3472,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceAccountProps.property.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceAccountProps.property.secrets"></a>
 
 ```typescript
 public readonly secrets: ISecret[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)[]
+- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)[]
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -3366,19 +3486,19 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 ---
 
-### ServiceIngressV1BetaBackendOptions <a name="cdk8s-plus-21.ServiceIngressV1BetaBackendOptions"></a>
+### ServiceIngressBackendOptions <a name="cdk8s-plus-22.ServiceIngressBackendOptions"></a>
 
 Options for setting up backends for ingress rules.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServiceIngressV1BetaBackendOptions } from 'cdk8s-plus-21'
+import { ServiceIngressBackendOptions } from 'cdk8s-plus-22'
 
-const serviceIngressV1BetaBackendOptions: ServiceIngressV1BetaBackendOptions = { ... }
+const serviceIngressBackendOptions: ServiceIngressBackendOptions = { ... }
 ```
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceIngressV1BetaBackendOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceIngressBackendOptions.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -3396,19 +3516,19 @@ This option will fail if the service does not expose any ports.
 
 ---
 
-### ServicePort <a name="cdk8s-plus-21.ServicePort"></a>
+### ServicePort <a name="cdk8s-plus-22.ServicePort"></a>
 
 Definition of a service port.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServicePort } from 'cdk8s-plus-21'
+import { ServicePort } from 'cdk8s-plus-22'
 
 const servicePort: ServicePort = { ... }
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePort.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePort.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3425,15 +3545,14 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePort.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePort.property.nodePort"></a>
 
 ```typescript
 public readonly nodePort: number;
 ```
 
 - *Type:* `number`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -3446,13 +3565,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePort.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePort.property.protocol"></a>
 
 ```typescript
 public readonly protocol: Protocol;
 ```
 
-- *Type:* [`cdk8s-plus-21.Protocol`](#cdk8s-plus-21.Protocol)
+- *Type:* [`cdk8s-plus-22.Protocol`](#cdk8s-plus-22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -3461,7 +3580,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePort.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePort.property.targetPort"></a>
 
 ```typescript
 public readonly targetPort: number;
@@ -3474,7 +3593,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Required</sup> <a name="cdk8s-plus-21.ServicePort.property.port"></a>
+##### `port`<sup>Required</sup> <a name="cdk8s-plus-22.ServicePort.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -3486,17 +3605,17 @@ The port number the service will bind to.
 
 ---
 
-### ServicePortOptions <a name="cdk8s-plus-21.ServicePortOptions"></a>
+### ServicePortOptions <a name="cdk8s-plus-22.ServicePortOptions"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServicePortOptions } from 'cdk8s-plus-21'
+import { ServicePortOptions } from 'cdk8s-plus-22'
 
 const servicePortOptions: ServicePortOptions = { ... }
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePortOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePortOptions.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3513,15 +3632,14 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePortOptions.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePortOptions.property.nodePort"></a>
 
 ```typescript
 public readonly nodePort: number;
 ```
 
 - *Type:* `number`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -3534,13 +3652,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePortOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePortOptions.property.protocol"></a>
 
 ```typescript
 public readonly protocol: Protocol;
 ```
 
-- *Type:* [`cdk8s-plus-21.Protocol`](#cdk8s-plus-21.Protocol)
+- *Type:* [`cdk8s-plus-22.Protocol`](#cdk8s-plus-22.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -3549,7 +3667,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePortOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePortOptions.property.targetPort"></a>
 
 ```typescript
 public readonly targetPort: number;
@@ -3562,19 +3680,19 @@ The port number the service will redirect to.
 
 ---
 
-### ServiceProps <a name="cdk8s-plus-21.ServiceProps"></a>
+### ServiceProps <a name="cdk8s-plus-22.ServiceProps"></a>
 
 Properties for initialization of `Service`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServiceProps } from 'cdk8s-plus-21'
+import { ServiceProps } from 'cdk8s-plus-22'
 
 const serviceProps: ServiceProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3586,7 +3704,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.clusterIP"></a>
 
 ```typescript
 public readonly clusterIP: string;
@@ -3608,7 +3726,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `externalIPs`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.externalIPs"></a>
+##### `externalIPs`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.externalIPs"></a>
 
 ```typescript
 public readonly externalIPs: string[];
@@ -3626,7 +3744,7 @@ Kubernetes system.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.externalName"></a>
 
 ```typescript
 public readonly externalName: string;
@@ -3639,7 +3757,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.loadBalancerSourceRanges"></a>
+##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.loadBalancerSourceRanges"></a>
 
 ```typescript
 public readonly loadBalancerSourceRanges: string[];
@@ -3653,13 +3771,13 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.ports"></a>
 
 ```typescript
 public readonly ports: ServicePort[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ServicePort`](#cdk8s-plus-21.ServicePort)[]
+- *Type:* [`cdk8s-plus-22.ServicePort`](#cdk8s-plus-22.ServicePort)[]
 
 The port exposed by this service.
 
@@ -3667,13 +3785,13 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.type"></a>
 
 ```typescript
 public readonly type: ServiceType;
 ```
 
-- *Type:* [`cdk8s-plus-21.ServiceType`](#cdk8s-plus-21.ServiceType)
+- *Type:* [`cdk8s-plus-22.ServiceType`](#cdk8s-plus-22.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -3682,19 +3800,19 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 ---
 
-### StatefulSetProps <a name="cdk8s-plus-21.StatefulSetProps"></a>
+### StatefulSetProps <a name="cdk8s-plus-22.StatefulSetProps"></a>
 
 Properties for initialization of `StatefulSet`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { StatefulSetProps } from 'cdk8s-plus-21'
+import { StatefulSetProps } from 'cdk8s-plus-22'
 
 const statefulSetProps: StatefulSetProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3706,13 +3824,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3724,13 +3842,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3739,13 +3857,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3761,13 +3879,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3778,7 +3896,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadata;
@@ -3790,19 +3908,19 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.service"></a>
+##### `service`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.service"></a>
 
 ```typescript
 public readonly service: Service;
 ```
 
-- *Type:* [`cdk8s-plus-21.Service`](#cdk8s-plus-21.Service)
+- *Type:* [`cdk8s-plus-22.Service`](#cdk8s-plus-22.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.defaultSelector"></a>
 
 ```typescript
 public readonly defaultSelector: boolean;
@@ -3818,20 +3936,20 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `podManagementPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.podManagementPolicy"></a>
 
 ```typescript
 public readonly podManagementPolicy: PodManagementPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.PodManagementPolicy`](#cdk8s-plus-21.PodManagementPolicy)
+- *Type:* [`cdk8s-plus-22.PodManagementPolicy`](#cdk8s-plus-22.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.replicas"></a>
 
 ```typescript
 public readonly replicas: number;
@@ -3844,25 +3962,25 @@ Number of desired pods.
 
 ---
 
-### VolumeMount <a name="cdk8s-plus-21.VolumeMount"></a>
+### VolumeMount <a name="cdk8s-plus-22.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { VolumeMount } from 'cdk8s-plus-21'
+import { VolumeMount } from 'cdk8s-plus-22'
 
 const volumeMount: VolumeMount = { ... }
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.propagation"></a>
 
 ```typescript
 public readonly propagation: MountPropagation;
 ```
 
-- *Type:* [`cdk8s-plus-21.MountPropagation`](#cdk8s-plus-21.MountPropagation)
+- *Type:* [`cdk8s-plus-22.MountPropagation`](#cdk8s-plus-22.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -3876,7 +3994,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.readOnly"></a>
+##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.readOnly"></a>
 
 ```typescript
 public readonly readOnly: boolean;
@@ -3891,7 +4009,7 @@ Defaults to false.
 
 ---
 
-##### `subPath`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.subPath"></a>
+##### `subPath`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.subPath"></a>
 
 ```typescript
 public readonly subPath: string;
@@ -3904,7 +4022,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `subPathExpr`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.subPathExpr"></a>
+##### `subPathExpr`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.subPathExpr"></a>
 
 ```typescript
 public readonly subPathExpr: string;
@@ -3925,7 +4043,7 @@ is beta in 1.15.
 
 ---
 
-##### `path`<sup>Required</sup> <a name="cdk8s-plus-21.VolumeMount.property.path"></a>
+##### `path`<sup>Required</sup> <a name="cdk8s-plus-22.VolumeMount.property.path"></a>
 
 ```typescript
 public readonly path: string;
@@ -3940,13 +4058,13 @@ contain ':'.
 
 ---
 
-##### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.VolumeMount.property.volume"></a>
+##### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.VolumeMount.property.volume"></a>
 
 ```typescript
 public readonly volume: Volume;
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
 
 The volume to mount.
 
@@ -3954,33 +4072,33 @@ The volume to mount.
 
 ## Classes <a name="Classes"></a>
 
-### Container <a name="cdk8s-plus-21.Container"></a>
+### Container <a name="cdk8s-plus-22.Container"></a>
 
 A single application container that you want to run within a pod.
 
-#### Initializers <a name="cdk8s-plus-21.Container.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Container.Initializer"></a>
 
 ```typescript
-import { Container } from 'cdk8s-plus-21'
+import { Container } from 'cdk8s-plus-22'
 
 new Container(props: ContainerProps)
 ```
 
-##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addEnv` <a name="cdk8s-plus-21.Container.addEnv"></a>
+##### `addEnv` <a name="cdk8s-plus-22.Container.addEnv"></a>
 
 ```typescript
 public addEnv(name: string, value: EnvValue)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.name"></a>
 
 - *Type:* `string`
 
@@ -3988,21 +4106,21 @@ The variable name.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.value"></a>
 
-- *Type:* [`cdk8s-plus-21.EnvValue`](#cdk8s-plus-21.EnvValue)
+- *Type:* [`cdk8s-plus-22.EnvValue`](#cdk8s-plus-22.EnvValue)
 
 The variable value.
 
 ---
 
-##### `mount` <a name="cdk8s-plus-21.Container.mount"></a>
+##### `mount` <a name="cdk8s-plus-22.Container.mount"></a>
 
 ```typescript
 public mount(path: string, volume: Volume, options?: MountOptions)
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.path"></a>
 
 - *Type:* `string`
 
@@ -4010,30 +4128,30 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
 
 The volume to mount.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.MountOptions`](#cdk8s-plus-21.MountOptions)
+- *Type:* [`cdk8s-plus-22.MountOptions`](#cdk8s-plus-22.MountOptions)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `env`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.env"></a>
+##### `env`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.env"></a>
 
 ```typescript
 public readonly env: {[ key: string ]: EnvValue};
 ```
 
-- *Type:* {[ key: string ]: [`cdk8s-plus-21.EnvValue`](#cdk8s-plus-21.EnvValue)}
+- *Type:* {[ key: string ]: [`cdk8s-plus-22.EnvValue`](#cdk8s-plus-22.EnvValue)}
 
 The environment variables for this container.
 
@@ -4041,7 +4159,7 @@ Returns a copy. To add environment variables use `addEnv()`.
 
 ---
 
-##### `image`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.image"></a>
 
 ```typescript
 public readonly image: string;
@@ -4053,31 +4171,31 @@ The container image.
 
 ---
 
-##### `imagePullPolicy`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.imagePullPolicy"></a>
 
 ```typescript
 public readonly imagePullPolicy: ImagePullPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.ImagePullPolicy`](#cdk8s-plus-21.ImagePullPolicy)
+- *Type:* [`cdk8s-plus-22.ImagePullPolicy`](#cdk8s-plus-22.ImagePullPolicy)
 
 Image pull policy for this container.
 
 ---
 
-##### `mounts`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.mounts"></a>
+##### `mounts`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.mounts"></a>
 
 ```typescript
 public readonly mounts: VolumeMount[];
 ```
 
-- *Type:* [`cdk8s-plus-21.VolumeMount`](#cdk8s-plus-21.VolumeMount)[]
+- *Type:* [`cdk8s-plus-22.VolumeMount`](#cdk8s-plus-22.VolumeMount)[]
 
 Volume mounts configured for this container.
 
 ---
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4089,7 +4207,7 @@ The name of the container.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.property.args"></a>
 
 ```typescript
 public readonly args: string[];
@@ -4101,7 +4219,7 @@ Arguments to the entrypoint.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.property.command"></a>
 
 ```typescript
 public readonly command: string[];
@@ -4113,7 +4231,7 @@ Entrypoint array (the command to execute when the container starts).
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -4125,7 +4243,7 @@ The port this container exposes.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.property.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.property.workingDir"></a>
 
 ```typescript
 public readonly workingDir: string;
@@ -4138,30 +4256,30 @@ The working directory inside the container.
 ---
 
 
-### EnvValue <a name="cdk8s-plus-21.EnvValue"></a>
+### EnvValue <a name="cdk8s-plus-22.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMap` <a name="cdk8s-plus-21.EnvValue.fromConfigMap"></a>
+##### `fromConfigMap` <a name="cdk8s-plus-22.EnvValue.fromConfigMap"></a>
 
 ```typescript
-import { EnvValue } from 'cdk8s-plus-21'
+import { EnvValue } from 'cdk8s-plus-22'
 
 EnvValue.fromConfigMap(configMap: IConfigMap, key: string, options?: EnvValueFromConfigMapOptions)
 ```
 
-###### `configMap`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.configMap"></a>
+###### `configMap`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.configMap"></a>
 
-- *Type:* [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
+- *Type:* [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap)
 
 The config map.
 
 ---
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -4169,23 +4287,23 @@ The key to extract the value from.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.EnvValueFromConfigMapOptions`](#cdk8s-plus-21.EnvValueFromConfigMapOptions)
+- *Type:* [`cdk8s-plus-22.EnvValueFromConfigMapOptions`](#cdk8s-plus-22.EnvValueFromConfigMapOptions)
 
 Additional options.
 
 ---
 
-##### `fromProcess` <a name="cdk8s-plus-21.EnvValue.fromProcess"></a>
+##### `fromProcess` <a name="cdk8s-plus-22.EnvValue.fromProcess"></a>
 
 ```typescript
-import { EnvValue } from 'cdk8s-plus-21'
+import { EnvValue } from 'cdk8s-plus-22'
 
 EnvValue.fromProcess(key: string, options?: EnvValueFromProcessOptions)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -4193,47 +4311,47 @@ The key to read.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.EnvValueFromProcessOptions`](#cdk8s-plus-21.EnvValueFromProcessOptions)
+- *Type:* [`cdk8s-plus-22.EnvValueFromProcessOptions`](#cdk8s-plus-22.EnvValueFromProcessOptions)
 
 Additional options.
 
 ---
 
-##### `fromSecretValue` <a name="cdk8s-plus-21.EnvValue.fromSecretValue"></a>
+##### `fromSecretValue` <a name="cdk8s-plus-22.EnvValue.fromSecretValue"></a>
 
 ```typescript
-import { EnvValue } from 'cdk8s-plus-21'
+import { EnvValue } from 'cdk8s-plus-22'
 
 EnvValue.fromSecretValue(secretValue: SecretValue, options?: EnvValueFromSecretOptions)
 ```
 
-###### `secretValue`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.secretValue"></a>
+###### `secretValue`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.secretValue"></a>
 
-- *Type:* [`cdk8s-plus-21.SecretValue`](#cdk8s-plus-21.SecretValue)
+- *Type:* [`cdk8s-plus-22.SecretValue`](#cdk8s-plus-22.SecretValue)
 
 The secret value (secrent + key).
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.EnvValueFromSecretOptions`](#cdk8s-plus-21.EnvValueFromSecretOptions)
+- *Type:* [`cdk8s-plus-22.EnvValueFromSecretOptions`](#cdk8s-plus-22.EnvValueFromSecretOptions)
 
 Additional options.
 
 ---
 
-##### `fromValue` <a name="cdk8s-plus-21.EnvValue.fromValue"></a>
+##### `fromValue` <a name="cdk8s-plus-22.EnvValue.fromValue"></a>
 
 ```typescript
-import { EnvValue } from 'cdk8s-plus-21'
+import { EnvValue } from 'cdk8s-plus-22'
 
 EnvValue.fromValue(value: string)
 ```
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -4243,7 +4361,7 @@ The value.
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.property.value"></a>
+##### `value`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.property.value"></a>
 
 ```typescript
 public readonly value: any;
@@ -4253,7 +4371,7 @@ public readonly value: any;
 
 ---
 
-##### `valueFrom`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.property.valueFrom"></a>
+##### `valueFrom`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.property.valueFrom"></a>
 
 ```typescript
 public readonly valueFrom: any;
@@ -4264,93 +4382,93 @@ public readonly valueFrom: any;
 ---
 
 
-### IngressV1Beta1Backend <a name="cdk8s-plus-21.IngressV1Beta1Backend"></a>
+### IngressBackend <a name="cdk8s-plus-22.IngressBackend"></a>
 
 The backend for an ingress path.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromService` <a name="cdk8s-plus-21.IngressV1Beta1Backend.fromService"></a>
+##### `fromService` <a name="cdk8s-plus-22.IngressBackend.fromService"></a>
 
 ```typescript
-import { IngressV1Beta1Backend } from 'cdk8s-plus-21'
+import { IngressBackend } from 'cdk8s-plus-22'
 
-IngressV1Beta1Backend.fromService(service: Service, options?: ServiceIngressV1BetaBackendOptions)
+IngressBackend.fromService(service: Service, options?: ServiceIngressBackendOptions)
 ```
 
-###### `service`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1Backend.parameter.service"></a>
+###### `service`<sup>Required</sup> <a name="cdk8s-plus-22.IngressBackend.parameter.service"></a>
 
-- *Type:* [`cdk8s-plus-21.Service`](#cdk8s-plus-21.Service)
+- *Type:* [`cdk8s-plus-22.Service`](#cdk8s-plus-22.Service)
 
 The service object.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Backend.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressBackend.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.ServiceIngressV1BetaBackendOptions`](#cdk8s-plus-21.ServiceIngressV1BetaBackendOptions)
+- *Type:* [`cdk8s-plus-22.ServiceIngressBackendOptions`](#cdk8s-plus-22.ServiceIngressBackendOptions)
 
 ---
 
 
 
-### PodSpec <a name="cdk8s-plus-21.PodSpec"></a>
+### PodSpec <a name="cdk8s-plus-22.PodSpec"></a>
 
-- *Implements:* [`cdk8s-plus-21.IPodSpec`](#cdk8s-plus-21.IPodSpec)
+- *Implements:* [`cdk8s-plus-22.IPodSpec`](#cdk8s-plus-22.IPodSpec)
 
 Provides read/write capabilities ontop of a `PodSpecProps`.
 
-#### Initializers <a name="cdk8s-plus-21.PodSpec.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.PodSpec.Initializer"></a>
 
 ```typescript
-import { PodSpec } from 'cdk8s-plus-21'
+import { PodSpec } from 'cdk8s-plus-22'
 
 new PodSpec(props?: PodSpecProps)
 ```
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpec.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.PodSpecProps`](#cdk8s-plus-21.PodSpecProps)
+- *Type:* [`cdk8s-plus-22.PodSpecProps`](#cdk8s-plus-22.PodSpecProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-21.PodSpec.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-22.PodSpec.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.PodSpec.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-21.PodSpec.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-22.PodSpec.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.PodSpec.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.PodSpec.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
+- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
 
 The containers belonging to the pod.
 
@@ -4358,13 +4476,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.PodSpec.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 
 The volumes associated with this pod.
 
@@ -4372,48 +4490,48 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpec.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### PodTemplate <a name="cdk8s-plus-21.PodTemplate"></a>
+### PodTemplate <a name="cdk8s-plus-22.PodTemplate"></a>
 
-- *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
+- *Implements:* [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
 
 Provides read/write capabilities ontop of a `PodTemplateProps`.
 
-#### Initializers <a name="cdk8s-plus-21.PodTemplate.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.PodTemplate.Initializer"></a>
 
 ```typescript
-import { PodTemplate } from 'cdk8s-plus-21'
+import { PodTemplate } from 'cdk8s-plus-22'
 
 new PodTemplate(props?: PodTemplateProps)
 ```
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplate.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplate.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-21.PodTemplateProps`](#cdk8s-plus-21.PodTemplateProps)
+- *Type:* [`cdk8s-plus-22.PodTemplateProps`](#cdk8s-plus-22.PodTemplateProps)
 
 ---
 
@@ -4421,7 +4539,7 @@ new PodTemplate(props?: PodTemplateProps)
 
 #### Properties <a name="Properties"></a>
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.PodTemplate.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.PodTemplate.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -4434,14 +4552,14 @@ Provides read/write access to the underlying pod metadata of the resource.
 ---
 
 
-### Probe <a name="cdk8s-plus-21.Probe"></a>
+### Probe <a name="cdk8s-plus-22.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 
-#### Initializers <a name="cdk8s-plus-21.Probe.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Probe.Initializer"></a>
 
 ```typescript
-import { Probe } from 'cdk8s-plus-21'
+import { Probe } from 'cdk8s-plus-22'
 
 new Probe()
 ```
@@ -4449,15 +4567,15 @@ new Probe()
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromCommand` <a name="cdk8s-plus-21.Probe.fromCommand"></a>
+##### `fromCommand` <a name="cdk8s-plus-22.Probe.fromCommand"></a>
 
 ```typescript
-import { Probe } from 'cdk8s-plus-21'
+import { Probe } from 'cdk8s-plus-22'
 
 Probe.fromCommand(command: string[], options?: CommandProbeOptions)
 ```
 
-###### `command`<sup>Required</sup> <a name="cdk8s-plus-21.Probe.parameter.command"></a>
+###### `command`<sup>Required</sup> <a name="cdk8s-plus-22.Probe.parameter.command"></a>
 
 - *Type:* `string`[]
 
@@ -4465,23 +4583,23 @@ The command to execute.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Probe.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Probe.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.CommandProbeOptions`](#cdk8s-plus-21.CommandProbeOptions)
+- *Type:* [`cdk8s-plus-22.CommandProbeOptions`](#cdk8s-plus-22.CommandProbeOptions)
 
 Options.
 
 ---
 
-##### `fromHttpGet` <a name="cdk8s-plus-21.Probe.fromHttpGet"></a>
+##### `fromHttpGet` <a name="cdk8s-plus-22.Probe.fromHttpGet"></a>
 
 ```typescript
-import { Probe } from 'cdk8s-plus-21'
+import { Probe } from 'cdk8s-plus-22'
 
 Probe.fromHttpGet(path: string, options?: HttpGetProbeOptions)
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.Probe.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-22.Probe.parameter.path"></a>
 
 - *Type:* `string`
 
@@ -4489,9 +4607,9 @@ The URL path to hit.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Probe.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Probe.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.HttpGetProbeOptions`](#cdk8s-plus-21.HttpGetProbeOptions)
+- *Type:* [`cdk8s-plus-22.HttpGetProbeOptions`](#cdk8s-plus-22.HttpGetProbeOptions)
 
 Options.
 
@@ -4499,7 +4617,7 @@ Options.
 
 
 
-### Volume <a name="cdk8s-plus-21.Volume"></a>
+### Volume <a name="cdk8s-plus-22.Volume"></a>
 
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
@@ -4532,21 +4650,21 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
-#### Initializers <a name="cdk8s-plus-21.Volume.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-22.Volume.Initializer"></a>
 
 ```typescript
-import { Volume } from 'cdk8s-plus-21'
+import { Volume } from 'cdk8s-plus-22'
 
 new Volume(name: string, config: any)
 ```
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.parameter.name"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `config`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.config"></a>
+##### `config`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.parameter.config"></a>
 
 - *Type:* `any`
 
@@ -4555,47 +4673,47 @@ new Volume(name: string, config: any)
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMap` <a name="cdk8s-plus-21.Volume.fromConfigMap"></a>
+##### `fromConfigMap` <a name="cdk8s-plus-22.Volume.fromConfigMap"></a>
 
 ```typescript
-import { Volume } from 'cdk8s-plus-21'
+import { Volume } from 'cdk8s-plus-22'
 
 Volume.fromConfigMap(configMap: IConfigMap, options?: ConfigMapVolumeOptions)
 ```
 
-###### `configMap`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.configMap"></a>
+###### `configMap`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.parameter.configMap"></a>
 
-- *Type:* [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
+- *Type:* [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap)
 
 The config map to use to populate the volume.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Volume.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Volume.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.ConfigMapVolumeOptions`](#cdk8s-plus-21.ConfigMapVolumeOptions)
+- *Type:* [`cdk8s-plus-22.ConfigMapVolumeOptions`](#cdk8s-plus-22.ConfigMapVolumeOptions)
 
 Options.
 
 ---
 
-##### `fromEmptyDir` <a name="cdk8s-plus-21.Volume.fromEmptyDir"></a>
+##### `fromEmptyDir` <a name="cdk8s-plus-22.Volume.fromEmptyDir"></a>
 
 ```typescript
-import { Volume } from 'cdk8s-plus-21'
+import { Volume } from 'cdk8s-plus-22'
 
 Volume.fromEmptyDir(name: string, options?: EmptyDirVolumeOptions)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.parameter.name"></a>
 
 - *Type:* `string`
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Volume.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Volume.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-21.EmptyDirVolumeOptions`](#cdk8s-plus-21.EmptyDirVolumeOptions)
+- *Type:* [`cdk8s-plus-22.EmptyDirVolumeOptions`](#cdk8s-plus-22.EmptyDirVolumeOptions)
 
 Additional options.
 
@@ -4603,7 +4721,7 @@ Additional options.
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4616,18 +4734,18 @@ public readonly name: string;
 
 ## Protocols <a name="Protocols"></a>
 
-### IConfigMap <a name="cdk8s-plus-21.IConfigMap"></a>
+### IConfigMap <a name="cdk8s-plus-22.IConfigMap"></a>
 
-- *Extends:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
+- *Extends:* [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource)
 
-- *Implemented By:* [`cdk8s-plus-21.ConfigMap`](#cdk8s-plus-21.ConfigMap), [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
+- *Implemented By:* [`cdk8s-plus-22.ConfigMap`](#cdk8s-plus-22.ConfigMap), [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap)
 
 Represents a config map.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.IConfigMap.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.IConfigMap.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4639,9 +4757,9 @@ The Kubernetes name of this resource.
 
 ---
 
-### IPodSpec <a name="cdk8s-plus-21.IPodSpec"></a>
+### IPodSpec <a name="cdk8s-plus-22.IPodSpec"></a>
 
-- *Implemented By:* [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment), [`cdk8s-plus-21.Job`](#cdk8s-plus-21.Job), [`cdk8s-plus-21.Pod`](#cdk8s-plus-21.Pod), [`cdk8s-plus-21.PodSpec`](#cdk8s-plus-21.PodSpec), [`cdk8s-plus-21.PodTemplate`](#cdk8s-plus-21.PodTemplate), [`cdk8s-plus-21.StatefulSet`](#cdk8s-plus-21.StatefulSet), [`cdk8s-plus-21.IPodSpec`](#cdk8s-plus-21.IPodSpec), [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
+- *Implemented By:* [`cdk8s-plus-22.Deployment`](#cdk8s-plus-22.Deployment), [`cdk8s-plus-22.Job`](#cdk8s-plus-22.Job), [`cdk8s-plus-22.Pod`](#cdk8s-plus-22.Pod), [`cdk8s-plus-22.PodSpec`](#cdk8s-plus-22.PodSpec), [`cdk8s-plus-22.PodTemplate`](#cdk8s-plus-22.PodTemplate), [`cdk8s-plus-22.StatefulSet`](#cdk8s-plus-22.StatefulSet), [`cdk8s-plus-22.IPodSpec`](#cdk8s-plus-22.IPodSpec), [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod spec. (e.g `Deployment`, `Job`, `Pod`, ...).
 
@@ -4649,29 +4767,29 @@ Use the `PodSpec` class as an implementation helper.
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-21.IPodSpec.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-22.IPodSpec.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.IPodSpec.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
+- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
 
 The container.
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-21.IPodSpec.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-22.IPodSpec.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.IPodSpec.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
 
 The volume.
 
@@ -4679,13 +4797,13 @@ The volume.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.IPodSpec.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
+- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
 
 The containers belonging to the pod.
 
@@ -4693,13 +4811,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.IPodSpec.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 
 The volumes associated with this pod.
 
@@ -4707,35 +4825,35 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.IPodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.IPodSpec.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.IPodSpec.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.IPodSpec.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-### IPodTemplate <a name="cdk8s-plus-21.IPodTemplate"></a>
+### IPodTemplate <a name="cdk8s-plus-22.IPodTemplate"></a>
 
-- *Extends:* [`cdk8s-plus-21.IPodSpec`](#cdk8s-plus-21.IPodSpec)
+- *Extends:* [`cdk8s-plus-22.IPodSpec`](#cdk8s-plus-22.IPodSpec)
 
-- *Implemented By:* [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment), [`cdk8s-plus-21.Job`](#cdk8s-plus-21.Job), [`cdk8s-plus-21.PodTemplate`](#cdk8s-plus-21.PodTemplate), [`cdk8s-plus-21.StatefulSet`](#cdk8s-plus-21.StatefulSet), [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
+- *Implemented By:* [`cdk8s-plus-22.Deployment`](#cdk8s-plus-22.Deployment), [`cdk8s-plus-22.Job`](#cdk8s-plus-22.Job), [`cdk8s-plus-22.PodTemplate`](#cdk8s-plus-22.PodTemplate), [`cdk8s-plus-22.StatefulSet`](#cdk8s-plus-22.StatefulSet), [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod template. (e.g `Deployment`, `Job`, ...).
 
@@ -4744,13 +4862,13 @@ Use the `PodTemplate` class as an implementation helper.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.IPodTemplate.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.IPodTemplate.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
+- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
 
 The containers belonging to the pod.
 
@@ -4758,13 +4876,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.IPodTemplate.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.IPodTemplate.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
+- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
 
 The volumes associated with this pod.
 
@@ -4772,31 +4890,31 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.IPodTemplate.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.IPodTemplate.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
+- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.IPodTemplate.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.IPodTemplate.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.IPodTemplate.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.IPodTemplate.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -4808,16 +4926,16 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-### IResource <a name="cdk8s-plus-21.IResource"></a>
+### IResource <a name="cdk8s-plus-22.IResource"></a>
 
-- *Implemented By:* [`cdk8s-plus-21.ConfigMap`](#cdk8s-plus-21.ConfigMap), [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment), [`cdk8s-plus-21.IngressV1Beta1`](#cdk8s-plus-21.IngressV1Beta1), [`cdk8s-plus-21.Job`](#cdk8s-plus-21.Job), [`cdk8s-plus-21.Pod`](#cdk8s-plus-21.Pod), [`cdk8s-plus-21.Resource`](#cdk8s-plus-21.Resource), [`cdk8s-plus-21.Secret`](#cdk8s-plus-21.Secret), [`cdk8s-plus-21.Service`](#cdk8s-plus-21.Service), [`cdk8s-plus-21.ServiceAccount`](#cdk8s-plus-21.ServiceAccount), [`cdk8s-plus-21.StatefulSet`](#cdk8s-plus-21.StatefulSet), [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap), [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource), [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret), [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Implemented By:* [`cdk8s-plus-22.ConfigMap`](#cdk8s-plus-22.ConfigMap), [`cdk8s-plus-22.Deployment`](#cdk8s-plus-22.Deployment), [`cdk8s-plus-22.Ingress`](#cdk8s-plus-22.Ingress), [`cdk8s-plus-22.Job`](#cdk8s-plus-22.Job), [`cdk8s-plus-22.Pod`](#cdk8s-plus-22.Pod), [`cdk8s-plus-22.Resource`](#cdk8s-plus-22.Resource), [`cdk8s-plus-22.Secret`](#cdk8s-plus-22.Secret), [`cdk8s-plus-22.Service`](#cdk8s-plus-22.Service), [`cdk8s-plus-22.ServiceAccount`](#cdk8s-plus-22.ServiceAccount), [`cdk8s-plus-22.StatefulSet`](#cdk8s-plus-22.StatefulSet), [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap), [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource), [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret), [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 Represents a resource.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.IResource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.IResource.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4829,16 +4947,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### ISecret <a name="cdk8s-plus-21.ISecret"></a>
+### ISecret <a name="cdk8s-plus-22.ISecret"></a>
 
-- *Extends:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
+- *Extends:* [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource)
 
-- *Implemented By:* [`cdk8s-plus-21.Secret`](#cdk8s-plus-21.Secret), [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
+- *Implemented By:* [`cdk8s-plus-22.Secret`](#cdk8s-plus-22.Secret), [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.ISecret.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.ISecret.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4850,16 +4968,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### IServiceAccount <a name="cdk8s-plus-21.IServiceAccount"></a>
+### IServiceAccount <a name="cdk8s-plus-22.IServiceAccount"></a>
 
-- *Extends:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
+- *Extends:* [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource)
 
-- *Implemented By:* [`cdk8s-plus-21.ServiceAccount`](#cdk8s-plus-21.ServiceAccount), [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Implemented By:* [`cdk8s-plus-22.ServiceAccount`](#cdk8s-plus-22.ServiceAccount), [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.IServiceAccount.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.IServiceAccount.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4877,14 +4995,14 @@ The Kubernetes name of this resource.
 
 The medium on which to store the volume.
 
-#### `DEFAULT` <a name="cdk8s-plus-21.EmptyDirMedium.DEFAULT"></a>
+#### `DEFAULT` <a name="cdk8s-plus-22.EmptyDirMedium.DEFAULT"></a>
 
 The default volume of the backing node.
 
 ---
 
 
-#### `MEMORY` <a name="cdk8s-plus-21.EmptyDirMedium.MEMORY"></a>
+#### `MEMORY` <a name="cdk8s-plus-22.EmptyDirMedium.MEMORY"></a>
 
 Mount a tmpfs (RAM-backed filesystem) for you instead.
 
@@ -4895,9 +5013,36 @@ files you write will count against your Container's memory limit.
 ---
 
 
+### HttpIngressPathType <a name="HttpIngressPathType"></a>
+
+Specify how the path is matched against request paths.
+
+> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+
+#### `PREFIX` <a name="cdk8s-plus-22.HttpIngressPathType.PREFIX"></a>
+
+Matches the URL path exactly.
+
+---
+
+
+#### `EXACT` <a name="cdk8s-plus-22.HttpIngressPathType.EXACT"></a>
+
+Matches based on a URL path prefix split by '/'.
+
+---
+
+
+#### `IMPLEMENTATION_SPECIFIC` <a name="cdk8s-plus-22.HttpIngressPathType.IMPLEMENTATION_SPECIFIC"></a>
+
+Matching is specified by the underlying IngressClass.
+
+---
+
+
 ### ImagePullPolicy <a name="ImagePullPolicy"></a>
 
-#### `ALWAYS` <a name="cdk8s-plus-21.ImagePullPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="cdk8s-plus-22.ImagePullPolicy.ALWAYS"></a>
 
 Every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest.
 
@@ -4911,7 +5056,7 @@ the image tag is omitted.
 ---
 
 
-#### `IF_NOT_PRESENT` <a name="cdk8s-plus-21.ImagePullPolicy.IF_NOT_PRESENT"></a>
+#### `IF_NOT_PRESENT` <a name="cdk8s-plus-22.ImagePullPolicy.IF_NOT_PRESENT"></a>
 
 The image is pulled only if it is not already present locally.
 
@@ -4921,7 +5066,7 @@ not :latest
 ---
 
 
-#### `NEVER` <a name="cdk8s-plus-21.ImagePullPolicy.NEVER"></a>
+#### `NEVER` <a name="cdk8s-plus-22.ImagePullPolicy.NEVER"></a>
 
 The image is assumed to exist locally.
 
@@ -4932,7 +5077,7 @@ No attempt is made to pull the image.
 
 ### MountPropagation <a name="MountPropagation"></a>
 
-#### `NONE` <a name="cdk8s-plus-21.MountPropagation.NONE"></a>
+#### `NONE` <a name="cdk8s-plus-22.MountPropagation.NONE"></a>
 
 This volume mount will not receive any subsequent mounts that are mounted to this volume or any of its subdirectories by the host.
 
@@ -4947,7 +5092,7 @@ kernel documentation
 ---
 
 
-#### `HOST_TO_CONTAINER` <a name="cdk8s-plus-21.MountPropagation.HOST_TO_CONTAINER"></a>
+#### `HOST_TO_CONTAINER` <a name="cdk8s-plus-22.MountPropagation.HOST_TO_CONTAINER"></a>
 
 This volume mount will receive all subsequent mounts that are mounted to this volume or any of its subdirectories.
 
@@ -4964,7 +5109,7 @@ kernel documentation
 ---
 
 
-#### `BIDIRECTIONAL` <a name="cdk8s-plus-21.MountPropagation.BIDIRECTIONAL"></a>
+#### `BIDIRECTIONAL` <a name="cdk8s-plus-22.MountPropagation.BIDIRECTIONAL"></a>
 
 This volume mount behaves the same the HostToContainer mount.
 
@@ -4998,29 +5143,29 @@ continuing. When scaling down, the pods are removed in the opposite order.
 The alternative policy is `Parallel` which will create pods in parallel to match the
 desired scale without waiting, and on scale down will delete all pods at once.
 
-#### `ORDERED_READY` <a name="cdk8s-plus-21.PodManagementPolicy.ORDERED_READY"></a>
+#### `ORDERED_READY` <a name="cdk8s-plus-22.PodManagementPolicy.ORDERED_READY"></a>
 
 ---
 
 
-#### `PARALLEL` <a name="cdk8s-plus-21.PodManagementPolicy.PARALLEL"></a>
+#### `PARALLEL` <a name="cdk8s-plus-22.PodManagementPolicy.PARALLEL"></a>
 
 ---
 
 
 ### Protocol <a name="Protocol"></a>
 
-#### `TCP` <a name="cdk8s-plus-21.Protocol.TCP"></a>
+#### `TCP` <a name="cdk8s-plus-22.Protocol.TCP"></a>
 
 ---
 
 
-#### `UDP` <a name="cdk8s-plus-21.Protocol.UDP"></a>
+#### `UDP` <a name="cdk8s-plus-22.Protocol.UDP"></a>
 
 ---
 
 
-#### `SCTP` <a name="cdk8s-plus-21.Protocol.SCTP"></a>
+#### `SCTP` <a name="cdk8s-plus-22.Protocol.SCTP"></a>
 
 ---
 
@@ -5029,21 +5174,21 @@ desired scale without waiting, and on scale down will delete all pods at once.
 
 Restart policy for all containers within the pod.
 
-#### `ALWAYS` <a name="cdk8s-plus-21.RestartPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="cdk8s-plus-22.RestartPolicy.ALWAYS"></a>
 
 Always restart the pod after it exits.
 
 ---
 
 
-#### `ON_FAILURE` <a name="cdk8s-plus-21.RestartPolicy.ON_FAILURE"></a>
+#### `ON_FAILURE` <a name="cdk8s-plus-22.RestartPolicy.ON_FAILURE"></a>
 
 Only restart if the pod exits with a non-zero exit code.
 
 ---
 
 
-#### `NEVER` <a name="cdk8s-plus-21.RestartPolicy.NEVER"></a>
+#### `NEVER` <a name="cdk8s-plus-22.RestartPolicy.NEVER"></a>
 
 Never restart the pod.
 
@@ -5057,7 +5202,7 @@ For some parts of your application (for example, frontends) you may want to expo
 Kubernetes ServiceTypes allow you to specify what kind of Service you want.
 The default is ClusterIP.
 
-#### `CLUSTER_IP` <a name="cdk8s-plus-21.ServiceType.CLUSTER_IP"></a>
+#### `CLUSTER_IP` <a name="cdk8s-plus-22.ServiceType.CLUSTER_IP"></a>
 
 Exposes the Service on a cluster-internal IP.
 
@@ -5067,7 +5212,7 @@ This is the default ServiceType
 ---
 
 
-#### `NODE_PORT` <a name="cdk8s-plus-21.ServiceType.NODE_PORT"></a>
+#### `NODE_PORT` <a name="cdk8s-plus-22.ServiceType.NODE_PORT"></a>
 
 Exposes the Service on each Node's IP at a static port (the NodePort).
 
@@ -5078,7 +5223,7 @@ by requesting <NodeIP>:<NodePort>.
 ---
 
 
-#### `LOAD_BALANCER` <a name="cdk8s-plus-21.ServiceType.LOAD_BALANCER"></a>
+#### `LOAD_BALANCER` <a name="cdk8s-plus-22.ServiceType.LOAD_BALANCER"></a>
 
 Exposes the Service externally using a cloud provider's load balancer.
 
@@ -5088,7 +5233,7 @@ are automatically created.
 ---
 
 
-#### `EXTERNAL_NAME` <a name="cdk8s-plus-21.ServiceType.EXTERNAL_NAME"></a>
+#### `EXTERNAL_NAME` <a name="cdk8s-plus-22.ServiceType.EXTERNAL_NAME"></a>
 
 Maps the Service to the contents of the externalName field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,47 +2,47 @@
 
 ## Constructs <a name="Constructs"></a>
 
-### ConfigMap <a name="cdk8s-plus-22.ConfigMap"></a>
+### ConfigMap <a name="cdk8s-plus-21.ConfigMap"></a>
 
-- *Implements:* [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap)
+- *Implements:* [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
 
 ConfigMap holds configuration data for pods to consume.
 
-#### Initializers <a name="cdk8s-plus-22.ConfigMap.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.ConfigMap.Initializer"></a>
 
 ```typescript
-import { ConfigMap } from 'cdk8s-plus-22'
+import { ConfigMap } from 'cdk8s-plus-21'
 
 new ConfigMap(scope: Construct, id: string, props?: ConfigMapProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.ConfigMapProps`](#cdk8s-plus-22.ConfigMapProps)
+- *Type:* [`cdk8s-plus-21.ConfigMapProps`](#cdk8s-plus-21.ConfigMapProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addBinaryData` <a name="cdk8s-plus-22.ConfigMap.addBinaryData"></a>
+##### `addBinaryData` <a name="cdk8s-plus-21.ConfigMap.addBinaryData"></a>
 
 ```typescript
 public addBinaryData(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -50,7 +50,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -58,13 +58,13 @@ The value.
 
 ---
 
-##### `addData` <a name="cdk8s-plus-22.ConfigMap.addData"></a>
+##### `addData` <a name="cdk8s-plus-21.ConfigMap.addData"></a>
 
 ```typescript
 public addData(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -72,7 +72,7 @@ The key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -80,13 +80,13 @@ The value.
 
 ---
 
-##### `addDirectory` <a name="cdk8s-plus-22.ConfigMap.addDirectory"></a>
+##### `addDirectory` <a name="cdk8s-plus-21.ConfigMap.addDirectory"></a>
 
 ```typescript
 public addDirectory(localDir: string, options?: AddDirectoryOptions)
 ```
 
-###### `localDir`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.localDir"></a>
+###### `localDir`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.localDir"></a>
 
 - *Type:* `string`
 
@@ -94,21 +94,21 @@ A path to a local directory.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.AddDirectoryOptions`](#cdk8s-plus-22.AddDirectoryOptions)
+- *Type:* [`cdk8s-plus-21.AddDirectoryOptions`](#cdk8s-plus-21.AddDirectoryOptions)
 
 Options.
 
 ---
 
-##### `addFile` <a name="cdk8s-plus-22.ConfigMap.addFile"></a>
+##### `addFile` <a name="cdk8s-plus-21.ConfigMap.addFile"></a>
 
 ```typescript
 public addFile(localFile: string, key?: string)
 ```
 
-###### `localFile`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.localFile"></a>
+###### `localFile`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.localFile"></a>
 
 - *Type:* `string`
 
@@ -116,7 +116,7 @@ The path to the local file.
 
 ---
 
-###### `key`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.key"></a>
+###### `key`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -126,15 +126,15 @@ The ConfigMap key (default to the file name).
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMapName` <a name="cdk8s-plus-22.ConfigMap.fromConfigMapName"></a>
+##### `fromConfigMapName` <a name="cdk8s-plus-21.ConfigMap.fromConfigMapName"></a>
 
 ```typescript
-import { ConfigMap } from 'cdk8s-plus-22'
+import { ConfigMap } from 'cdk8s-plus-21'
 
 ConfigMap.fromConfigMapName(name: string)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.parameter.name"></a>
 
 - *Type:* `string`
 
@@ -144,7 +144,7 @@ The name of the config map to import.
 
 #### Properties <a name="Properties"></a>
 
-##### `binaryData`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.property.binaryData"></a>
+##### `binaryData`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.property.binaryData"></a>
 
 ```typescript
 public readonly binaryData: {[ key: string ]: string};
@@ -158,7 +158,7 @@ Returns a copy. To add data records, use `addBinaryData()` or `addData()`.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.property.data"></a>
+##### `data`<sup>Required</sup> <a name="cdk8s-plus-21.ConfigMap.property.data"></a>
 
 ```typescript
 public readonly data: {[ key: string ]: string};
@@ -173,9 +173,9 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 ---
 
 
-### Deployment <a name="cdk8s-plus-22.Deployment"></a>
+### Deployment <a name="cdk8s-plus-21.Deployment"></a>
 
-- *Implements:* [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
+- *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
 
 A Deployment provides declarative updates for Pods and ReplicaSets.
 
@@ -202,79 +202,79 @@ The following are typical use cases for Deployments:
 - Use the status of the Deployment as an indicator that a rollout has stuck.
 - Clean up older ReplicaSets that you don't need anymore.
 
-#### Initializers <a name="cdk8s-plus-22.Deployment.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Deployment.Initializer"></a>
 
 ```typescript
-import { Deployment } from 'cdk8s-plus-22'
+import { Deployment } from 'cdk8s-plus-21'
 
 new Deployment(scope: Construct, id: string, props?: DeploymentProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Deployment.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Deployment.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.DeploymentProps`](#cdk8s-plus-22.DeploymentProps)
+- *Type:* [`cdk8s-plus-21.DeploymentProps`](#cdk8s-plus-21.DeploymentProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-22.Deployment.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-21.Deployment.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-22.Deployment.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-21.Deployment.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
 
 ---
 
-##### `expose` <a name="cdk8s-plus-22.Deployment.expose"></a>
+##### `expose` <a name="cdk8s-plus-21.Deployment.expose"></a>
 
 ```typescript
 public expose(options?: ExposeOptions)
 ```
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Deployment.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Deployment.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.ExposeOptions`](#cdk8s-plus-22.ExposeOptions)
+- *Type:* [`cdk8s-plus-21.ExposeOptions`](#cdk8s-plus-21.ExposeOptions)
 
 Options to determine details of the service and port exposed.
 
 ---
 
-##### `selectByLabel` <a name="cdk8s-plus-22.Deployment.selectByLabel"></a>
+##### `selectByLabel` <a name="cdk8s-plus-21.Deployment.selectByLabel"></a>
 
 ```typescript
 public selectByLabel(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -282,7 +282,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -293,13 +293,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
+- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
 
 The containers belonging to the pod.
 
@@ -307,7 +307,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `labelSelector`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.labelSelector"></a>
+##### `labelSelector`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.labelSelector"></a>
 
 ```typescript
 public readonly labelSelector: {[ key: string ]: string};
@@ -321,7 +321,7 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -333,7 +333,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.replicas"></a>
 
 ```typescript
 public readonly replicas: number;
@@ -345,13 +345,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 
 The volumes associated with this pod.
 
@@ -359,32 +359,32 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.Deployment.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.Deployment.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.Deployment.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.Deployment.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Ingress <a name="cdk8s-plus-22.Ingress"></a>
+### IngressV1Beta1 <a name="cdk8s-plus-21.IngressV1Beta1"></a>
 
 Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend.
 
@@ -392,55 +392,55 @@ An Ingress can be configured to give services
 externally-reachable urls, load balance traffic, terminate SSL, offer name
 based virtual hosting etc.
 
-#### Initializers <a name="cdk8s-plus-22.Ingress.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.IngressV1Beta1.Initializer"></a>
 
 ```typescript
-import { Ingress } from 'cdk8s-plus-22'
+import { IngressV1Beta1 } from 'cdk8s-plus-21'
 
-new Ingress(scope: Construct, id: string, props?: IngressProps)
+new IngressV1Beta1(scope: Construct, id: string, props?: IngressV1Beta1Props)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Ingress.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.IngressProps`](#cdk8s-plus-22.IngressProps)
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Props`](#cdk8s-plus-21.IngressV1Beta1Props)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addDefaultBackend` <a name="cdk8s-plus-22.Ingress.addDefaultBackend"></a>
+##### `addDefaultBackend` <a name="cdk8s-plus-21.IngressV1Beta1.addDefaultBackend"></a>
 
 ```typescript
-public addDefaultBackend(backend: IngressBackend)
+public addDefaultBackend(backend: IngressV1Beta1Backend)
 ```
 
-###### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
 
 The backend to use for requests that do not match any rule.
 
 ---
 
-##### `addHostDefaultBackend` <a name="cdk8s-plus-22.Ingress.addHostDefaultBackend"></a>
+##### `addHostDefaultBackend` <a name="cdk8s-plus-21.IngressV1Beta1.addHostDefaultBackend"></a>
 
 ```typescript
-public addHostDefaultBackend(host: string, backend: IngressBackend)
+public addHostDefaultBackend(host: string, backend: IngressV1Beta1Backend)
 ```
 
-###### `host`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.host"></a>
 
 - *Type:* `string`
 
@@ -448,21 +448,21 @@ The host name to match.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
 
 The backend to route to.
 
 ---
 
-##### `addHostRule` <a name="cdk8s-plus-22.Ingress.addHostRule"></a>
+##### `addHostRule` <a name="cdk8s-plus-21.IngressV1Beta1.addHostRule"></a>
 
 ```typescript
-public addHostRule(host: string, path: string, backend: IngressBackend, pathType?: HttpIngressPathType)
+public addHostRule(host: string, path: string, backend: IngressV1Beta1Backend)
 ```
 
-###### `host`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.host"></a>
+###### `host`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.host"></a>
 
 - *Type:* `string`
 
@@ -470,7 +470,7 @@ The host name.
 
 ---
 
-###### `path`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.path"></a>
 
 - *Type:* `string`
 
@@ -478,29 +478,21 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
 
 The backend to route requests to.
 
 ---
 
-###### `pathType`<sup>Optional</sup> <a name="cdk8s-plus-22.Ingress.parameter.pathType"></a>
-
-- *Type:* [`cdk8s-plus-22.HttpIngressPathType`](#cdk8s-plus-22.HttpIngressPathType)
-
-How the path is matched against request paths.
-
----
-
-##### `addRule` <a name="cdk8s-plus-22.Ingress.addRule"></a>
+##### `addRule` <a name="cdk8s-plus-21.IngressV1Beta1.addRule"></a>
 
 ```typescript
-public addRule(path: string, backend: IngressBackend, pathType?: HttpIngressPathType)
+public addRule(path: string, backend: IngressV1Beta1Backend)
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.path"></a>
 
 - *Type:* `string`
 
@@ -508,54 +500,46 @@ The HTTP path.
 
 ---
 
-###### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.backend"></a>
+###### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.backend"></a>
 
-- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
 
 The backend to route requests to.
 
 ---
 
-###### `pathType`<sup>Optional</sup> <a name="cdk8s-plus-22.Ingress.parameter.pathType"></a>
-
-- *Type:* [`cdk8s-plus-22.HttpIngressPathType`](#cdk8s-plus-22.HttpIngressPathType)
-
-How the path is matched against request paths.
-
----
-
-##### `addRules` <a name="cdk8s-plus-22.Ingress.addRules"></a>
+##### `addRules` <a name="cdk8s-plus-21.IngressV1Beta1.addRules"></a>
 
 ```typescript
-public addRules(rules: IngressRule)
+public addRules(rules: IngressV1Beta1Rule)
 ```
 
-###### `rules`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.rules"></a>
+###### `rules`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.rules"></a>
 
-- *Type:* [`cdk8s-plus-22.IngressRule`](#cdk8s-plus-22.IngressRule)
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Rule`](#cdk8s-plus-21.IngressV1Beta1Rule)
 
 The rules to add.
 
 ---
 
-##### `addTls` <a name="cdk8s-plus-22.Ingress.addTls"></a>
+##### `addTls` <a name="cdk8s-plus-21.IngressV1Beta1.addTls"></a>
 
 ```typescript
-public addTls(tls: IngressTls[])
+public addTls(tls: IngressV1Beta1Tls[])
 ```
 
-###### `tls`<sup>Required</sup> <a name="cdk8s-plus-22.Ingress.parameter.tls"></a>
+###### `tls`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1.parameter.tls"></a>
 
-- *Type:* [`cdk8s-plus-22.IngressTls`](#cdk8s-plus-22.IngressTls)[]
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Tls`](#cdk8s-plus-21.IngressV1Beta1Tls)[]
 
 ---
 
 
 
 
-### Job <a name="cdk8s-plus-22.Job"></a>
+### Job <a name="cdk8s-plus-21.Job"></a>
 
-- *Implements:* [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
+- *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
 
 A Job creates one or more Pods and ensures that a specified number of them successfully terminate.
 
@@ -565,68 +549,68 @@ Deleting a Job will clean up the Pods it created. A simple case is to create one
 The Job object will start a new Pod if the first Pod fails or is deleted (for example due to a node hardware failure or a node reboot).
 You can also use a Job to run multiple Pods in parallel.
 
-#### Initializers <a name="cdk8s-plus-22.Job.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Job.Initializer"></a>
 
 ```typescript
-import { Job } from 'cdk8s-plus-22'
+import { Job } from 'cdk8s-plus-21'
 
 new Job(scope: Construct, id: string, props?: JobProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Job.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Job.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.JobProps`](#cdk8s-plus-22.JobProps)
+- *Type:* [`cdk8s-plus-21.JobProps`](#cdk8s-plus-21.JobProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-22.Job.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-21.Job.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.Job.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-22.Job.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-21.Job.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.Job.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.Job.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.Job.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
+- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
 
 The containers belonging to the pod.
 
@@ -634,7 +618,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.Job.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.Job.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -646,13 +630,13 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.Job.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.Job.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 
 The volumes associated with this pod.
 
@@ -660,7 +644,7 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.activeDeadline"></a>
 
 ```typescript
 public readonly activeDeadline: Duration;
@@ -674,7 +658,7 @@ If undefined, there is no deadline.
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.backoffLimit"></a>
 
 ```typescript
 public readonly backoffLimit: number;
@@ -686,31 +670,31 @@ Number of retries before marking failed.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="cdk8s-plus-22.Job.property.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="cdk8s-plus-21.Job.property.ttlAfterFinished"></a>
 
 ```typescript
 public readonly ttlAfterFinished: Duration;
@@ -723,77 +707,77 @@ TTL before the job is deleted after it is finished.
 ---
 
 
-### Pod <a name="cdk8s-plus-22.Pod"></a>
+### Pod <a name="cdk8s-plus-21.Pod"></a>
 
-- *Implements:* [`cdk8s-plus-22.IPodSpec`](#cdk8s-plus-22.IPodSpec)
+- *Implements:* [`cdk8s-plus-21.IPodSpec`](#cdk8s-plus-21.IPodSpec)
 
 Pod is a collection of containers that can run on a host.
 
 This resource is
 created by clients and scheduled onto hosts.
 
-#### Initializers <a name="cdk8s-plus-22.Pod.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Pod.Initializer"></a>
 
 ```typescript
-import { Pod } from 'cdk8s-plus-22'
+import { Pod } from 'cdk8s-plus-21'
 
 new Pod(scope: Construct, id: string, props?: PodProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Pod.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Pod.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.PodProps`](#cdk8s-plus-22.PodProps)
+- *Type:* [`cdk8s-plus-21.PodProps`](#cdk8s-plus-21.PodProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-22.Pod.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-21.Pod.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-22.Pod.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-21.Pod.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
+- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
 
 The containers belonging to the pod.
 
@@ -801,13 +785,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.Pod.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 
 The volumes associated with this pod.
 
@@ -815,49 +799,49 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.Pod.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.Pod.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.Pod.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.Pod.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### Resource <a name="cdk8s-plus-22.Resource"></a>
+### Resource <a name="cdk8s-plus-21.Resource"></a>
 
-- *Implements:* [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource)
+- *Implements:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
 
 Base class for all Kubernetes objects in stdk8s.
 
 Represents a single
 resource.
 
-#### Initializers <a name="cdk8s-plus-22.Resource.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Resource.Initializer"></a>
 
 ```typescript
-import { Resource } from 'cdk8s-plus-22'
+import { Resource } from 'cdk8s-plus-21'
 
 new Resource(scope: Construct, id: string, options?: ConstructOptions)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Resource.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Resource.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
@@ -865,7 +849,7 @@ The scope in which to define this construct.
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Resource.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Resource.parameter.id"></a>
 
 - *Type:* `string`
 
@@ -877,7 +861,7 @@ dash `--`.
 
 ---
 
-##### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Resource.parameter.options"></a>
+##### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Resource.parameter.options"></a>
 
 - *Type:* [`constructs.ConstructOptions`](#constructs.ConstructOptions)
 
@@ -889,7 +873,7 @@ Options.
 
 #### Properties <a name="Properties"></a>
 
-##### `metadata`<sup>Required</sup> <a name="cdk8s-plus-22.Resource.property.metadata"></a>
+##### `metadata`<sup>Required</sup> <a name="cdk8s-plus-21.Resource.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadataDefinition;
@@ -899,7 +883,7 @@ public readonly metadata: ApiObjectMetadataDefinition;
 
 ---
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Resource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Resource.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -912,9 +896,9 @@ The name of this API object.
 ---
 
 
-### Secret <a name="cdk8s-plus-22.Secret"></a>
+### Secret <a name="cdk8s-plus-21.Secret"></a>
 
-- *Implements:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
+- *Implements:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
 
 Kubernetes Secrets let you store and manage sensitive information, such as passwords, OAuth tokens, and ssh keys.
 
@@ -924,41 +908,41 @@ definition or in a container image.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
 
-#### Initializers <a name="cdk8s-plus-22.Secret.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Secret.Initializer"></a>
 
 ```typescript
-import { Secret } from 'cdk8s-plus-22'
+import { Secret } from 'cdk8s-plus-21'
 
 new Secret(scope: Construct, id: string, props?: SecretProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Secret.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Secret.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.SecretProps`](#cdk8s-plus-22.SecretProps)
+- *Type:* [`cdk8s-plus-21.SecretProps`](#cdk8s-plus-21.SecretProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addStringData` <a name="cdk8s-plus-22.Secret.addStringData"></a>
+##### `addStringData` <a name="cdk8s-plus-21.Secret.addStringData"></a>
 
 ```typescript
 public addStringData(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -966,7 +950,7 @@ Key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -974,13 +958,13 @@ Value.
 
 ---
 
-##### `getStringData` <a name="cdk8s-plus-22.Secret.getStringData"></a>
+##### `getStringData` <a name="cdk8s-plus-21.Secret.getStringData"></a>
 
 ```typescript
 public getStringData(key: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -990,15 +974,15 @@ Key.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromSecretName` <a name="cdk8s-plus-22.Secret.fromSecretName"></a>
+##### `fromSecretName` <a name="cdk8s-plus-21.Secret.fromSecretName"></a>
 
 ```typescript
-import { Secret } from 'cdk8s-plus-22'
+import { Secret } from 'cdk8s-plus-21'
 
 Secret.fromSecretName(name: string)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.parameter.name"></a>
 
 - *Type:* `string`
 
@@ -1008,7 +992,7 @@ The name of the secret to reference.
 
 
 
-### Service <a name="cdk8s-plus-22.Service"></a>
+### Service <a name="cdk8s-plus-21.Service"></a>
 
 An abstract way to expose an application running on a set of Pods as a network service.
 
@@ -1024,63 +1008,63 @@ If you're able to use Kubernetes APIs for service discovery in your application,
 that get updated whenever the set of Pods in a Service changes. For non-native applications, Kubernetes offers ways to place a network port
 or load balancer in between your application and the backend Pods.
 
-#### Initializers <a name="cdk8s-plus-22.Service.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Service.Initializer"></a>
 
 ```typescript
-import { Service } from 'cdk8s-plus-22'
+import { Service } from 'cdk8s-plus-21'
 
 new Service(scope: Construct, id: string, props?: ServiceProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.ServiceProps`](#cdk8s-plus-22.ServiceProps)
+- *Type:* [`cdk8s-plus-21.ServiceProps`](#cdk8s-plus-21.ServiceProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addDeployment` <a name="cdk8s-plus-22.Service.addDeployment"></a>
+##### `addDeployment` <a name="cdk8s-plus-21.Service.addDeployment"></a>
 
 ```typescript
 public addDeployment(deployment: Deployment, options?: AddDeploymentOptions)
 ```
 
-###### `deployment`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.deployment"></a>
+###### `deployment`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.deployment"></a>
 
-- *Type:* [`cdk8s-plus-22.Deployment`](#cdk8s-plus-22.Deployment)
+- *Type:* [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment)
 
 The deployment to expose.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.AddDeploymentOptions`](#cdk8s-plus-22.AddDeploymentOptions)
+- *Type:* [`cdk8s-plus-21.AddDeploymentOptions`](#cdk8s-plus-21.AddDeploymentOptions)
 
 Optional settings for the port.
 
 ---
 
-##### `addSelector` <a name="cdk8s-plus-22.Service.addSelector"></a>
+##### `addSelector` <a name="cdk8s-plus-21.Service.addSelector"></a>
 
 ```typescript
 public addSelector(label: string, value: string)
 ```
 
-###### `label`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.label"></a>
+###### `label`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.label"></a>
 
 - *Type:* `string`
 
@@ -1088,7 +1072,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -1096,13 +1080,13 @@ The label value.
 
 ---
 
-##### `serve` <a name="cdk8s-plus-22.Service.serve"></a>
+##### `serve` <a name="cdk8s-plus-21.Service.serve"></a>
 
 ```typescript
 public serve(port: number, options?: ServicePortOptions)
 ```
 
-###### `port`<sup>Required</sup> <a name="cdk8s-plus-22.Service.parameter.port"></a>
+###### `port`<sup>Required</sup> <a name="cdk8s-plus-21.Service.parameter.port"></a>
 
 - *Type:* `number`
 
@@ -1110,22 +1094,22 @@ The port definition.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.ServicePortOptions`](#cdk8s-plus-22.ServicePortOptions)
+- *Type:* [`cdk8s-plus-21.ServicePortOptions`](#cdk8s-plus-21.ServicePortOptions)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `ports`<sup>Required</sup> <a name="cdk8s-plus-22.Service.property.ports"></a>
+##### `ports`<sup>Required</sup> <a name="cdk8s-plus-21.Service.property.ports"></a>
 
 ```typescript
 public readonly ports: ServicePort[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ServicePort`](#cdk8s-plus-22.ServicePort)[]
+- *Type:* [`cdk8s-plus-21.ServicePort`](#cdk8s-plus-21.ServicePort)[]
 
 Ports for this service.
 
@@ -1133,7 +1117,7 @@ Use `serve()` to expose additional service ports.
 
 ---
 
-##### `selector`<sup>Required</sup> <a name="cdk8s-plus-22.Service.property.selector"></a>
+##### `selector`<sup>Required</sup> <a name="cdk8s-plus-21.Service.property.selector"></a>
 
 ```typescript
 public readonly selector: {[ key: string ]: string};
@@ -1145,19 +1129,19 @@ Returns the labels which are used to select pods for this service.
 
 ---
 
-##### `type`<sup>Required</sup> <a name="cdk8s-plus-22.Service.property.type"></a>
+##### `type`<sup>Required</sup> <a name="cdk8s-plus-21.Service.property.type"></a>
 
 ```typescript
 public readonly type: ServiceType;
 ```
 
-- *Type:* [`cdk8s-plus-22.ServiceType`](#cdk8s-plus-22.ServiceType)
+- *Type:* [`cdk8s-plus-21.ServiceType`](#cdk8s-plus-21.ServiceType)
 
 Determines how the Service is exposed.
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.property.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.property.clusterIP"></a>
 
 ```typescript
 public readonly clusterIP: string;
@@ -1169,7 +1153,7 @@ The IP address of the service and is usually assigned randomly by the master.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="cdk8s-plus-22.Service.property.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="cdk8s-plus-21.Service.property.externalName"></a>
 
 ```typescript
 public readonly externalName: string;
@@ -1182,9 +1166,9 @@ The externalName to be used for EXTERNAL_NAME types.
 ---
 
 
-### ServiceAccount <a name="cdk8s-plus-22.ServiceAccount"></a>
+### ServiceAccount <a name="cdk8s-plus-21.ServiceAccount"></a>
 
-- *Implements:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Implements:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 A service account provides an identity for processes that run in a Pod.
 
@@ -1197,43 +1181,43 @@ example, default).
 
 > https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account
 
-#### Initializers <a name="cdk8s-plus-22.ServiceAccount.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.ServiceAccount.Initializer"></a>
 
 ```typescript
-import { ServiceAccount } from 'cdk8s-plus-22'
+import { ServiceAccount } from 'cdk8s-plus-21'
 
 new ServiceAccount(scope: Construct, id: string, props?: ServiceAccountProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.ServiceAccountProps`](#cdk8s-plus-22.ServiceAccountProps)
+- *Type:* [`cdk8s-plus-21.ServiceAccountProps`](#cdk8s-plus-21.ServiceAccountProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addSecret` <a name="cdk8s-plus-22.ServiceAccount.addSecret"></a>
+##### `addSecret` <a name="cdk8s-plus-21.ServiceAccount.addSecret"></a>
 
 ```typescript
 public addSecret(secret: ISecret)
 ```
 
-###### `secret`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.secret"></a>
+###### `secret`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.secret"></a>
 
-- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
+- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
 
 The secret.
 
@@ -1241,15 +1225,15 @@ The secret.
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromServiceAccountName` <a name="cdk8s-plus-22.ServiceAccount.fromServiceAccountName"></a>
+##### `fromServiceAccountName` <a name="cdk8s-plus-21.ServiceAccount.fromServiceAccountName"></a>
 
 ```typescript
-import { ServiceAccount } from 'cdk8s-plus-22'
+import { ServiceAccount } from 'cdk8s-plus-21'
 
 ServiceAccount.fromServiceAccountName(name: string)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.parameter.name"></a>
 
 - *Type:* `string`
 
@@ -1259,13 +1243,13 @@ The name of the service account resource.
 
 #### Properties <a name="Properties"></a>
 
-##### `secrets`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccount.property.secrets"></a>
+##### `secrets`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccount.property.secrets"></a>
 
 ```typescript
 public readonly secrets: ISecret[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)[]
+- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)[]
 
 List of secrets allowed to be used by pods running using this service account.
 
@@ -1274,9 +1258,9 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
-### StatefulSet <a name="cdk8s-plus-22.StatefulSet"></a>
+### StatefulSet <a name="cdk8s-plus-21.StatefulSet"></a>
 
-- *Implements:* [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
+- *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
 
 StatefulSet is the workload API object used to manage stateful applications.
 
@@ -1303,65 +1287,65 @@ StatefulSets are valuable for applications that require one or more of the follo
 - Ordered, graceful deployment and scaling.
 - Ordered, automated rolling updates.
 
-#### Initializers <a name="cdk8s-plus-22.StatefulSet.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.StatefulSet.Initializer"></a>
 
 ```typescript
-import { StatefulSet } from 'cdk8s-plus-22'
+import { StatefulSet } from 'cdk8s-plus-21'
 
 new StatefulSet(scope: Construct, id: string, props: StatefulSetProps)
 ```
 
-##### `scope`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.scope"></a>
 
 - *Type:* [`constructs.Construct`](#constructs.Construct)
 
 ---
 
-##### `id`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.id"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `props`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.StatefulSetProps`](#cdk8s-plus-22.StatefulSetProps)
+- *Type:* [`cdk8s-plus-21.StatefulSetProps`](#cdk8s-plus-21.StatefulSetProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-22.StatefulSet.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-21.StatefulSet.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-22.StatefulSet.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-21.StatefulSet.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
 
 ---
 
-##### `selectByLabel` <a name="cdk8s-plus-22.StatefulSet.selectByLabel"></a>
+##### `selectByLabel` <a name="cdk8s-plus-21.StatefulSet.selectByLabel"></a>
 
 ```typescript
 public selectByLabel(key: string, value: string)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -1369,7 +1353,7 @@ The label key.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -1380,13 +1364,13 @@ The label value.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
+- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
 
 The containers belonging to the pod.
 
@@ -1394,7 +1378,7 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `labelSelector`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.labelSelector"></a>
+##### `labelSelector`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.labelSelector"></a>
 
 ```typescript
 public readonly labelSelector: {[ key: string ]: string};
@@ -1408,19 +1392,19 @@ Returns a a copy. Use `selectByLabel()` to add labels.
 
 ---
 
-##### `podManagementPolicy`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.podManagementPolicy"></a>
 
 ```typescript
 public readonly podManagementPolicy: PodManagementPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.PodManagementPolicy`](#cdk8s-plus-22.PodManagementPolicy)
+- *Type:* [`cdk8s-plus-21.PodManagementPolicy`](#cdk8s-plus-21.PodManagementPolicy)
 
 Management policy to use for the set.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -1432,7 +1416,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-##### `replicas`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.replicas"></a>
+##### `replicas`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.replicas"></a>
 
 ```typescript
 public readonly replicas: number;
@@ -1444,13 +1428,13 @@ Number of desired pods.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 
 The volumes associated with this pod.
 
@@ -1458,25 +1442,25 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSet.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSet.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSet.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSet.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 The service account used to run this pod.
 
@@ -1485,19 +1469,19 @@ The service account used to run this pod.
 
 ## Structs <a name="Structs"></a>
 
-### AddDeploymentOptions <a name="cdk8s-plus-22.AddDeploymentOptions"></a>
+### AddDeploymentOptions <a name="cdk8s-plus-21.AddDeploymentOptions"></a>
 
 Options to add a deployment to a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { AddDeploymentOptions } from 'cdk8s-plus-22'
+import { AddDeploymentOptions } from 'cdk8s-plus-21'
 
 const addDeploymentOptions: AddDeploymentOptions = { ... }
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDeploymentOptions.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -1514,7 +1498,7 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDeploymentOptions.property.nodePort"></a>
 
 ```typescript
 public readonly nodePort: number;
@@ -1534,13 +1518,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDeploymentOptions.property.protocol"></a>
 
 ```typescript
 public readonly protocol: Protocol;
 ```
 
-- *Type:* [`cdk8s-plus-22.Protocol`](#cdk8s-plus-22.Protocol)
+- *Type:* [`cdk8s-plus-21.Protocol`](#cdk8s-plus-21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -1549,7 +1533,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDeploymentOptions.property.targetPort"></a>
 
 ```typescript
 public readonly targetPort: number;
@@ -1562,7 +1546,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDeploymentOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDeploymentOptions.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -1575,19 +1559,19 @@ The port number the service will bind to.
 
 ---
 
-### AddDirectoryOptions <a name="cdk8s-plus-22.AddDirectoryOptions"></a>
+### AddDirectoryOptions <a name="cdk8s-plus-21.AddDirectoryOptions"></a>
 
 Options for `configmap.addDirectory()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { AddDirectoryOptions } from 'cdk8s-plus-22'
+import { AddDirectoryOptions } from 'cdk8s-plus-21'
 
 const addDirectoryOptions: AddDirectoryOptions = { ... }
 ```
 
-##### `exclude`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDirectoryOptions.property.exclude"></a>
+##### `exclude`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDirectoryOptions.property.exclude"></a>
 
 ```typescript
 public readonly exclude: string[];
@@ -1600,7 +1584,7 @@ Glob patterns to exclude when adding files.
 
 ---
 
-##### `keyPrefix`<sup>Optional</sup> <a name="cdk8s-plus-22.AddDirectoryOptions.property.keyPrefix"></a>
+##### `keyPrefix`<sup>Optional</sup> <a name="cdk8s-plus-21.AddDirectoryOptions.property.keyPrefix"></a>
 
 ```typescript
 public readonly keyPrefix: string;
@@ -1613,19 +1597,19 @@ A prefix to add to all keys in the config map.
 
 ---
 
-### CommandProbeOptions <a name="cdk8s-plus-22.CommandProbeOptions"></a>
+### CommandProbeOptions <a name="cdk8s-plus-21.CommandProbeOptions"></a>
 
 Options for `Probe.fromCommand()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { CommandProbeOptions } from 'cdk8s-plus-22'
+import { CommandProbeOptions } from 'cdk8s-plus-21'
 
 const commandProbeOptions: CommandProbeOptions = { ... }
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.failureThreshold"></a>
 
 ```typescript
 public readonly failureThreshold: number;
@@ -1640,7 +1624,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.initialDelaySeconds"></a>
 
 ```typescript
 public readonly initialDelaySeconds: Duration;
@@ -1655,7 +1639,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.periodSeconds"></a>
 
 ```typescript
 public readonly periodSeconds: Duration;
@@ -1670,7 +1654,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.successThreshold"></a>
 
 ```typescript
 public readonly successThreshold: number;
@@ -1685,7 +1669,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.CommandProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.CommandProbeOptions.property.timeoutSeconds"></a>
 
 ```typescript
 public readonly timeoutSeconds: Duration;
@@ -1702,19 +1686,19 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="cdk8s-plus-22.ConfigMapProps"></a>
+### ConfigMapProps <a name="cdk8s-plus-21.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ConfigMapProps } from 'cdk8s-plus-22'
+import { ConfigMapProps } from 'cdk8s-plus-21'
 
 const configMapProps: ConfigMapProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -1726,7 +1710,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `binaryData`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapProps.property.binaryData"></a>
+##### `binaryData`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapProps.property.binaryData"></a>
 
 ```typescript
 public readonly binaryData: {[ key: string ]: string};
@@ -1746,7 +1730,7 @@ You can also add binary data using `configMap.addBinaryData()`.
 
 ---
 
-##### `data`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapProps.property.data"></a>
+##### `data`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapProps.property.data"></a>
 
 ```typescript
 public readonly data: {[ key: string ]: string};
@@ -1765,19 +1749,19 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="cdk8s-plus-22.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="cdk8s-plus-21.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ConfigMapVolumeOptions } from 'cdk8s-plus-22'
+import { ConfigMapVolumeOptions } from 'cdk8s-plus-21'
 
 const configMapVolumeOptions: ConfigMapVolumeOptions = { ... }
 ```
 
-##### `defaultMode`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapVolumeOptions.property.defaultMode"></a>
+##### `defaultMode`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapVolumeOptions.property.defaultMode"></a>
 
 ```typescript
 public readonly defaultMode: number;
@@ -1797,13 +1781,13 @@ file mode, like fsGroup, and the result can be other mode bits set.
 
 ---
 
-##### `items`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapVolumeOptions.property.items"></a>
+##### `items`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapVolumeOptions.property.items"></a>
 
 ```typescript
 public readonly items: {[ key: string ]: PathMapping};
 ```
 
-- *Type:* {[ key: string ]: [`cdk8s-plus-22.PathMapping`](#cdk8s-plus-22.PathMapping)}
+- *Type:* {[ key: string ]: [`cdk8s-plus-21.PathMapping`](#cdk8s-plus-21.PathMapping)}
 - *Default:* no mapping
 
 If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value.
@@ -1816,7 +1800,7 @@ contain the '..' path or start with '..'.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapVolumeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapVolumeOptions.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -1829,7 +1813,7 @@ The volume name.
 
 ---
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapVolumeOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-21.ConfigMapVolumeOptions.property.optional"></a>
 
 ```typescript
 public readonly optional: boolean;
@@ -1842,19 +1826,19 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
-### ContainerProps <a name="cdk8s-plus-22.ContainerProps"></a>
+### ContainerProps <a name="cdk8s-plus-21.ContainerProps"></a>
 
 Properties for creating a container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ContainerProps } from 'cdk8s-plus-22'
+import { ContainerProps } from 'cdk8s-plus-21'
 
 const containerProps: ContainerProps = { ... }
 ```
 
-##### `image`<sup>Required</sup> <a name="cdk8s-plus-22.ContainerProps.property.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s-plus-21.ContainerProps.property.image"></a>
 
 ```typescript
 public readonly image: string;
@@ -1866,7 +1850,7 @@ Docker image name.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.args"></a>
 
 ```typescript
 public readonly args: string[];
@@ -1889,7 +1873,7 @@ Cannot be updated.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.command"></a>
 
 ```typescript
 public readonly command: string[];
@@ -1907,13 +1891,13 @@ More info: https://kubernetes.io/docs/tasks/inject-data-application/define-comma
 
 ---
 
-##### `env`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.env"></a>
+##### `env`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.env"></a>
 
 ```typescript
 public readonly env: {[ key: string ]: EnvValue};
 ```
 
-- *Type:* {[ key: string ]: [`cdk8s-plus-22.EnvValue`](#cdk8s-plus-22.EnvValue)}
+- *Type:* {[ key: string ]: [`cdk8s-plus-21.EnvValue`](#cdk8s-plus-21.EnvValue)}
 - *Default:* No environment variables.
 
 List of environment variables to set in the container.
@@ -1922,26 +1906,26 @@ Cannot be updated.
 
 ---
 
-##### `imagePullPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.imagePullPolicy"></a>
 
 ```typescript
 public readonly imagePullPolicy: ImagePullPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.ImagePullPolicy`](#cdk8s-plus-22.ImagePullPolicy)
+- *Type:* [`cdk8s-plus-21.ImagePullPolicy`](#cdk8s-plus-21.ImagePullPolicy)
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
 
 ---
 
-##### `liveness`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.liveness"></a>
+##### `liveness`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.liveness"></a>
 
 ```typescript
 public readonly liveness: Probe;
 ```
 
-- *Type:* [`cdk8s-plus-22.Probe`](#cdk8s-plus-22.Probe)
+- *Type:* [`cdk8s-plus-21.Probe`](#cdk8s-plus-21.Probe)
 - *Default:* no liveness probe is defined
 
 Periodic probe of container liveness.
@@ -1950,7 +1934,7 @@ Container will be restarted if the probe fails.
 
 ---
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -1965,7 +1949,7 @@ Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -1980,26 +1964,26 @@ This must be a valid port number, 0 < x < 65536.
 
 ---
 
-##### `readiness`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.readiness"></a>
+##### `readiness`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.readiness"></a>
 
 ```typescript
 public readonly readiness: Probe;
 ```
 
-- *Type:* [`cdk8s-plus-22.Probe`](#cdk8s-plus-22.Probe)
+- *Type:* [`cdk8s-plus-21.Probe`](#cdk8s-plus-21.Probe)
 - *Default:* no readiness probe is defined
 
 Determines when the container is ready to serve traffic.
 
 ---
 
-##### `startup`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.startup"></a>
+##### `startup`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.startup"></a>
 
 ```typescript
 public readonly startup: Probe;
 ```
 
-- *Type:* [`cdk8s-plus-22.Probe`](#cdk8s-plus-22.Probe)
+- *Type:* [`cdk8s-plus-21.Probe`](#cdk8s-plus-21.Probe)
 - *Default:* no startup probe is defined.
 
 StartupProbe indicates that the Pod has successfully initialized.
@@ -2008,13 +1992,13 @@ If specified, no other probes are executed until this completes successfully
 
 ---
 
-##### `volumeMounts`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.volumeMounts"></a>
+##### `volumeMounts`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.volumeMounts"></a>
 
 ```typescript
 public readonly volumeMounts: VolumeMount[];
 ```
 
-- *Type:* [`cdk8s-plus-22.VolumeMount`](#cdk8s-plus-22.VolumeMount)[]
+- *Type:* [`cdk8s-plus-21.VolumeMount`](#cdk8s-plus-21.VolumeMount)[]
 
 Pod volumes to mount into the container's filesystem.
 
@@ -2022,7 +2006,7 @@ Cannot be updated.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="cdk8s-plus-22.ContainerProps.property.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="cdk8s-plus-21.ContainerProps.property.workingDir"></a>
 
 ```typescript
 public readonly workingDir: string;
@@ -2037,19 +2021,19 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
-### DeploymentProps <a name="cdk8s-plus-22.DeploymentProps"></a>
+### DeploymentProps <a name="cdk8s-plus-21.DeploymentProps"></a>
 
 Properties for initialization of `Deployment`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { DeploymentProps } from 'cdk8s-plus-22'
+import { DeploymentProps } from 'cdk8s-plus-21'
 
 const deploymentProps: DeploymentProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -2061,13 +2045,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2079,13 +2063,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2094,13 +2078,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2116,13 +2100,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2133,7 +2117,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadata;
@@ -2145,7 +2129,7 @@ The pod metadata.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.defaultSelector"></a>
 
 ```typescript
 public readonly defaultSelector: boolean;
@@ -2161,7 +2145,7 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.replicas"></a>
 
 ```typescript
 public readonly replicas: number;
@@ -2174,25 +2158,25 @@ Number of desired pods.
 
 ---
 
-### EmptyDirVolumeOptions <a name="cdk8s-plus-22.EmptyDirVolumeOptions"></a>
+### EmptyDirVolumeOptions <a name="cdk8s-plus-21.EmptyDirVolumeOptions"></a>
 
 Options for volumes populated with an empty directory.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { EmptyDirVolumeOptions } from 'cdk8s-plus-22'
+import { EmptyDirVolumeOptions } from 'cdk8s-plus-21'
 
 const emptyDirVolumeOptions: EmptyDirVolumeOptions = { ... }
 ```
 
-##### `medium`<sup>Optional</sup> <a name="cdk8s-plus-22.EmptyDirVolumeOptions.property.medium"></a>
+##### `medium`<sup>Optional</sup> <a name="cdk8s-plus-21.EmptyDirVolumeOptions.property.medium"></a>
 
 ```typescript
 public readonly medium: EmptyDirMedium;
 ```
 
-- *Type:* [`cdk8s-plus-22.EmptyDirMedium`](#cdk8s-plus-22.EmptyDirMedium)
+- *Type:* [`cdk8s-plus-21.EmptyDirMedium`](#cdk8s-plus-21.EmptyDirMedium)
 - *Default:* EmptyDirMedium.DEFAULT
 
 By default, emptyDir volumes are stored on whatever medium is backing the node - that might be disk or SSD or network storage, depending on your environment.
@@ -2205,7 +2189,7 @@ against your Container's memory limit.
 
 ---
 
-##### `sizeLimit`<sup>Optional</sup> <a name="cdk8s-plus-22.EmptyDirVolumeOptions.property.sizeLimit"></a>
+##### `sizeLimit`<sup>Optional</sup> <a name="cdk8s-plus-21.EmptyDirVolumeOptions.property.sizeLimit"></a>
 
 ```typescript
 public readonly sizeLimit: Size;
@@ -2223,19 +2207,19 @@ here and the sum of memory limits of all containers in a pod.
 
 ---
 
-### EnvValueFromConfigMapOptions <a name="cdk8s-plus-22.EnvValueFromConfigMapOptions"></a>
+### EnvValueFromConfigMapOptions <a name="cdk8s-plus-21.EnvValueFromConfigMapOptions"></a>
 
 Options to specify an envionment variable value from a ConfigMap key.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { EnvValueFromConfigMapOptions } from 'cdk8s-plus-22'
+import { EnvValueFromConfigMapOptions } from 'cdk8s-plus-21'
 
 const envValueFromConfigMapOptions: EnvValueFromConfigMapOptions = { ... }
 ```
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValueFromConfigMapOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValueFromConfigMapOptions.property.optional"></a>
 
 ```typescript
 public readonly optional: boolean;
@@ -2248,19 +2232,19 @@ Specify whether the ConfigMap or its key must be defined.
 
 ---
 
-### EnvValueFromProcessOptions <a name="cdk8s-plus-22.EnvValueFromProcessOptions"></a>
+### EnvValueFromProcessOptions <a name="cdk8s-plus-21.EnvValueFromProcessOptions"></a>
 
 Options to specify an environment variable value from the process environment.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { EnvValueFromProcessOptions } from 'cdk8s-plus-22'
+import { EnvValueFromProcessOptions } from 'cdk8s-plus-21'
 
 const envValueFromProcessOptions: EnvValueFromProcessOptions = { ... }
 ```
 
-##### `required`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValueFromProcessOptions.property.required"></a>
+##### `required`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValueFromProcessOptions.property.required"></a>
 
 ```typescript
 public readonly required: boolean;
@@ -2275,19 +2259,19 @@ If this is set to true, and the key does not exist, an error will thrown.
 
 ---
 
-### EnvValueFromSecretOptions <a name="cdk8s-plus-22.EnvValueFromSecretOptions"></a>
+### EnvValueFromSecretOptions <a name="cdk8s-plus-21.EnvValueFromSecretOptions"></a>
 
 Options to specify an environment variable value from a Secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { EnvValueFromSecretOptions } from 'cdk8s-plus-22'
+import { EnvValueFromSecretOptions } from 'cdk8s-plus-21'
 
 const envValueFromSecretOptions: EnvValueFromSecretOptions = { ... }
 ```
 
-##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValueFromSecretOptions.property.optional"></a>
+##### `optional`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValueFromSecretOptions.property.optional"></a>
 
 ```typescript
 public readonly optional: boolean;
@@ -2300,19 +2284,19 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="cdk8s-plus-22.ExposeOptions"></a>
+### ExposeOptions <a name="cdk8s-plus-21.ExposeOptions"></a>
 
 Options for exposing a deployment via a service.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ExposeOptions } from 'cdk8s-plus-22'
+import { ExposeOptions } from 'cdk8s-plus-21'
 
 const exposeOptions: ExposeOptions = { ... }
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -2327,7 +2311,7 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -2340,13 +2324,13 @@ The port that the service should serve on.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.protocol"></a>
 
 ```typescript
 public readonly protocol: Protocol;
 ```
 
-- *Type:* [`cdk8s-plus-22.Protocol`](#cdk8s-plus-22.Protocol)
+- *Type:* [`cdk8s-plus-21.Protocol`](#cdk8s-plus-21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -2355,20 +2339,20 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `serviceType`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.serviceType"></a>
+##### `serviceType`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.serviceType"></a>
 
 ```typescript
 public readonly serviceType: ServiceType;
 ```
 
-- *Type:* [`cdk8s-plus-22.ServiceType`](#cdk8s-plus-22.ServiceType)
+- *Type:* [`cdk8s-plus-21.ServiceType`](#cdk8s-plus-21.ServiceType)
 - *Default:* ClusterIP.
 
 The type of the exposed service.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-22.ExposeOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-21.ExposeOptions.property.targetPort"></a>
 
 ```typescript
 public readonly targetPort: number;
@@ -2381,19 +2365,19 @@ The port number the service will redirect to.
 
 ---
 
-### HttpGetProbeOptions <a name="cdk8s-plus-22.HttpGetProbeOptions"></a>
+### HttpGetProbeOptions <a name="cdk8s-plus-21.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { HttpGetProbeOptions } from 'cdk8s-plus-22'
+import { HttpGetProbeOptions } from 'cdk8s-plus-21'
 
 const httpGetProbeOptions: HttpGetProbeOptions = { ... }
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.failureThreshold"></a>
 
 ```typescript
 public readonly failureThreshold: number;
@@ -2408,7 +2392,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.initialDelaySeconds"></a>
 
 ```typescript
 public readonly initialDelaySeconds: Duration;
@@ -2423,7 +2407,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.periodSeconds"></a>
 
 ```typescript
 public readonly periodSeconds: Duration;
@@ -2438,7 +2422,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.successThreshold"></a>
 
 ```typescript
 public readonly successThreshold: number;
@@ -2453,7 +2437,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.timeoutSeconds"></a>
 
 ```typescript
 public readonly timeoutSeconds: Duration;
@@ -2470,7 +2454,7 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.HttpGetProbeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.HttpGetProbeOptions.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -2483,19 +2467,19 @@ The TCP port to use when sending the GET request.
 
 ---
 
-### IngressProps <a name="cdk8s-plus-22.IngressProps"></a>
+### IngressV1Beta1Props <a name="cdk8s-plus-21.IngressV1Beta1Props"></a>
 
 Properties for `Ingress`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { IngressProps } from 'cdk8s-plus-22'
+import { IngressV1Beta1Props } from 'cdk8s-plus-21'
 
-const ingressProps: IngressProps = { ... }
+const ingressV1Beta1Props: IngressV1Beta1Props = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Props.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -2507,13 +2491,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `defaultBackend`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressProps.property.defaultBackend"></a>
+##### `defaultBackend`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Props.property.defaultBackend"></a>
 
 ```typescript
-public readonly defaultBackend: IngressBackend;
+public readonly defaultBackend: IngressV1Beta1Backend;
 ```
 
-- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
 
 The default backend services requests that do not match any rule.
 
@@ -2522,13 +2506,13 @@ adding a rule with both `path` and `host` undefined.
 
 ---
 
-##### `rules`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressProps.property.rules"></a>
+##### `rules`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Props.property.rules"></a>
 
 ```typescript
-public readonly rules: IngressRule[];
+public readonly rules: IngressV1Beta1Rule[];
 ```
 
-- *Type:* [`cdk8s-plus-22.IngressRule`](#cdk8s-plus-22.IngressRule)[]
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Rule`](#cdk8s-plus-21.IngressV1Beta1Rule)[]
 
 Routing rules for this ingress.
 
@@ -2541,13 +2525,13 @@ You can also add rules later using `addRule()`, `addHostRule()`,
 
 ---
 
-##### `tls`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressProps.property.tls"></a>
+##### `tls`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Props.property.tls"></a>
 
 ```typescript
-public readonly tls: IngressTls[];
+public readonly tls: IngressV1Beta1Tls[];
 ```
 
-- *Type:* [`cdk8s-plus-22.IngressTls`](#cdk8s-plus-22.IngressTls)[]
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Tls`](#cdk8s-plus-21.IngressV1Beta1Tls)[]
 
 TLS settings for this ingress.
 
@@ -2559,7 +2543,7 @@ extension, if the ingress controller fulfilling the ingress supports SNI.
 
 ---
 
-### IngressRule <a name="cdk8s-plus-22.IngressRule"></a>
+### IngressV1Beta1Rule <a name="cdk8s-plus-21.IngressV1Beta1Rule"></a>
 
 Represents the rules mapping the paths under a specified host to the related backend services.
 
@@ -2569,24 +2553,24 @@ then routed to the backend associated with the matching path.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { IngressRule } from 'cdk8s-plus-22'
+import { IngressV1Beta1Rule } from 'cdk8s-plus-21'
 
-const ingressRule: IngressRule = { ... }
+const ingressV1Beta1Rule: IngressV1Beta1Rule = { ... }
 ```
 
-##### `backend`<sup>Required</sup> <a name="cdk8s-plus-22.IngressRule.property.backend"></a>
+##### `backend`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1Rule.property.backend"></a>
 
 ```typescript
-public readonly backend: IngressBackend;
+public readonly backend: IngressV1Beta1Backend;
 ```
 
-- *Type:* [`cdk8s-plus-22.IngressBackend`](#cdk8s-plus-22.IngressBackend)
+- *Type:* [`cdk8s-plus-21.IngressV1Beta1Backend`](#cdk8s-plus-21.IngressV1Beta1Backend)
 
 Backend defines the referenced service endpoint to which the traffic will be forwarded to.
 
 ---
 
-##### `host`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressRule.property.host"></a>
+##### `host`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Rule.property.host"></a>
 
 ```typescript
 public readonly host: string;
@@ -2608,7 +2592,7 @@ host before the IngressRuleValue.
 
 ---
 
-##### `path`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressRule.property.path"></a>
+##### `path`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Rule.property.path"></a>
 
 ```typescript
 public readonly path: string;
@@ -2622,36 +2606,19 @@ Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows
 
 ---
 
-##### `pathType`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressRule.property.pathType"></a>
-
-```typescript
-public readonly pathType: HttpIngressPathType;
-```
-
-- *Type:* [`cdk8s-plus-22.HttpIngressPathType`](#cdk8s-plus-22.HttpIngressPathType)
-
-Specify how the path is matched against request paths.
-
-By default, path
-types will be matched by prefix.
-
-> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-
----
-
-### IngressTls <a name="cdk8s-plus-22.IngressTls"></a>
+### IngressV1Beta1Tls <a name="cdk8s-plus-21.IngressV1Beta1Tls"></a>
 
 Represents the TLS configuration mapping that is passed to the ingress controller for SSL termination.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { IngressTls } from 'cdk8s-plus-22'
+import { IngressV1Beta1Tls } from 'cdk8s-plus-21'
 
-const ingressTls: IngressTls = { ... }
+const ingressV1Beta1Tls: IngressV1Beta1Tls = { ... }
 ```
 
-##### `hosts`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressTls.property.hosts"></a>
+##### `hosts`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Tls.property.hosts"></a>
 
 ```typescript
 public readonly hosts: string[];
@@ -2668,13 +2635,13 @@ this list must match the name/s used in the TLS Secret.
 
 ---
 
-##### `secret`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressTls.property.secret"></a>
+##### `secret`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Tls.property.secret"></a>
 
 ```typescript
 public readonly secret: ISecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
+- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
 - *Default:* If unspecified, it allows SSL routing based on SNI hostname.
 
 Secret is the secret that contains the certificate and key used to terminate SSL traffic on 443.
@@ -2685,19 +2652,19 @@ termination and value of the Host header is used for routing.
 
 ---
 
-### JobProps <a name="cdk8s-plus-22.JobProps"></a>
+### JobProps <a name="cdk8s-plus-21.JobProps"></a>
 
 Properties for initialization of `Job`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { JobProps } from 'cdk8s-plus-22'
+import { JobProps } from 'cdk8s-plus-21'
 
 const jobProps: JobProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -2709,13 +2676,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -2727,13 +2694,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -2742,13 +2709,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -2764,13 +2731,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -2781,7 +2748,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadata;
@@ -2793,7 +2760,7 @@ The pod metadata.
 
 ---
 
-##### `activeDeadline`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.activeDeadline"></a>
+##### `activeDeadline`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.activeDeadline"></a>
 
 ```typescript
 public readonly activeDeadline: Duration;
@@ -2806,7 +2773,7 @@ Specifies the duration the job may be active before the system tries to terminat
 
 ---
 
-##### `backoffLimit`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.backoffLimit"></a>
+##### `backoffLimit`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.backoffLimit"></a>
 
 ```typescript
 public readonly backoffLimit: number;
@@ -2819,7 +2786,7 @@ Specifies the number of retries before marking this job failed.
 
 ---
 
-##### `ttlAfterFinished`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.ttlAfterFinished"></a>
+##### `ttlAfterFinished`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.ttlAfterFinished"></a>
 
 ```typescript
 public readonly ttlAfterFinished: Duration;
@@ -2839,25 +2806,25 @@ field is alpha-level and is only honored by servers that enable the
 
 ---
 
-### MountOptions <a name="cdk8s-plus-22.MountOptions"></a>
+### MountOptions <a name="cdk8s-plus-21.MountOptions"></a>
 
 Options for mounts.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { MountOptions } from 'cdk8s-plus-22'
+import { MountOptions } from 'cdk8s-plus-21'
 
 const mountOptions: MountOptions = { ... }
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.propagation"></a>
 
 ```typescript
 public readonly propagation: MountPropagation;
 ```
 
-- *Type:* [`cdk8s-plus-22.MountPropagation`](#cdk8s-plus-22.MountPropagation)
+- *Type:* [`cdk8s-plus-21.MountPropagation`](#cdk8s-plus-21.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -2871,7 +2838,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.readOnly"></a>
+##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.readOnly"></a>
 
 ```typescript
 public readonly readOnly: boolean;
@@ -2886,7 +2853,7 @@ Defaults to false.
 
 ---
 
-##### `subPath`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.subPath"></a>
+##### `subPath`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.subPath"></a>
 
 ```typescript
 public readonly subPath: string;
@@ -2899,7 +2866,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `subPathExpr`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.subPathExpr"></a>
+##### `subPathExpr`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.subPathExpr"></a>
 
 ```typescript
 public readonly subPathExpr: string;
@@ -2920,19 +2887,19 @@ is beta in 1.15.
 
 ---
 
-### PathMapping <a name="cdk8s-plus-22.PathMapping"></a>
+### PathMapping <a name="cdk8s-plus-21.PathMapping"></a>
 
 Maps a string key to a path within a volume.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { PathMapping } from 'cdk8s-plus-22'
+import { PathMapping } from 'cdk8s-plus-21'
 
 const pathMapping: PathMapping = { ... }
 ```
 
-##### `path`<sup>Required</sup> <a name="cdk8s-plus-22.PathMapping.property.path"></a>
+##### `path`<sup>Required</sup> <a name="cdk8s-plus-21.PathMapping.property.path"></a>
 
 ```typescript
 public readonly path: string;
@@ -2948,7 +2915,7 @@ path. May not contain the path element '..'. May not start with the string
 
 ---
 
-##### `mode`<sup>Optional</sup> <a name="cdk8s-plus-22.PathMapping.property.mode"></a>
+##### `mode`<sup>Optional</sup> <a name="cdk8s-plus-21.PathMapping.property.mode"></a>
 
 ```typescript
 public readonly mode: number;
@@ -2964,19 +2931,19 @@ the result can be other mode bits set.
 
 ---
 
-### PodProps <a name="cdk8s-plus-22.PodProps"></a>
+### PodProps <a name="cdk8s-plus-21.PodProps"></a>
 
 Properties for initialization of `Pod`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { PodProps } from 'cdk8s-plus-22'
+import { PodProps } from 'cdk8s-plus-21'
 
 const podProps: PodProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -2988,13 +2955,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3006,13 +2973,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3021,13 +2988,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3043,13 +3010,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3060,25 +3027,25 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodSpecProps <a name="cdk8s-plus-22.PodSpecProps"></a>
+### PodSpecProps <a name="cdk8s-plus-21.PodSpecProps"></a>
 
 Properties of a `PodSpec`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { PodSpecProps } from 'cdk8s-plus-22'
+import { PodSpecProps } from 'cdk8s-plus-21'
 
 const podSpecProps: PodSpecProps = { ... }
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3090,13 +3057,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3105,13 +3072,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3127,13 +3094,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3144,7 +3111,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-### PodTemplateProps <a name="cdk8s-plus-22.PodTemplateProps"></a>
+### PodTemplateProps <a name="cdk8s-plus-21.PodTemplateProps"></a>
 
 Properties of a `PodTemplate`.
 
@@ -3153,18 +3120,18 @@ Adds metadata information on top of the spec.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { PodTemplateProps } from 'cdk8s-plus-22'
+import { PodTemplateProps } from 'cdk8s-plus-21'
 
 const podTemplateProps: PodTemplateProps = { ... }
 ```
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3176,13 +3143,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3191,13 +3158,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3213,13 +3180,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3230,7 +3197,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadata;
@@ -3242,19 +3209,19 @@ The pod metadata.
 
 ---
 
-### ProbeOptions <a name="cdk8s-plus-22.ProbeOptions"></a>
+### ProbeOptions <a name="cdk8s-plus-21.ProbeOptions"></a>
 
 Probe options.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ProbeOptions } from 'cdk8s-plus-22'
+import { ProbeOptions } from 'cdk8s-plus-21'
 
 const probeOptions: ProbeOptions = { ... }
 ```
 
-##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.failureThreshold"></a>
+##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.failureThreshold"></a>
 
 ```typescript
 public readonly failureThreshold: number;
@@ -3269,7 +3236,7 @@ Defaults to 3. Minimum value is 1.
 
 ---
 
-##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.initialDelaySeconds"></a>
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.initialDelaySeconds"></a>
 
 ```typescript
 public readonly initialDelaySeconds: Duration;
@@ -3284,7 +3251,7 @@ Number of seconds after the container has started before liveness probes are ini
 
 ---
 
-##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.periodSeconds"></a>
+##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.periodSeconds"></a>
 
 ```typescript
 public readonly periodSeconds: Duration;
@@ -3299,7 +3266,7 @@ Default to 10 seconds. Minimum value is 1.
 
 ---
 
-##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.successThreshold"></a>
+##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.successThreshold"></a>
 
 ```typescript
 public readonly successThreshold: number;
@@ -3314,7 +3281,7 @@ Must be 1 for liveness and startup. Minimum value is 1.
 
 ---
 
-##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.ProbeOptions.property.timeoutSeconds"></a>
+##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-21.ProbeOptions.property.timeoutSeconds"></a>
 
 ```typescript
 public readonly timeoutSeconds: Duration;
@@ -3331,19 +3298,19 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ResourceProps <a name="cdk8s-plus-22.ResourceProps"></a>
+### ResourceProps <a name="cdk8s-plus-21.ResourceProps"></a>
 
 Initialization properties for resources.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ResourceProps } from 'cdk8s-plus-22'
+import { ResourceProps } from 'cdk8s-plus-21'
 
 const resourceProps: ResourceProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.ResourceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ResourceProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3355,17 +3322,17 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-### SecretProps <a name="cdk8s-plus-22.SecretProps"></a>
+### SecretProps <a name="cdk8s-plus-21.SecretProps"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { SecretProps } from 'cdk8s-plus-22'
+import { SecretProps } from 'cdk8s-plus-21'
 
 const secretProps: SecretProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3377,7 +3344,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.stringData"></a>
 
 ```typescript
 public readonly stringData: {[ key: string ]: string};
@@ -3394,7 +3361,7 @@ output when reading from the API.
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.type"></a>
 
 ```typescript
 public readonly type: string;
@@ -3410,19 +3377,19 @@ handling of secret data by various controllers.
 
 ---
 
-### SecretValue <a name="cdk8s-plus-22.SecretValue"></a>
+### SecretValue <a name="cdk8s-plus-21.SecretValue"></a>
 
 Represents a specific value in JSON secret.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { SecretValue } from 'cdk8s-plus-22'
+import { SecretValue } from 'cdk8s-plus-21'
 
 const secretValue: SecretValue = { ... }
 ```
 
-##### `key`<sup>Required</sup> <a name="cdk8s-plus-22.SecretValue.property.key"></a>
+##### `key`<sup>Required</sup> <a name="cdk8s-plus-21.SecretValue.property.key"></a>
 
 ```typescript
 public readonly key: string;
@@ -3434,19 +3401,19 @@ The JSON key.
 
 ---
 
-##### `secret`<sup>Required</sup> <a name="cdk8s-plus-22.SecretValue.property.secret"></a>
+##### `secret`<sup>Required</sup> <a name="cdk8s-plus-21.SecretValue.property.secret"></a>
 
 ```typescript
 public readonly secret: ISecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
+- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
 
 The secret.
 
 ---
 
-### ServiceAccountProps <a name="cdk8s-plus-22.ServiceAccountProps"></a>
+### ServiceAccountProps <a name="cdk8s-plus-21.ServiceAccountProps"></a>
 
 Properties for initialization of `ServiceAccount`.
 
@@ -3455,12 +3422,12 @@ Properties for initialization of `ServiceAccount`.
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServiceAccountProps } from 'cdk8s-plus-22'
+import { ServiceAccountProps } from 'cdk8s-plus-21'
 
 const serviceAccountProps: ServiceAccountProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceAccountProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceAccountProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3472,13 +3439,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `secrets`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceAccountProps.property.secrets"></a>
+##### `secrets`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceAccountProps.property.secrets"></a>
 
 ```typescript
 public readonly secrets: ISecret[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)[]
+- *Type:* [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)[]
 
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
@@ -3486,19 +3453,19 @@ List of secrets allowed to be used by pods running using this ServiceAccount.
 
 ---
 
-### ServiceIngressBackendOptions <a name="cdk8s-plus-22.ServiceIngressBackendOptions"></a>
+### ServiceIngressV1BetaBackendOptions <a name="cdk8s-plus-21.ServiceIngressV1BetaBackendOptions"></a>
 
 Options for setting up backends for ingress rules.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServiceIngressBackendOptions } from 'cdk8s-plus-22'
+import { ServiceIngressV1BetaBackendOptions } from 'cdk8s-plus-21'
 
-const serviceIngressBackendOptions: ServiceIngressBackendOptions = { ... }
+const serviceIngressV1BetaBackendOptions: ServiceIngressV1BetaBackendOptions = { ... }
 ```
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceIngressBackendOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceIngressV1BetaBackendOptions.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -3516,19 +3483,19 @@ This option will fail if the service does not expose any ports.
 
 ---
 
-### ServicePort <a name="cdk8s-plus-22.ServicePort"></a>
+### ServicePort <a name="cdk8s-plus-21.ServicePort"></a>
 
 Definition of a service port.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServicePort } from 'cdk8s-plus-22'
+import { ServicePort } from 'cdk8s-plus-21'
 
 const servicePort: ServicePort = { ... }
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePort.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePort.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3545,7 +3512,7 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePort.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePort.property.nodePort"></a>
 
 ```typescript
 public readonly nodePort: number;
@@ -3565,13 +3532,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePort.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePort.property.protocol"></a>
 
 ```typescript
 public readonly protocol: Protocol;
 ```
 
-- *Type:* [`cdk8s-plus-22.Protocol`](#cdk8s-plus-22.Protocol)
+- *Type:* [`cdk8s-plus-21.Protocol`](#cdk8s-plus-21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -3580,7 +3547,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePort.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePort.property.targetPort"></a>
 
 ```typescript
 public readonly targetPort: number;
@@ -3593,7 +3560,7 @@ The port number the service will redirect to.
 
 ---
 
-##### `port`<sup>Required</sup> <a name="cdk8s-plus-22.ServicePort.property.port"></a>
+##### `port`<sup>Required</sup> <a name="cdk8s-plus-21.ServicePort.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -3605,17 +3572,17 @@ The port number the service will bind to.
 
 ---
 
-### ServicePortOptions <a name="cdk8s-plus-22.ServicePortOptions"></a>
+### ServicePortOptions <a name="cdk8s-plus-21.ServicePortOptions"></a>
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServicePortOptions } from 'cdk8s-plus-22'
+import { ServicePortOptions } from 'cdk8s-plus-21'
 
 const servicePortOptions: ServicePortOptions = { ... }
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePortOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePortOptions.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -3632,7 +3599,7 @@ on this service.
 
 ---
 
-##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePortOptions.property.nodePort"></a>
+##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePortOptions.property.nodePort"></a>
 
 ```typescript
 public readonly nodePort: number;
@@ -3652,13 +3619,13 @@ requires one.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePortOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePortOptions.property.protocol"></a>
 
 ```typescript
 public readonly protocol: Protocol;
 ```
 
-- *Type:* [`cdk8s-plus-22.Protocol`](#cdk8s-plus-22.Protocol)
+- *Type:* [`cdk8s-plus-21.Protocol`](#cdk8s-plus-21.Protocol)
 - *Default:* Protocol.TCP
 
 The IP protocol for this port.
@@ -3667,7 +3634,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-22.ServicePortOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-21.ServicePortOptions.property.targetPort"></a>
 
 ```typescript
 public readonly targetPort: number;
@@ -3680,19 +3647,19 @@ The port number the service will redirect to.
 
 ---
 
-### ServiceProps <a name="cdk8s-plus-22.ServiceProps"></a>
+### ServiceProps <a name="cdk8s-plus-21.ServiceProps"></a>
 
 Properties for initialization of `Service`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ServiceProps } from 'cdk8s-plus-22'
+import { ServiceProps } from 'cdk8s-plus-21'
 
 const serviceProps: ServiceProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3704,7 +3671,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `clusterIP`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.clusterIP"></a>
+##### `clusterIP`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.clusterIP"></a>
 
 ```typescript
 public readonly clusterIP: string;
@@ -3726,7 +3693,7 @@ ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.
 
 ---
 
-##### `externalIPs`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.externalIPs"></a>
+##### `externalIPs`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.externalIPs"></a>
 
 ```typescript
 public readonly externalIPs: string[];
@@ -3744,7 +3711,7 @@ Kubernetes system.
 
 ---
 
-##### `externalName`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.externalName"></a>
+##### `externalName`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.externalName"></a>
 
 ```typescript
 public readonly externalName: string;
@@ -3757,7 +3724,7 @@ The externalName to be used when ServiceType.EXTERNAL_NAME is set.
 
 ---
 
-##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.loadBalancerSourceRanges"></a>
+##### `loadBalancerSourceRanges`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.loadBalancerSourceRanges"></a>
 
 ```typescript
 public readonly loadBalancerSourceRanges: string[];
@@ -3771,13 +3738,13 @@ More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure
 
 ---
 
-##### `ports`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.ports"></a>
+##### `ports`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.ports"></a>
 
 ```typescript
 public readonly ports: ServicePort[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ServicePort`](#cdk8s-plus-22.ServicePort)[]
+- *Type:* [`cdk8s-plus-21.ServicePort`](#cdk8s-plus-21.ServicePort)[]
 
 The port exposed by this service.
 
@@ -3785,13 +3752,13 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#virt
 
 ---
 
-##### `type`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceProps.property.type"></a>
+##### `type`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceProps.property.type"></a>
 
 ```typescript
 public readonly type: ServiceType;
 ```
 
-- *Type:* [`cdk8s-plus-22.ServiceType`](#cdk8s-plus-22.ServiceType)
+- *Type:* [`cdk8s-plus-21.ServiceType`](#cdk8s-plus-21.ServiceType)
 - *Default:* ServiceType.ClusterIP
 
 Determines how the Service is exposed.
@@ -3800,19 +3767,19 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 
 ---
 
-### StatefulSetProps <a name="cdk8s-plus-22.StatefulSetProps"></a>
+### StatefulSetProps <a name="cdk8s-plus-21.StatefulSetProps"></a>
 
 Properties for initialization of `StatefulSet`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { StatefulSetProps } from 'cdk8s-plus-22'
+import { StatefulSetProps } from 'cdk8s-plus-21'
 
 const statefulSetProps: StatefulSetProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3824,13 +3791,13 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.containers"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.containers"></a>
 
 ```typescript
 public readonly containers: ContainerProps[];
 ```
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)[]
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)[]
 - *Default:* No containers. Note that a pod spec must include at least one container.
 
 List of containers belonging to the pod.
@@ -3842,13 +3809,13 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 - *Default:* RestartPolicy.ALWAYS
 
 Restart policy for all containers within the pod.
@@ -3857,13 +3824,13 @@ Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 - *Default:* No service account.
 
 A service account provides an identity for processes that run in a Pod.
@@ -3879,13 +3846,13 @@ Account (for example, default).
 
 ---
 
-##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.volumes"></a>
+##### `volumes`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 - *Default:* No volumes.
 
 List of volumes that can be mounted by containers belonging to the pod.
@@ -3896,7 +3863,7 @@ You can also add volumes later using `podSpec.addVolume()`
 
 ---
 
-##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.podMetadata"></a>
+##### `podMetadata`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadata;
@@ -3908,19 +3875,19 @@ The pod metadata.
 
 ---
 
-##### `service`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.service"></a>
+##### `service`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.service"></a>
 
 ```typescript
 public readonly service: Service;
 ```
 
-- *Type:* [`cdk8s-plus-22.Service`](#cdk8s-plus-22.Service)
+- *Type:* [`cdk8s-plus-21.Service`](#cdk8s-plus-21.Service)
 
 Service to associate with the statefulset.
 
 ---
 
-##### `defaultSelector`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.defaultSelector"></a>
+##### `defaultSelector`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.defaultSelector"></a>
 
 ```typescript
 public readonly defaultSelector: boolean;
@@ -3936,20 +3903,20 @@ If this is set to `false` you must define your selector through
 
 ---
 
-##### `podManagementPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.podManagementPolicy"></a>
+##### `podManagementPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.podManagementPolicy"></a>
 
 ```typescript
 public readonly podManagementPolicy: PodManagementPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.PodManagementPolicy`](#cdk8s-plus-22.PodManagementPolicy)
+- *Type:* [`cdk8s-plus-21.PodManagementPolicy`](#cdk8s-plus-21.PodManagementPolicy)
 - *Default:* PodManagementPolicy.ORDERED_READY
 
 Pod management policy to use for this statefulset.
 
 ---
 
-##### `replicas`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.replicas"></a>
+##### `replicas`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.replicas"></a>
 
 ```typescript
 public readonly replicas: number;
@@ -3962,25 +3929,25 @@ Number of desired pods.
 
 ---
 
-### VolumeMount <a name="cdk8s-plus-22.VolumeMount"></a>
+### VolumeMount <a name="cdk8s-plus-21.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { VolumeMount } from 'cdk8s-plus-22'
+import { VolumeMount } from 'cdk8s-plus-21'
 
 const volumeMount: VolumeMount = { ... }
 ```
 
-##### `propagation`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.propagation"></a>
+##### `propagation`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.propagation"></a>
 
 ```typescript
 public readonly propagation: MountPropagation;
 ```
 
-- *Type:* [`cdk8s-plus-22.MountPropagation`](#cdk8s-plus-22.MountPropagation)
+- *Type:* [`cdk8s-plus-21.MountPropagation`](#cdk8s-plus-21.MountPropagation)
 - *Default:* MountPropagation.NONE
 
 Determines how mounts are propagated from the host to container and the other way around.
@@ -3994,7 +3961,7 @@ This field is beta in 1.10.
 
 ---
 
-##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.readOnly"></a>
+##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.readOnly"></a>
 
 ```typescript
 public readonly readOnly: boolean;
@@ -4009,7 +3976,7 @@ Defaults to false.
 
 ---
 
-##### `subPath`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.subPath"></a>
+##### `subPath`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.subPath"></a>
 
 ```typescript
 public readonly subPath: string;
@@ -4022,7 +3989,7 @@ Path within the volume from which the container's volume should be mounted.).
 
 ---
 
-##### `subPathExpr`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.subPathExpr"></a>
+##### `subPathExpr`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.subPathExpr"></a>
 
 ```typescript
 public readonly subPathExpr: string;
@@ -4043,7 +4010,7 @@ is beta in 1.15.
 
 ---
 
-##### `path`<sup>Required</sup> <a name="cdk8s-plus-22.VolumeMount.property.path"></a>
+##### `path`<sup>Required</sup> <a name="cdk8s-plus-21.VolumeMount.property.path"></a>
 
 ```typescript
 public readonly path: string;
@@ -4058,13 +4025,13 @@ contain ':'.
 
 ---
 
-##### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.VolumeMount.property.volume"></a>
+##### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.VolumeMount.property.volume"></a>
 
 ```typescript
 public readonly volume: Volume;
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
 
 The volume to mount.
 
@@ -4072,33 +4039,33 @@ The volume to mount.
 
 ## Classes <a name="Classes"></a>
 
-### Container <a name="cdk8s-plus-22.Container"></a>
+### Container <a name="cdk8s-plus-21.Container"></a>
 
 A single application container that you want to run within a pod.
 
-#### Initializers <a name="cdk8s-plus-22.Container.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Container.Initializer"></a>
 
 ```typescript
-import { Container } from 'cdk8s-plus-22'
+import { Container } from 'cdk8s-plus-21'
 
 new Container(props: ContainerProps)
 ```
 
-##### `props`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.props"></a>
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addEnv` <a name="cdk8s-plus-22.Container.addEnv"></a>
+##### `addEnv` <a name="cdk8s-plus-21.Container.addEnv"></a>
 
 ```typescript
 public addEnv(name: string, value: EnvValue)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.name"></a>
 
 - *Type:* `string`
 
@@ -4106,21 +4073,21 @@ The variable name.
 
 ---
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.value"></a>
 
-- *Type:* [`cdk8s-plus-22.EnvValue`](#cdk8s-plus-22.EnvValue)
+- *Type:* [`cdk8s-plus-21.EnvValue`](#cdk8s-plus-21.EnvValue)
 
 The variable value.
 
 ---
 
-##### `mount` <a name="cdk8s-plus-22.Container.mount"></a>
+##### `mount` <a name="cdk8s-plus-21.Container.mount"></a>
 
 ```typescript
 public mount(path: string, volume: Volume, options?: MountOptions)
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.path"></a>
 
 - *Type:* `string`
 
@@ -4128,30 +4095,30 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.Container.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
 
 The volume to mount.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.MountOptions`](#cdk8s-plus-22.MountOptions)
+- *Type:* [`cdk8s-plus-21.MountOptions`](#cdk8s-plus-21.MountOptions)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `env`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.env"></a>
+##### `env`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.env"></a>
 
 ```typescript
 public readonly env: {[ key: string ]: EnvValue};
 ```
 
-- *Type:* {[ key: string ]: [`cdk8s-plus-22.EnvValue`](#cdk8s-plus-22.EnvValue)}
+- *Type:* {[ key: string ]: [`cdk8s-plus-21.EnvValue`](#cdk8s-plus-21.EnvValue)}
 
 The environment variables for this container.
 
@@ -4159,7 +4126,7 @@ Returns a copy. To add environment variables use `addEnv()`.
 
 ---
 
-##### `image`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.image"></a>
+##### `image`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.image"></a>
 
 ```typescript
 public readonly image: string;
@@ -4171,31 +4138,31 @@ The container image.
 
 ---
 
-##### `imagePullPolicy`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.imagePullPolicy"></a>
+##### `imagePullPolicy`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.imagePullPolicy"></a>
 
 ```typescript
 public readonly imagePullPolicy: ImagePullPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.ImagePullPolicy`](#cdk8s-plus-22.ImagePullPolicy)
+- *Type:* [`cdk8s-plus-21.ImagePullPolicy`](#cdk8s-plus-21.ImagePullPolicy)
 
 Image pull policy for this container.
 
 ---
 
-##### `mounts`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.mounts"></a>
+##### `mounts`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.mounts"></a>
 
 ```typescript
 public readonly mounts: VolumeMount[];
 ```
 
-- *Type:* [`cdk8s-plus-22.VolumeMount`](#cdk8s-plus-22.VolumeMount)[]
+- *Type:* [`cdk8s-plus-21.VolumeMount`](#cdk8s-plus-21.VolumeMount)[]
 
 Volume mounts configured for this container.
 
 ---
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Container.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Container.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4207,7 +4174,7 @@ The name of the container.
 
 ---
 
-##### `args`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.property.args"></a>
+##### `args`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.property.args"></a>
 
 ```typescript
 public readonly args: string[];
@@ -4219,7 +4186,7 @@ Arguments to the entrypoint.
 
 ---
 
-##### `command`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.property.command"></a>
+##### `command`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.property.command"></a>
 
 ```typescript
 public readonly command: string[];
@@ -4231,7 +4198,7 @@ Entrypoint array (the command to execute when the container starts).
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -4243,7 +4210,7 @@ The port this container exposes.
 
 ---
 
-##### `workingDir`<sup>Optional</sup> <a name="cdk8s-plus-22.Container.property.workingDir"></a>
+##### `workingDir`<sup>Optional</sup> <a name="cdk8s-plus-21.Container.property.workingDir"></a>
 
 ```typescript
 public readonly workingDir: string;
@@ -4256,30 +4223,30 @@ The working directory inside the container.
 ---
 
 
-### EnvValue <a name="cdk8s-plus-22.EnvValue"></a>
+### EnvValue <a name="cdk8s-plus-21.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMap` <a name="cdk8s-plus-22.EnvValue.fromConfigMap"></a>
+##### `fromConfigMap` <a name="cdk8s-plus-21.EnvValue.fromConfigMap"></a>
 
 ```typescript
-import { EnvValue } from 'cdk8s-plus-22'
+import { EnvValue } from 'cdk8s-plus-21'
 
 EnvValue.fromConfigMap(configMap: IConfigMap, key: string, options?: EnvValueFromConfigMapOptions)
 ```
 
-###### `configMap`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.configMap"></a>
+###### `configMap`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.configMap"></a>
 
-- *Type:* [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap)
+- *Type:* [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
 
 The config map.
 
 ---
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -4287,23 +4254,23 @@ The key to extract the value from.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.EnvValueFromConfigMapOptions`](#cdk8s-plus-22.EnvValueFromConfigMapOptions)
+- *Type:* [`cdk8s-plus-21.EnvValueFromConfigMapOptions`](#cdk8s-plus-21.EnvValueFromConfigMapOptions)
 
 Additional options.
 
 ---
 
-##### `fromProcess` <a name="cdk8s-plus-22.EnvValue.fromProcess"></a>
+##### `fromProcess` <a name="cdk8s-plus-21.EnvValue.fromProcess"></a>
 
 ```typescript
-import { EnvValue } from 'cdk8s-plus-22'
+import { EnvValue } from 'cdk8s-plus-21'
 
 EnvValue.fromProcess(key: string, options?: EnvValueFromProcessOptions)
 ```
 
-###### `key`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.key"></a>
+###### `key`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.key"></a>
 
 - *Type:* `string`
 
@@ -4311,47 +4278,47 @@ The key to read.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.EnvValueFromProcessOptions`](#cdk8s-plus-22.EnvValueFromProcessOptions)
+- *Type:* [`cdk8s-plus-21.EnvValueFromProcessOptions`](#cdk8s-plus-21.EnvValueFromProcessOptions)
 
 Additional options.
 
 ---
 
-##### `fromSecretValue` <a name="cdk8s-plus-22.EnvValue.fromSecretValue"></a>
+##### `fromSecretValue` <a name="cdk8s-plus-21.EnvValue.fromSecretValue"></a>
 
 ```typescript
-import { EnvValue } from 'cdk8s-plus-22'
+import { EnvValue } from 'cdk8s-plus-21'
 
 EnvValue.fromSecretValue(secretValue: SecretValue, options?: EnvValueFromSecretOptions)
 ```
 
-###### `secretValue`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.secretValue"></a>
+###### `secretValue`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.secretValue"></a>
 
-- *Type:* [`cdk8s-plus-22.SecretValue`](#cdk8s-plus-22.SecretValue)
+- *Type:* [`cdk8s-plus-21.SecretValue`](#cdk8s-plus-21.SecretValue)
 
 The secret value (secrent + key).
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.EnvValueFromSecretOptions`](#cdk8s-plus-22.EnvValueFromSecretOptions)
+- *Type:* [`cdk8s-plus-21.EnvValueFromSecretOptions`](#cdk8s-plus-21.EnvValueFromSecretOptions)
 
 Additional options.
 
 ---
 
-##### `fromValue` <a name="cdk8s-plus-22.EnvValue.fromValue"></a>
+##### `fromValue` <a name="cdk8s-plus-21.EnvValue.fromValue"></a>
 
 ```typescript
-import { EnvValue } from 'cdk8s-plus-22'
+import { EnvValue } from 'cdk8s-plus-21'
 
 EnvValue.fromValue(value: string)
 ```
 
-###### `value`<sup>Required</sup> <a name="cdk8s-plus-22.EnvValue.parameter.value"></a>
+###### `value`<sup>Required</sup> <a name="cdk8s-plus-21.EnvValue.parameter.value"></a>
 
 - *Type:* `string`
 
@@ -4361,7 +4328,7 @@ The value.
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.property.value"></a>
+##### `value`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.property.value"></a>
 
 ```typescript
 public readonly value: any;
@@ -4371,7 +4338,7 @@ public readonly value: any;
 
 ---
 
-##### `valueFrom`<sup>Optional</sup> <a name="cdk8s-plus-22.EnvValue.property.valueFrom"></a>
+##### `valueFrom`<sup>Optional</sup> <a name="cdk8s-plus-21.EnvValue.property.valueFrom"></a>
 
 ```typescript
 public readonly valueFrom: any;
@@ -4382,93 +4349,93 @@ public readonly valueFrom: any;
 ---
 
 
-### IngressBackend <a name="cdk8s-plus-22.IngressBackend"></a>
+### IngressV1Beta1Backend <a name="cdk8s-plus-21.IngressV1Beta1Backend"></a>
 
 The backend for an ingress path.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromService` <a name="cdk8s-plus-22.IngressBackend.fromService"></a>
+##### `fromService` <a name="cdk8s-plus-21.IngressV1Beta1Backend.fromService"></a>
 
 ```typescript
-import { IngressBackend } from 'cdk8s-plus-22'
+import { IngressV1Beta1Backend } from 'cdk8s-plus-21'
 
-IngressBackend.fromService(service: Service, options?: ServiceIngressBackendOptions)
+IngressV1Beta1Backend.fromService(service: Service, options?: ServiceIngressV1BetaBackendOptions)
 ```
 
-###### `service`<sup>Required</sup> <a name="cdk8s-plus-22.IngressBackend.parameter.service"></a>
+###### `service`<sup>Required</sup> <a name="cdk8s-plus-21.IngressV1Beta1Backend.parameter.service"></a>
 
-- *Type:* [`cdk8s-plus-22.Service`](#cdk8s-plus-22.Service)
+- *Type:* [`cdk8s-plus-21.Service`](#cdk8s-plus-21.Service)
 
 The service object.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.IngressBackend.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.IngressV1Beta1Backend.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.ServiceIngressBackendOptions`](#cdk8s-plus-22.ServiceIngressBackendOptions)
+- *Type:* [`cdk8s-plus-21.ServiceIngressV1BetaBackendOptions`](#cdk8s-plus-21.ServiceIngressV1BetaBackendOptions)
 
 ---
 
 
 
-### PodSpec <a name="cdk8s-plus-22.PodSpec"></a>
+### PodSpec <a name="cdk8s-plus-21.PodSpec"></a>
 
-- *Implements:* [`cdk8s-plus-22.IPodSpec`](#cdk8s-plus-22.IPodSpec)
+- *Implements:* [`cdk8s-plus-21.IPodSpec`](#cdk8s-plus-21.IPodSpec)
 
 Provides read/write capabilities ontop of a `PodSpecProps`.
 
-#### Initializers <a name="cdk8s-plus-22.PodSpec.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.PodSpec.Initializer"></a>
 
 ```typescript
-import { PodSpec } from 'cdk8s-plus-22'
+import { PodSpec } from 'cdk8s-plus-21'
 
 new PodSpec(props?: PodSpecProps)
 ```
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpec.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.PodSpecProps`](#cdk8s-plus-22.PodSpecProps)
+- *Type:* [`cdk8s-plus-21.PodSpecProps`](#cdk8s-plus-21.PodSpecProps)
 
 ---
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-22.PodSpec.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-21.PodSpec.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.PodSpec.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-22.PodSpec.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-21.PodSpec.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.PodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
 
 ---
 
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.PodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
+- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
 
 The containers belonging to the pod.
 
@@ -4476,13 +4443,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.PodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 
 The volumes associated with this pod.
 
@@ -4490,48 +4457,48 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpec.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpec.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
 
-### PodTemplate <a name="cdk8s-plus-22.PodTemplate"></a>
+### PodTemplate <a name="cdk8s-plus-21.PodTemplate"></a>
 
-- *Implements:* [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
+- *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
 
 Provides read/write capabilities ontop of a `PodTemplateProps`.
 
-#### Initializers <a name="cdk8s-plus-22.PodTemplate.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.PodTemplate.Initializer"></a>
 
 ```typescript
-import { PodTemplate } from 'cdk8s-plus-22'
+import { PodTemplate } from 'cdk8s-plus-21'
 
 new PodTemplate(props?: PodTemplateProps)
 ```
 
-##### `props`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplate.parameter.props"></a>
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplate.parameter.props"></a>
 
-- *Type:* [`cdk8s-plus-22.PodTemplateProps`](#cdk8s-plus-22.PodTemplateProps)
+- *Type:* [`cdk8s-plus-21.PodTemplateProps`](#cdk8s-plus-21.PodTemplateProps)
 
 ---
 
@@ -4539,7 +4506,7 @@ new PodTemplate(props?: PodTemplateProps)
 
 #### Properties <a name="Properties"></a>
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.PodTemplate.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.PodTemplate.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -4552,14 +4519,14 @@ Provides read/write access to the underlying pod metadata of the resource.
 ---
 
 
-### Probe <a name="cdk8s-plus-22.Probe"></a>
+### Probe <a name="cdk8s-plus-21.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
 
-#### Initializers <a name="cdk8s-plus-22.Probe.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Probe.Initializer"></a>
 
 ```typescript
-import { Probe } from 'cdk8s-plus-22'
+import { Probe } from 'cdk8s-plus-21'
 
 new Probe()
 ```
@@ -4567,15 +4534,15 @@ new Probe()
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromCommand` <a name="cdk8s-plus-22.Probe.fromCommand"></a>
+##### `fromCommand` <a name="cdk8s-plus-21.Probe.fromCommand"></a>
 
 ```typescript
-import { Probe } from 'cdk8s-plus-22'
+import { Probe } from 'cdk8s-plus-21'
 
 Probe.fromCommand(command: string[], options?: CommandProbeOptions)
 ```
 
-###### `command`<sup>Required</sup> <a name="cdk8s-plus-22.Probe.parameter.command"></a>
+###### `command`<sup>Required</sup> <a name="cdk8s-plus-21.Probe.parameter.command"></a>
 
 - *Type:* `string`[]
 
@@ -4583,23 +4550,23 @@ The command to execute.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Probe.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Probe.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.CommandProbeOptions`](#cdk8s-plus-22.CommandProbeOptions)
+- *Type:* [`cdk8s-plus-21.CommandProbeOptions`](#cdk8s-plus-21.CommandProbeOptions)
 
 Options.
 
 ---
 
-##### `fromHttpGet` <a name="cdk8s-plus-22.Probe.fromHttpGet"></a>
+##### `fromHttpGet` <a name="cdk8s-plus-21.Probe.fromHttpGet"></a>
 
 ```typescript
-import { Probe } from 'cdk8s-plus-22'
+import { Probe } from 'cdk8s-plus-21'
 
 Probe.fromHttpGet(path: string, options?: HttpGetProbeOptions)
 ```
 
-###### `path`<sup>Required</sup> <a name="cdk8s-plus-22.Probe.parameter.path"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.Probe.parameter.path"></a>
 
 - *Type:* `string`
 
@@ -4607,9 +4574,9 @@ The URL path to hit.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Probe.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Probe.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.HttpGetProbeOptions`](#cdk8s-plus-22.HttpGetProbeOptions)
+- *Type:* [`cdk8s-plus-21.HttpGetProbeOptions`](#cdk8s-plus-21.HttpGetProbeOptions)
 
 Options.
 
@@ -4617,7 +4584,7 @@ Options.
 
 
 
-### Volume <a name="cdk8s-plus-22.Volume"></a>
+### Volume <a name="cdk8s-plus-21.Volume"></a>
 
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
@@ -4650,21 +4617,21 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
-#### Initializers <a name="cdk8s-plus-22.Volume.Initializer"></a>
+#### Initializers <a name="cdk8s-plus-21.Volume.Initializer"></a>
 
 ```typescript
-import { Volume } from 'cdk8s-plus-22'
+import { Volume } from 'cdk8s-plus-21'
 
 new Volume(name: string, config: any)
 ```
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.parameter.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.name"></a>
 
 - *Type:* `string`
 
 ---
 
-##### `config`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.parameter.config"></a>
+##### `config`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.config"></a>
 
 - *Type:* `any`
 
@@ -4673,47 +4640,47 @@ new Volume(name: string, config: any)
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `fromConfigMap` <a name="cdk8s-plus-22.Volume.fromConfigMap"></a>
+##### `fromConfigMap` <a name="cdk8s-plus-21.Volume.fromConfigMap"></a>
 
 ```typescript
-import { Volume } from 'cdk8s-plus-22'
+import { Volume } from 'cdk8s-plus-21'
 
 Volume.fromConfigMap(configMap: IConfigMap, options?: ConfigMapVolumeOptions)
 ```
 
-###### `configMap`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.parameter.configMap"></a>
+###### `configMap`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.configMap"></a>
 
-- *Type:* [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap)
+- *Type:* [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
 
 The config map to use to populate the volume.
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Volume.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Volume.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.ConfigMapVolumeOptions`](#cdk8s-plus-22.ConfigMapVolumeOptions)
+- *Type:* [`cdk8s-plus-21.ConfigMapVolumeOptions`](#cdk8s-plus-21.ConfigMapVolumeOptions)
 
 Options.
 
 ---
 
-##### `fromEmptyDir` <a name="cdk8s-plus-22.Volume.fromEmptyDir"></a>
+##### `fromEmptyDir` <a name="cdk8s-plus-21.Volume.fromEmptyDir"></a>
 
 ```typescript
-import { Volume } from 'cdk8s-plus-22'
+import { Volume } from 'cdk8s-plus-21'
 
 Volume.fromEmptyDir(name: string, options?: EmptyDirVolumeOptions)
 ```
 
-###### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.parameter.name"></a>
+###### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.name"></a>
 
 - *Type:* `string`
 
 ---
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Volume.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Volume.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.EmptyDirVolumeOptions`](#cdk8s-plus-22.EmptyDirVolumeOptions)
+- *Type:* [`cdk8s-plus-21.EmptyDirVolumeOptions`](#cdk8s-plus-21.EmptyDirVolumeOptions)
 
 Additional options.
 
@@ -4721,7 +4688,7 @@ Additional options.
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.Volume.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4734,18 +4701,18 @@ public readonly name: string;
 
 ## Protocols <a name="Protocols"></a>
 
-### IConfigMap <a name="cdk8s-plus-22.IConfigMap"></a>
+### IConfigMap <a name="cdk8s-plus-21.IConfigMap"></a>
 
-- *Extends:* [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource)
+- *Extends:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
 
-- *Implemented By:* [`cdk8s-plus-22.ConfigMap`](#cdk8s-plus-22.ConfigMap), [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap)
+- *Implemented By:* [`cdk8s-plus-21.ConfigMap`](#cdk8s-plus-21.ConfigMap), [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
 
 Represents a config map.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.IConfigMap.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.IConfigMap.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4757,9 +4724,9 @@ The Kubernetes name of this resource.
 
 ---
 
-### IPodSpec <a name="cdk8s-plus-22.IPodSpec"></a>
+### IPodSpec <a name="cdk8s-plus-21.IPodSpec"></a>
 
-- *Implemented By:* [`cdk8s-plus-22.Deployment`](#cdk8s-plus-22.Deployment), [`cdk8s-plus-22.Job`](#cdk8s-plus-22.Job), [`cdk8s-plus-22.Pod`](#cdk8s-plus-22.Pod), [`cdk8s-plus-22.PodSpec`](#cdk8s-plus-22.PodSpec), [`cdk8s-plus-22.PodTemplate`](#cdk8s-plus-22.PodTemplate), [`cdk8s-plus-22.StatefulSet`](#cdk8s-plus-22.StatefulSet), [`cdk8s-plus-22.IPodSpec`](#cdk8s-plus-22.IPodSpec), [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
+- *Implemented By:* [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment), [`cdk8s-plus-21.Job`](#cdk8s-plus-21.Job), [`cdk8s-plus-21.Pod`](#cdk8s-plus-21.Pod), [`cdk8s-plus-21.PodSpec`](#cdk8s-plus-21.PodSpec), [`cdk8s-plus-21.PodTemplate`](#cdk8s-plus-21.PodTemplate), [`cdk8s-plus-21.StatefulSet`](#cdk8s-plus-21.StatefulSet), [`cdk8s-plus-21.IPodSpec`](#cdk8s-plus-21.IPodSpec), [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod spec. (e.g `Deployment`, `Job`, `Pod`, ...).
 
@@ -4767,29 +4734,29 @@ Use the `PodSpec` class as an implementation helper.
 
 #### Methods <a name="Methods"></a>
 
-##### `addContainer` <a name="cdk8s-plus-22.IPodSpec.addContainer"></a>
+##### `addContainer` <a name="cdk8s-plus-21.IPodSpec.addContainer"></a>
 
 ```typescript
 public addContainer(container: ContainerProps)
 ```
 
-###### `container`<sup>Required</sup> <a name="cdk8s-plus-22.IPodSpec.parameter.container"></a>
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.parameter.container"></a>
 
-- *Type:* [`cdk8s-plus-22.ContainerProps`](#cdk8s-plus-22.ContainerProps)
+- *Type:* [`cdk8s-plus-21.ContainerProps`](#cdk8s-plus-21.ContainerProps)
 
 The container.
 
 ---
 
-##### `addVolume` <a name="cdk8s-plus-22.IPodSpec.addVolume"></a>
+##### `addVolume` <a name="cdk8s-plus-21.IPodSpec.addVolume"></a>
 
 ```typescript
 public addVolume(volume: Volume)
 ```
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-22.IPodSpec.parameter.volume"></a>
+###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.parameter.volume"></a>
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
 
 The volume.
 
@@ -4797,13 +4764,13 @@ The volume.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.IPodSpec.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
+- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
 
 The containers belonging to the pod.
 
@@ -4811,13 +4778,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.IPodSpec.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 
 The volumes associated with this pod.
 
@@ -4825,35 +4792,35 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.IPodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.IPodSpec.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.IPodSpec.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.IPodSpec.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-### IPodTemplate <a name="cdk8s-plus-22.IPodTemplate"></a>
+### IPodTemplate <a name="cdk8s-plus-21.IPodTemplate"></a>
 
-- *Extends:* [`cdk8s-plus-22.IPodSpec`](#cdk8s-plus-22.IPodSpec)
+- *Extends:* [`cdk8s-plus-21.IPodSpec`](#cdk8s-plus-21.IPodSpec)
 
-- *Implemented By:* [`cdk8s-plus-22.Deployment`](#cdk8s-plus-22.Deployment), [`cdk8s-plus-22.Job`](#cdk8s-plus-22.Job), [`cdk8s-plus-22.PodTemplate`](#cdk8s-plus-22.PodTemplate), [`cdk8s-plus-22.StatefulSet`](#cdk8s-plus-22.StatefulSet), [`cdk8s-plus-22.IPodTemplate`](#cdk8s-plus-22.IPodTemplate)
+- *Implemented By:* [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment), [`cdk8s-plus-21.Job`](#cdk8s-plus-21.Job), [`cdk8s-plus-21.PodTemplate`](#cdk8s-plus-21.PodTemplate), [`cdk8s-plus-21.StatefulSet`](#cdk8s-plus-21.StatefulSet), [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
 
 Represents a resource that can be configured with a kuberenets pod template. (e.g `Deployment`, `Job`, ...).
 
@@ -4862,13 +4829,13 @@ Use the `PodTemplate` class as an implementation helper.
 
 #### Properties <a name="Properties"></a>
 
-##### `containers`<sup>Required</sup> <a name="cdk8s-plus-22.IPodTemplate.property.containers"></a>
+##### `containers`<sup>Required</sup> <a name="cdk8s-plus-21.IPodTemplate.property.containers"></a>
 
 ```typescript
 public readonly containers: Container[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Container`](#cdk8s-plus-22.Container)[]
+- *Type:* [`cdk8s-plus-21.Container`](#cdk8s-plus-21.Container)[]
 
 The containers belonging to the pod.
 
@@ -4876,13 +4843,13 @@ Use `addContainer` to add containers.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.IPodTemplate.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-21.IPodTemplate.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
 ```
 
-- *Type:* [`cdk8s-plus-22.Volume`](#cdk8s-plus-22.Volume)[]
+- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)[]
 
 The volumes associated with this pod.
 
@@ -4890,31 +4857,31 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.IPodTemplate.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-21.IPodTemplate.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;
 ```
 
-- *Type:* [`cdk8s-plus-22.RestartPolicy`](#cdk8s-plus-22.RestartPolicy)
+- *Type:* [`cdk8s-plus-21.RestartPolicy`](#cdk8s-plus-21.RestartPolicy)
 
 Restart policy for all containers within the pod.
 
 ---
 
-##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-22.IPodTemplate.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Optional</sup> <a name="cdk8s-plus-21.IPodTemplate.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
 ```
 
-- *Type:* [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 The service account used to run this pod.
 
 ---
 
-##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-22.IPodTemplate.property.podMetadata"></a>
+##### `podMetadata`<sup>Required</sup> <a name="cdk8s-plus-21.IPodTemplate.property.podMetadata"></a>
 
 ```typescript
 public readonly podMetadata: ApiObjectMetadataDefinition;
@@ -4926,16 +4893,16 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ---
 
-### IResource <a name="cdk8s-plus-22.IResource"></a>
+### IResource <a name="cdk8s-plus-21.IResource"></a>
 
-- *Implemented By:* [`cdk8s-plus-22.ConfigMap`](#cdk8s-plus-22.ConfigMap), [`cdk8s-plus-22.Deployment`](#cdk8s-plus-22.Deployment), [`cdk8s-plus-22.Ingress`](#cdk8s-plus-22.Ingress), [`cdk8s-plus-22.Job`](#cdk8s-plus-22.Job), [`cdk8s-plus-22.Pod`](#cdk8s-plus-22.Pod), [`cdk8s-plus-22.Resource`](#cdk8s-plus-22.Resource), [`cdk8s-plus-22.Secret`](#cdk8s-plus-22.Secret), [`cdk8s-plus-22.Service`](#cdk8s-plus-22.Service), [`cdk8s-plus-22.ServiceAccount`](#cdk8s-plus-22.ServiceAccount), [`cdk8s-plus-22.StatefulSet`](#cdk8s-plus-22.StatefulSet), [`cdk8s-plus-22.IConfigMap`](#cdk8s-plus-22.IConfigMap), [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource), [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret), [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Implemented By:* [`cdk8s-plus-21.ConfigMap`](#cdk8s-plus-21.ConfigMap), [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment), [`cdk8s-plus-21.IngressV1Beta1`](#cdk8s-plus-21.IngressV1Beta1), [`cdk8s-plus-21.Job`](#cdk8s-plus-21.Job), [`cdk8s-plus-21.Pod`](#cdk8s-plus-21.Pod), [`cdk8s-plus-21.Resource`](#cdk8s-plus-21.Resource), [`cdk8s-plus-21.Secret`](#cdk8s-plus-21.Secret), [`cdk8s-plus-21.Service`](#cdk8s-plus-21.Service), [`cdk8s-plus-21.ServiceAccount`](#cdk8s-plus-21.ServiceAccount), [`cdk8s-plus-21.StatefulSet`](#cdk8s-plus-21.StatefulSet), [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap), [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource), [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret), [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 Represents a resource.
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.IResource.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.IResource.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4947,16 +4914,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### ISecret <a name="cdk8s-plus-22.ISecret"></a>
+### ISecret <a name="cdk8s-plus-21.ISecret"></a>
 
-- *Extends:* [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource)
+- *Extends:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
 
-- *Implemented By:* [`cdk8s-plus-22.Secret`](#cdk8s-plus-22.Secret), [`cdk8s-plus-22.ISecret`](#cdk8s-plus-22.ISecret)
+- *Implemented By:* [`cdk8s-plus-21.Secret`](#cdk8s-plus-21.Secret), [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.ISecret.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.ISecret.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4968,16 +4935,16 @@ The Kubernetes name of this resource.
 
 ---
 
-### IServiceAccount <a name="cdk8s-plus-22.IServiceAccount"></a>
+### IServiceAccount <a name="cdk8s-plus-21.IServiceAccount"></a>
 
-- *Extends:* [`cdk8s-plus-22.IResource`](#cdk8s-plus-22.IResource)
+- *Extends:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
 
-- *Implemented By:* [`cdk8s-plus-22.ServiceAccount`](#cdk8s-plus-22.ServiceAccount), [`cdk8s-plus-22.IServiceAccount`](#cdk8s-plus-22.IServiceAccount)
+- *Implemented By:* [`cdk8s-plus-21.ServiceAccount`](#cdk8s-plus-21.ServiceAccount), [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 
 #### Properties <a name="Properties"></a>
 
-##### `name`<sup>Required</sup> <a name="cdk8s-plus-22.IServiceAccount.property.name"></a>
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-21.IServiceAccount.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -4995,14 +4962,14 @@ The Kubernetes name of this resource.
 
 The medium on which to store the volume.
 
-#### `DEFAULT` <a name="cdk8s-plus-22.EmptyDirMedium.DEFAULT"></a>
+#### `DEFAULT` <a name="cdk8s-plus-21.EmptyDirMedium.DEFAULT"></a>
 
 The default volume of the backing node.
 
 ---
 
 
-#### `MEMORY` <a name="cdk8s-plus-22.EmptyDirMedium.MEMORY"></a>
+#### `MEMORY` <a name="cdk8s-plus-21.EmptyDirMedium.MEMORY"></a>
 
 Mount a tmpfs (RAM-backed filesystem) for you instead.
 
@@ -5013,36 +4980,9 @@ files you write will count against your Container's memory limit.
 ---
 
 
-### HttpIngressPathType <a name="HttpIngressPathType"></a>
-
-Specify how the path is matched against request paths.
-
-> https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
-
-#### `PREFIX` <a name="cdk8s-plus-22.HttpIngressPathType.PREFIX"></a>
-
-Matches the URL path exactly.
-
----
-
-
-#### `EXACT` <a name="cdk8s-plus-22.HttpIngressPathType.EXACT"></a>
-
-Matches based on a URL path prefix split by '/'.
-
----
-
-
-#### `IMPLEMENTATION_SPECIFIC` <a name="cdk8s-plus-22.HttpIngressPathType.IMPLEMENTATION_SPECIFIC"></a>
-
-Matching is specified by the underlying IngressClass.
-
----
-
-
 ### ImagePullPolicy <a name="ImagePullPolicy"></a>
 
-#### `ALWAYS` <a name="cdk8s-plus-22.ImagePullPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="cdk8s-plus-21.ImagePullPolicy.ALWAYS"></a>
 
 Every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image digest.
 
@@ -5056,7 +4996,7 @@ the image tag is omitted.
 ---
 
 
-#### `IF_NOT_PRESENT` <a name="cdk8s-plus-22.ImagePullPolicy.IF_NOT_PRESENT"></a>
+#### `IF_NOT_PRESENT` <a name="cdk8s-plus-21.ImagePullPolicy.IF_NOT_PRESENT"></a>
 
 The image is pulled only if it is not already present locally.
 
@@ -5066,7 +5006,7 @@ not :latest
 ---
 
 
-#### `NEVER` <a name="cdk8s-plus-22.ImagePullPolicy.NEVER"></a>
+#### `NEVER` <a name="cdk8s-plus-21.ImagePullPolicy.NEVER"></a>
 
 The image is assumed to exist locally.
 
@@ -5077,7 +5017,7 @@ No attempt is made to pull the image.
 
 ### MountPropagation <a name="MountPropagation"></a>
 
-#### `NONE` <a name="cdk8s-plus-22.MountPropagation.NONE"></a>
+#### `NONE` <a name="cdk8s-plus-21.MountPropagation.NONE"></a>
 
 This volume mount will not receive any subsequent mounts that are mounted to this volume or any of its subdirectories by the host.
 
@@ -5092,7 +5032,7 @@ kernel documentation
 ---
 
 
-#### `HOST_TO_CONTAINER` <a name="cdk8s-plus-22.MountPropagation.HOST_TO_CONTAINER"></a>
+#### `HOST_TO_CONTAINER` <a name="cdk8s-plus-21.MountPropagation.HOST_TO_CONTAINER"></a>
 
 This volume mount will receive all subsequent mounts that are mounted to this volume or any of its subdirectories.
 
@@ -5109,7 +5049,7 @@ kernel documentation
 ---
 
 
-#### `BIDIRECTIONAL` <a name="cdk8s-plus-22.MountPropagation.BIDIRECTIONAL"></a>
+#### `BIDIRECTIONAL` <a name="cdk8s-plus-21.MountPropagation.BIDIRECTIONAL"></a>
 
 This volume mount behaves the same the HostToContainer mount.
 
@@ -5143,29 +5083,29 @@ continuing. When scaling down, the pods are removed in the opposite order.
 The alternative policy is `Parallel` which will create pods in parallel to match the
 desired scale without waiting, and on scale down will delete all pods at once.
 
-#### `ORDERED_READY` <a name="cdk8s-plus-22.PodManagementPolicy.ORDERED_READY"></a>
+#### `ORDERED_READY` <a name="cdk8s-plus-21.PodManagementPolicy.ORDERED_READY"></a>
 
 ---
 
 
-#### `PARALLEL` <a name="cdk8s-plus-22.PodManagementPolicy.PARALLEL"></a>
+#### `PARALLEL` <a name="cdk8s-plus-21.PodManagementPolicy.PARALLEL"></a>
 
 ---
 
 
 ### Protocol <a name="Protocol"></a>
 
-#### `TCP` <a name="cdk8s-plus-22.Protocol.TCP"></a>
+#### `TCP` <a name="cdk8s-plus-21.Protocol.TCP"></a>
 
 ---
 
 
-#### `UDP` <a name="cdk8s-plus-22.Protocol.UDP"></a>
+#### `UDP` <a name="cdk8s-plus-21.Protocol.UDP"></a>
 
 ---
 
 
-#### `SCTP` <a name="cdk8s-plus-22.Protocol.SCTP"></a>
+#### `SCTP` <a name="cdk8s-plus-21.Protocol.SCTP"></a>
 
 ---
 
@@ -5174,21 +5114,21 @@ desired scale without waiting, and on scale down will delete all pods at once.
 
 Restart policy for all containers within the pod.
 
-#### `ALWAYS` <a name="cdk8s-plus-22.RestartPolicy.ALWAYS"></a>
+#### `ALWAYS` <a name="cdk8s-plus-21.RestartPolicy.ALWAYS"></a>
 
 Always restart the pod after it exits.
 
 ---
 
 
-#### `ON_FAILURE` <a name="cdk8s-plus-22.RestartPolicy.ON_FAILURE"></a>
+#### `ON_FAILURE` <a name="cdk8s-plus-21.RestartPolicy.ON_FAILURE"></a>
 
 Only restart if the pod exits with a non-zero exit code.
 
 ---
 
 
-#### `NEVER` <a name="cdk8s-plus-22.RestartPolicy.NEVER"></a>
+#### `NEVER` <a name="cdk8s-plus-21.RestartPolicy.NEVER"></a>
 
 Never restart the pod.
 
@@ -5202,7 +5142,7 @@ For some parts of your application (for example, frontends) you may want to expo
 Kubernetes ServiceTypes allow you to specify what kind of Service you want.
 The default is ClusterIP.
 
-#### `CLUSTER_IP` <a name="cdk8s-plus-22.ServiceType.CLUSTER_IP"></a>
+#### `CLUSTER_IP` <a name="cdk8s-plus-21.ServiceType.CLUSTER_IP"></a>
 
 Exposes the Service on a cluster-internal IP.
 
@@ -5212,7 +5152,7 @@ This is the default ServiceType
 ---
 
 
-#### `NODE_PORT` <a name="cdk8s-plus-22.ServiceType.NODE_PORT"></a>
+#### `NODE_PORT` <a name="cdk8s-plus-21.ServiceType.NODE_PORT"></a>
 
 Exposes the Service on each Node's IP at a static port (the NodePort).
 
@@ -5223,7 +5163,7 @@ by requesting <NodeIP>:<NodePort>.
 ---
 
 
-#### `LOAD_BALANCER` <a name="cdk8s-plus-22.ServiceType.LOAD_BALANCER"></a>
+#### `LOAD_BALANCER` <a name="cdk8s-plus-21.ServiceType.LOAD_BALANCER"></a>
 
 Exposes the Service externally using a cloud provider's load balancer.
 
@@ -5233,7 +5173,7 @@ are automatically created.
 ---
 
 
-#### `EXTERNAL_NAME` <a name="cdk8s-plus-22.ServiceType.EXTERNAL_NAME"></a>
+#### `EXTERNAL_NAME` <a name="cdk8s-plus-21.ServiceType.EXTERNAL_NAME"></a>
 
 Maps the Service to the contents of the externalName field (e.g. foo.bar.example.com), by returning a CNAME record with its value. No proxying of any kind is set up.
 

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -36,6 +36,14 @@ export interface DeploymentProps extends ResourceProps, PodTemplateProps {
  * Options for exposing a deployment via a service.
  */
 export interface ExposeOptions {
+
+  /**
+   * The port that the service should serve on.
+   *
+   * @default - Copied from the container of the deployment. If a port could not be determined, throws an error.
+   */
+  readonly port?: number;
+
   /**
    * The type of the exposed service.
    *
@@ -175,16 +183,14 @@ export class Deployment extends Resource implements IPodTemplate {
    *
    * This is equivalent to running `kubectl expose deployment <deployment-name>`.
    *
-   * @param port The port number the service will bind to.
    * @param options Options to determine details of the service and port exposed.
    */
-  public expose(port: number, options: ExposeOptions = {}): Service {
+  public expose(options: ExposeOptions = {}): Service {
     const service = new Service(this, 'Service', {
       metadata: options.name ? { name: options.name } : undefined,
       type: options.serviceType ?? ServiceType.CLUSTER_IP,
     });
-
-    service.addDeployment(this, port, { protocol: options.protocol, targetPort: options.targetPort });
+    service.addDeployment(this, { protocol: options.protocol, targetPort: options.targetPort, port: options.port });
     return service;
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -108,6 +108,18 @@ export enum ServiceType {
 }
 
 /**
+ * Options to add a deployment to a service.
+ */
+export interface AddDeploymentOptions extends ServicePortOptions {
+  /**
+   * The port number the service will bind to.
+   *
+   * @default - Copied from the first container of the deployment.
+   */
+  readonly port?: number;
+}
+
+/**
  * An abstract way to expose an application running on a set of Pods as a network service.
  * With Kubernetes you don't need to modify your application to use an unfamiliar service discovery mechanism.
  * Kubernetes gives Pods their own IP addresses and a single DNS name for a set of Pods, and can load-balance across them.
@@ -201,13 +213,22 @@ export class Service extends Resource {
    * The deployment's `labelSelector` will be used to select pods.
    *
    * @param deployment The deployment to expose
-   * @param port The external port
    * @param options Optional settings for the port.
    */
-  public addDeployment(deployment: Deployment, port: number, options: ServicePortOptions = {}) {
+  public addDeployment(deployment: Deployment, options: AddDeploymentOptions = {}) {
     const containers = deployment.containers;
     if (containers.length === 0) {
       throw new Error('Cannot expose a deployment without containers');
+    }
+
+    // just a PoC, we assume the first container is the main one.
+    // TODO: figure out what the correct thing to do here.
+    const container = containers[0];
+    const port = options.port ?? container.port;
+    const targetPort = options.targetPort ?? containers[0].port;
+
+    if (!port) {
+      throw new Error('Cannot determine port. Either pass `port` in options or configure a port on the first container of the deployment');
     }
 
     const selector = Object.entries(deployment.labelSelector);
@@ -223,13 +244,7 @@ export class Service extends Resource {
       this.addSelector(k, v);
     }
 
-    this.serve(port, {
-      ...options,
-
-      // just a PoC, we assume the first container is the main one.
-      // TODO: figure out what the correct thing to do here.
-      targetPort: options.targetPort ?? containers[0].port,
-    });
+    this.serve(port, { ...options, targetPort });
   }
 
   /**
@@ -249,7 +264,7 @@ export class Service extends Resource {
    * @param port The port definition.
    */
   public serve(port: number, options: ServicePortOptions = { }) {
-    this._ports.push({ port, ...options });
+    this._ports.push({ ...options, port });
   }
 
   /**
@@ -315,8 +330,7 @@ export interface ServicePortOptions {
    *
    * @see https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
    *
-   * @default to auto-allocate a port if the ServiceType of this Service
-   * requires one.
+   * @default - auto-allocate a port if the ServiceType of this Service requires one.
    */
   readonly nodePort?: number;
 

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -90,7 +90,7 @@ test('Can be exposed as via service', () => {
     ],
   });
 
-  deployment.expose(9200, { serviceType: kplus.ServiceType.LOAD_BALANCER });
+  deployment.expose({ port: 9200, serviceType: kplus.ServiceType.LOAD_BALANCER });
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('LoadBalancer');
@@ -113,11 +113,12 @@ test('Expose uses the correct default values', () => {
     ],
   });
 
-  deployment.expose(9200);
+  deployment.expose();
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('ClusterIP');
   expect(spec.ports![0].targetPort).toEqual(9300);
+  expect(spec.ports![0].port).toEqual(9300);
 
 });
 
@@ -133,15 +134,13 @@ test('Expose can set service and port details', () => {
     ],
   });
 
-  deployment.expose(
-    9200,
-    {
-      name: 'test-srv',
-      serviceType: kplus.ServiceType.CLUSTER_IP,
-      protocol: kplus.Protocol.UDP,
-      targetPort: 9500,
-    },
-  );
+  deployment.expose({
+    port: 9200,
+    name: 'test-srv',
+    serviceType: kplus.ServiceType.CLUSTER_IP,
+    protocol: kplus.Protocol.UDP,
+    targetPort: 9500,
+  });
 
   const srv = Testing.synth(chart)[1];
   const spec = srv.spec;
@@ -163,9 +162,7 @@ test('Cannot be exposed if there are no containers in spec', () => {
 
   const deployment = new kplus.Deployment(chart, 'Deployment');
 
-  expect(() => deployment.expose(9000)).toThrowError(
-    'Cannot expose a deployment without containers',
-  );
+  expect(() => deployment.expose()).toThrowError('Cannot expose a deployment without containers');
 });
 
 test('Synthesizes spec lazily', () => {


### PR DESCRIPTION
Backport of https://github.com/cdk8s-team/cdk8s-plus/pull/41 to `k8s-21/main`

BREAKING CHANGE: `deployment.expose` and `service.addDeployment` now accept a `port` as part of the options, and not a positional argument.
