### PR TITLE
feat: default port when exposing deployment

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -392,17 +392,9 @@ public addVolume(Volume volume)
 ##### `expose` <a name="org.cdk8s.plus20.Deployment.expose"></a>
 
 ```java
-public expose(java.lang.Number port)
-public expose(java.lang.Number port, ExposeOptions options)
+public expose()
+public expose(ExposeOptions options)
 ```
-
-###### `port`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.parameter.port"></a>
-
-- *Type:* `java.lang.Number`
-
-The port number the service will bind to.
-
----
 
 ###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.Deployment.parameter.options"></a>
 
@@ -1520,8 +1512,8 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 ##### `addDeployment` <a name="org.cdk8s.plus20.Service.addDeployment"></a>
 
 ```java
-public addDeployment(Deployment deployment, java.lang.Number port)
-public addDeployment(Deployment deployment, java.lang.Number port, ServicePortOptions options)
+public addDeployment(Deployment deployment)
+public addDeployment(Deployment deployment, AddDeploymentOptions options)
 ```
 
 ###### `deployment`<sup>Required</sup> <a name="org.cdk8s.plus20.Service.parameter.deployment"></a>
@@ -1532,17 +1524,9 @@ The deployment to expose.
 
 ---
 
-###### `port`<sup>Required</sup> <a name="org.cdk8s.plus20.Service.parameter.port"></a>
-
-- *Type:* `java.lang.Number`
-
-The external port.
-
----
-
 ###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.Service.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus20.ServicePortOptions`](#org.cdk8s.plus20.ServicePortOptions)
+- *Type:* [`org.cdk8s.plus20.AddDeploymentOptions`](#org.cdk8s.plus20.AddDeploymentOptions)
 
 Optional settings for the port.
 
@@ -2089,6 +2073,102 @@ The service account used to run this pod.
 
 
 ## Structs <a name="Structs"></a>
+
+### AddDeploymentOptions <a name="org.cdk8s.plus20.AddDeploymentOptions"></a>
+
+Options to add a deployment to a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus20.AddDeploymentOptions;
+
+AddDeploymentOptions.builder()
+//  .name(java.lang.String)
+//  .nodePort(java.lang.Number)
+//  .protocol(Protocol)
+//  .targetPort(java.lang.Number)
+//  .port(java.lang.Number)
+    .build();
+```
+
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus20.AddDeploymentOptions.property.name"></a>
+
+```java
+public java.lang.String getName();
+```
+
+- *Type:* `java.lang.String`
+
+The name of this port within the service.
+
+This must be a DNS_LABEL. All
+ports within a ServiceSpec must have unique names. This maps to the 'Name'
+field in EndpointPort objects. Optional if only one ServicePort is defined
+on this service.
+
+---
+
+##### `nodePort`<sup>Optional</sup> <a name="org.cdk8s.plus20.AddDeploymentOptions.property.nodePort"></a>
+
+```java
+public java.lang.Number getNodePort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
+
+The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
+
+Usually assigned by the system. If specified, it will be
+allocated to the service if unused or else creation of the service will
+fail. Default is to auto-allocate a port if the ServiceType of this Service
+requires one.
+
+> https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus20.AddDeploymentOptions.property.protocol"></a>
+
+```java
+public Protocol getProtocol();
+```
+
+- *Type:* [`org.cdk8s.plus20.Protocol`](#org.cdk8s.plus20.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus20.AddDeploymentOptions.property.targetPort"></a>
+
+```java
+public java.lang.Number getTargetPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* The value of `port` will be used.
+
+The port number the service will redirect to.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus20.AddDeploymentOptions.property.port"></a>
+
+```java
+public java.lang.Number getPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* Copied from the first container of the deployment.
+
+The port number the service will bind to.
+
+---
 
 ### AddDirectoryOptions <a name="org.cdk8s.plus20.AddDirectoryOptions"></a>
 
@@ -2875,6 +2955,7 @@ import org.cdk8s.plus20.ExposeOptions;
 
 ExposeOptions.builder()
 //  .name(java.lang.String)
+//  .port(java.lang.Number)
 //  .protocol(Protocol)
 //  .serviceType(ServiceType)
 //  .targetPort(java.lang.Number)
@@ -2893,6 +2974,19 @@ public java.lang.String getName();
 The name of the service to expose.
 
 This will be set on the Service.metadata and must be a DNS_LABEL
+
+---
+
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeOptions.property.port"></a>
+
+```java
+public java.lang.Number getPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
 
 ---
 
@@ -4171,8 +4265,7 @@ public java.lang.Number getNodePort();
 ```
 
 - *Type:* `java.lang.Number`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -4264,8 +4357,7 @@ public java.lang.Number getNodePort();
 ```
 
 - *Type:* `java.lang.Number`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -564,21 +564,13 @@ def add_volume(
 
 ```python
 def expose(
-  port: typing.Union[int, float],
   name: str = None,
+  port: typing.Union[int, float] = None,
   protocol: Protocol = None,
   service_type: ServiceType = None,
   target_port: typing.Union[int, float] = None
 )
 ```
-
-###### `port`<sup>Required</sup> <a name="cdk8s_plus_20.Deployment.parameter.port"></a>
-
-- *Type:* `typing.Union[int, float]`
-
-The port number the service will bind to.
-
----
 
 ###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.parameter.name"></a>
 
@@ -588,6 +580,15 @@ The port number the service will bind to.
 The name of the service to expose.
 
 This will be set on the Service.metadata and must be a DNS_LABEL
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
 
 ---
 
@@ -2086,11 +2087,11 @@ More info: https://kubernetes.io/docs/concepts/services-networking/service/#publ
 ```python
 def add_deployment(
   deployment: Deployment,
-  port: typing.Union[int, float],
   name: str = None,
   node_port: typing.Union[int, float] = None,
   protocol: Protocol = None,
-  target_port: typing.Union[int, float] = None
+  target_port: typing.Union[int, float] = None,
+  port: typing.Union[int, float] = None
 )
 ```
 
@@ -2102,15 +2103,7 @@ The deployment to expose.
 
 ---
 
-###### `port`<sup>Required</sup> <a name="cdk8s_plus_20.Service.parameter.port"></a>
-
-- *Type:* `typing.Union[int, float]`
-
-The external port.
-
----
-
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ServicePortOptions.parameter.name"></a>
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.parameter.name"></a>
 
 - *Type:* `str`
 
@@ -2123,11 +2116,10 @@ on this service.
 
 ---
 
-###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ServicePortOptions.parameter.node_port"></a>
+###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.parameter.node_port"></a>
 
 - *Type:* `typing.Union[int, float]`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -2140,7 +2132,7 @@ requires one.
 
 ---
 
-###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.ServicePortOptions.parameter.protocol"></a>
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.parameter.protocol"></a>
 
 - *Type:* [`cdk8s_plus_20.Protocol`](#cdk8s_plus_20.Protocol)
 - *Default:* Protocol.TCP
@@ -2151,12 +2143,21 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ServicePortOptions.parameter.target_port"></a>
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.parameter.target_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* The value of `port` will be used.
 
 The port number the service will redirect to.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the first container of the deployment.
+
+The port number the service will bind to.
 
 ---
 
@@ -2221,8 +2222,7 @@ on this service.
 ###### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ServicePortOptions.parameter.node_port"></a>
 
 - *Type:* `typing.Union[int, float]`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -2908,6 +2908,102 @@ The service account used to run this pod.
 
 
 ## Structs <a name="Structs"></a>
+
+### AddDeploymentOptions <a name="cdk8s_plus_20.AddDeploymentOptions"></a>
+
+Options to add a deployment to a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.AddDeploymentOptions(
+  name: str = None,
+  node_port: typing.Union[int, float] = None,
+  protocol: Protocol = None,
+  target_port: typing.Union[int, float] = None,
+  port: typing.Union[int, float] = None
+)
+```
+
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.property.name"></a>
+
+```python
+name: str
+```
+
+- *Type:* `str`
+
+The name of this port within the service.
+
+This must be a DNS_LABEL. All
+ports within a ServiceSpec must have unique names. This maps to the 'Name'
+field in EndpointPort objects. Optional if only one ServicePort is defined
+on this service.
+
+---
+
+##### `node_port`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.property.node_port"></a>
+
+```python
+node_port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
+
+The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
+
+Usually assigned by the system. If specified, it will be
+allocated to the service if unused or else creation of the service will
+fail. Default is to auto-allocate a port if the ServiceType of this Service
+requires one.
+
+> https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.property.protocol"></a>
+
+```python
+protocol: Protocol
+```
+
+- *Type:* [`cdk8s_plus_20.Protocol`](#cdk8s_plus_20.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.property.target_port"></a>
+
+```python
+target_port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* The value of `port` will be used.
+
+The port number the service will redirect to.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.AddDeploymentOptions.property.port"></a>
+
+```python
+port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the first container of the deployment.
+
+The port number the service will bind to.
+
+---
 
 ### AddDirectoryOptions <a name="cdk8s_plus_20.AddDirectoryOptions"></a>
 
@@ -3694,6 +3790,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.ExposeOptions(
   name: str = None,
+  port: typing.Union[int, float] = None,
   protocol: Protocol = None,
   service_type: ServiceType = None,
   target_port: typing.Union[int, float] = None
@@ -3712,6 +3809,19 @@ name: str
 The name of the service to expose.
 
 This will be set on the Service.metadata and must be a DNS_LABEL
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.property.port"></a>
+
+```python
+port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
 
 ---
 
@@ -4990,8 +5100,7 @@ node_port: typing.Union[int, float]
 ```
 
 - *Type:* `typing.Union[int, float]`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -5083,8 +5192,7 @@ node_port: typing.Union[int, float]
 ```
 
 - *Type:* `typing.Union[int, float]`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -257,16 +257,8 @@ public addVolume(volume: Volume)
 ##### `expose` <a name="cdk8s-plus-20.Deployment.expose"></a>
 
 ```typescript
-public expose(port: number, options?: ExposeOptions)
+public expose(options?: ExposeOptions)
 ```
-
-###### `port`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.parameter.port"></a>
-
-- *Type:* `number`
-
-The port number the service will bind to.
-
----
 
 ###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.Deployment.parameter.options"></a>
 
@@ -1047,7 +1039,7 @@ new Service(scope: Construct, id: string, props?: ServiceProps)
 ##### `addDeployment` <a name="cdk8s-plus-20.Service.addDeployment"></a>
 
 ```typescript
-public addDeployment(deployment: Deployment, port: number, options?: ServicePortOptions)
+public addDeployment(deployment: Deployment, options?: AddDeploymentOptions)
 ```
 
 ###### `deployment`<sup>Required</sup> <a name="cdk8s-plus-20.Service.parameter.deployment"></a>
@@ -1058,17 +1050,9 @@ The deployment to expose.
 
 ---
 
-###### `port`<sup>Required</sup> <a name="cdk8s-plus-20.Service.parameter.port"></a>
-
-- *Type:* `number`
-
-The external port.
-
----
-
 ###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.Service.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-20.ServicePortOptions`](#cdk8s-plus-20.ServicePortOptions)
+- *Type:* [`cdk8s-plus-20.AddDeploymentOptions`](#cdk8s-plus-20.AddDeploymentOptions)
 
 Optional settings for the port.
 
@@ -1484,6 +1468,96 @@ The service account used to run this pod.
 
 
 ## Structs <a name="Structs"></a>
+
+### AddDeploymentOptions <a name="cdk8s-plus-20.AddDeploymentOptions"></a>
+
+Options to add a deployment to a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { AddDeploymentOptions } from 'cdk8s-plus-20'
+
+const addDeploymentOptions: AddDeploymentOptions = { ... }
+```
+
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-20.AddDeploymentOptions.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* `string`
+
+The name of this port within the service.
+
+This must be a DNS_LABEL. All
+ports within a ServiceSpec must have unique names. This maps to the 'Name'
+field in EndpointPort objects. Optional if only one ServicePort is defined
+on this service.
+
+---
+
+##### `nodePort`<sup>Optional</sup> <a name="cdk8s-plus-20.AddDeploymentOptions.property.nodePort"></a>
+
+```typescript
+public readonly nodePort: number;
+```
+
+- *Type:* `number`
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
+
+The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
+
+Usually assigned by the system. If specified, it will be
+allocated to the service if unused or else creation of the service will
+fail. Default is to auto-allocate a port if the ServiceType of this Service
+requires one.
+
+> https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-20.AddDeploymentOptions.property.protocol"></a>
+
+```typescript
+public readonly protocol: Protocol;
+```
+
+- *Type:* [`cdk8s-plus-20.Protocol`](#cdk8s-plus-20.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-20.AddDeploymentOptions.property.targetPort"></a>
+
+```typescript
+public readonly targetPort: number;
+```
+
+- *Type:* `number`
+- *Default:* The value of `port` will be used.
+
+The port number the service will redirect to.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-20.AddDeploymentOptions.property.port"></a>
+
+```typescript
+public readonly port: number;
+```
+
+- *Type:* `number`
+- *Default:* Copied from the first container of the deployment.
+
+The port number the service will bind to.
+
+---
 
 ### AddDirectoryOptions <a name="cdk8s-plus-20.AddDirectoryOptions"></a>
 
@@ -2234,6 +2308,19 @@ public readonly name: string;
 The name of the service to expose.
 
 This will be set on the Service.metadata and must be a DNS_LABEL
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeOptions.property.port"></a>
+
+```typescript
+public readonly port: number;
+```
+
+- *Type:* `number`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
 
 ---
 
@@ -3432,8 +3519,7 @@ public readonly nodePort: number;
 ```
 
 - *Type:* `number`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 
@@ -3520,8 +3606,7 @@ public readonly nodePort: number;
 ```
 
 - *Type:* `number`
-- *Default:* to auto-allocate a port if the ServiceType of this Service
-requires one.
+- *Default:* auto-allocate a port if the ServiceType of this Service requires one.
 
 The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -36,6 +36,14 @@ export interface DeploymentProps extends ResourceProps, PodTemplateProps {
  * Options for exposing a deployment via a service.
  */
 export interface ExposeOptions {
+
+  /**
+   * The port that the service should serve on.
+   *
+   * @default - Copied from the container of the deployment. If a port could not be determined, throws an error.
+   */
+  readonly port?: number;
+
   /**
    * The type of the exposed service.
    *
@@ -175,16 +183,14 @@ export class Deployment extends Resource implements IPodTemplate {
    *
    * This is equivalent to running `kubectl expose deployment <deployment-name>`.
    *
-   * @param port The port number the service will bind to.
    * @param options Options to determine details of the service and port exposed.
    */
-  public expose(port: number, options: ExposeOptions = {}): Service {
+  public expose(options: ExposeOptions = {}): Service {
     const service = new Service(this, 'Service', {
       metadata: options.name ? { name: options.name } : undefined,
       type: options.serviceType ?? ServiceType.CLUSTER_IP,
     });
-
-    service.addDeployment(this, port, { protocol: options.protocol, targetPort: options.targetPort });
+    service.addDeployment(this, { protocol: options.protocol, targetPort: options.targetPort, port: options.port });
     return service;
   }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -108,6 +108,18 @@ export enum ServiceType {
 }
 
 /**
+ * Options to add a deployment to a service.
+ */
+export interface AddDeploymentOptions extends ServicePortOptions {
+  /**
+   * The port number the service will bind to.
+   *
+   * @default - Copied from the first container of the deployment.
+   */
+  readonly port?: number;
+}
+
+/**
  * An abstract way to expose an application running on a set of Pods as a network service.
  * With Kubernetes you don't need to modify your application to use an unfamiliar service discovery mechanism.
  * Kubernetes gives Pods their own IP addresses and a single DNS name for a set of Pods, and can load-balance across them.
@@ -201,13 +213,22 @@ export class Service extends Resource {
    * The deployment's `labelSelector` will be used to select pods.
    *
    * @param deployment The deployment to expose
-   * @param port The external port
    * @param options Optional settings for the port.
    */
-  public addDeployment(deployment: Deployment, port: number, options: ServicePortOptions = {}) {
+  public addDeployment(deployment: Deployment, options: AddDeploymentOptions = {}) {
     const containers = deployment.containers;
     if (containers.length === 0) {
       throw new Error('Cannot expose a deployment without containers');
+    }
+
+    // just a PoC, we assume the first container is the main one.
+    // TODO: figure out what the correct thing to do here.
+    const container = containers[0];
+    const port = options.port ?? container.port;
+    const targetPort = options.targetPort ?? containers[0].port;
+
+    if (!port) {
+      throw new Error('Cannot determine port. Either pass `port` in options or configure a port on the first container of the deployment');
     }
 
     const selector = Object.entries(deployment.labelSelector);
@@ -223,13 +244,7 @@ export class Service extends Resource {
       this.addSelector(k, v);
     }
 
-    this.serve(port, {
-      ...options,
-
-      // just a PoC, we assume the first container is the main one.
-      // TODO: figure out what the correct thing to do here.
-      targetPort: options.targetPort ?? containers[0].port,
-    });
+    this.serve(port, { ...options, targetPort });
   }
 
   /**
@@ -249,7 +264,7 @@ export class Service extends Resource {
    * @param port The port definition.
    */
   public serve(port: number, options: ServicePortOptions = { }) {
-    this._ports.push({ port, ...options });
+    this._ports.push({ ...options, port });
   }
 
   /**
@@ -315,8 +330,7 @@ export interface ServicePortOptions {
    *
    * @see https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
    *
-   * @default to auto-allocate a port if the ServiceType of this Service
-   * requires one.
+   * @default - auto-allocate a port if the ServiceType of this Service requires one.
    */
   readonly nodePort?: number;
 

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -90,7 +90,7 @@ test('Can be exposed as via service', () => {
     ],
   });
 
-  deployment.expose(9200, { serviceType: kplus.ServiceType.LOAD_BALANCER });
+  deployment.expose({ port: 9200, serviceType: kplus.ServiceType.LOAD_BALANCER });
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('LoadBalancer');
@@ -113,11 +113,12 @@ test('Expose uses the correct default values', () => {
     ],
   });
 
-  deployment.expose(9200);
+  deployment.expose();
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('ClusterIP');
   expect(spec.ports![0].targetPort).toEqual(9300);
+  expect(spec.ports![0].port).toEqual(9300);
 
 });
 
@@ -133,15 +134,13 @@ test('Expose can set service and port details', () => {
     ],
   });
 
-  deployment.expose(
-    9200,
-    {
-      name: 'test-srv',
-      serviceType: kplus.ServiceType.CLUSTER_IP,
-      protocol: kplus.Protocol.UDP,
-      targetPort: 9500,
-    },
-  );
+  deployment.expose({
+    port: 9200,
+    name: 'test-srv',
+    serviceType: kplus.ServiceType.CLUSTER_IP,
+    protocol: kplus.Protocol.UDP,
+    targetPort: 9500,
+  });
 
   const srv = Testing.synth(chart)[1];
   const spec = srv.spec;
@@ -163,9 +162,7 @@ test('Cannot be exposed if there are no containers in spec', () => {
 
   const deployment = new kplus.Deployment(chart, 'Deployment');
 
-  expect(() => deployment.expose(9000)).toThrowError(
-    'Cannot expose a deployment without containers',
-  );
+  expect(() => deployment.expose()).toThrowError('Cannot expose a deployment without containers');
 });
 
 test('Synthesizes spec lazily', () => {


### PR DESCRIPTION
Backport of https://github.com/cdk8s-team/cdk8s-plus/pull/41 to `k8s-20/main`

BREAKING CHANGE: `deployment.expose` and `service.addDeployment` now accept a `port` as part of the options, and not a positional argument.
