### PR TITLE
feat: expose service via ingress

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -389,16 +389,39 @@ public addVolume(Volume volume)
 
 ---
 
-##### `expose` <a name="org.cdk8s.plus20.Deployment.expose"></a>
+##### `exposeViaIngress` <a name="org.cdk8s.plus20.Deployment.exposeViaIngress"></a>
 
 ```java
-public expose()
-public expose(ExposeOptions options)
+public exposeViaIngress(java.lang.String path)
+public exposeViaIngress(java.lang.String path, ExposeDeploymentViaIngressOptions options)
+```
+
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.parameter.path"></a>
+
+- *Type:* `java.lang.String`
+
+The ingress path to register under.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.Deployment.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus20.ExposeDeploymentViaIngressOptions`](#org.cdk8s.plus20.ExposeDeploymentViaIngressOptions)
+
+Additional options.
+
+---
+
+##### `exposeViaService` <a name="org.cdk8s.plus20.Deployment.exposeViaService"></a>
+
+```java
+public exposeViaService()
+public exposeViaService(ExposeDeploymentViaServiceOptions options)
 ```
 
 ###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.Deployment.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus20.ExposeOptions`](#org.cdk8s.plus20.ExposeOptions)
+- *Type:* [`org.cdk8s.plus20.ExposeDeploymentViaServiceOptions`](#org.cdk8s.plus20.ExposeDeploymentViaServiceOptions)
 
 Options to determine details of the service and port exposed.
 
@@ -1551,6 +1574,29 @@ The label key.
 - *Type:* `java.lang.String`
 
 The label value.
+
+---
+
+##### `exposeViaIngress` <a name="org.cdk8s.plus20.Service.exposeViaIngress"></a>
+
+```java
+public exposeViaIngress(java.lang.String path)
+public exposeViaIngress(java.lang.String path, ExposeServiceViaIngressOptions options)
+```
+
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus20.Service.parameter.path"></a>
+
+- *Type:* `java.lang.String`
+
+The path to expose the service under.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.Service.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus20.ExposeServiceViaIngressOptions`](#org.cdk8s.plus20.ExposeServiceViaIngressOptions)
+
+Additional options.
 
 ---
 
@@ -2944,25 +2990,26 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="org.cdk8s.plus20.ExposeOptions"></a>
+### ExposeDeploymentViaIngressOptions <a name="org.cdk8s.plus20.ExposeDeploymentViaIngressOptions"></a>
 
-Options for exposing a deployment via a service.
+Options for exposing a deployment via an ingress.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus20.ExposeOptions;
+import org.cdk8s.plus20.ExposeDeploymentViaIngressOptions;
 
-ExposeOptions.builder()
+ExposeDeploymentViaIngressOptions.builder()
 //  .name(java.lang.String)
 //  .port(java.lang.Number)
 //  .protocol(Protocol)
 //  .serviceType(ServiceType)
 //  .targetPort(java.lang.Number)
+//  .ingress(IngressV1Beta1)
     .build();
 ```
 
-##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaIngressOptions.property.name"></a>
 
 ```java
 public java.lang.String getName();
@@ -2977,7 +3024,7 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaIngressOptions.property.port"></a>
 
 ```java
 public java.lang.Number getPort();
@@ -2990,7 +3037,7 @@ The port that the service should serve on.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaIngressOptions.property.protocol"></a>
 
 ```java
 public Protocol getProtocol();
@@ -3005,7 +3052,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `serviceType`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeOptions.property.serviceType"></a>
+##### `serviceType`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaIngressOptions.property.serviceType"></a>
 
 ```java
 public ServiceType getServiceType();
@@ -3018,7 +3065,7 @@ The type of the exposed service.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaIngressOptions.property.targetPort"></a>
 
 ```java
 public java.lang.Number getTargetPort();
@@ -3028,6 +3075,133 @@ public java.lang.Number getTargetPort();
 - *Default:* The port of the first container in the deployment (ie. containers[0].port)
 
 The port number the service will redirect to.
+
+---
+
+##### `ingress`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaIngressOptions.property.ingress"></a>
+
+```java
+public IngressV1Beta1 getIngress();
+```
+
+- *Type:* [`org.cdk8s.plus20.IngressV1Beta1`](#org.cdk8s.plus20.IngressV1Beta1)
+- *Default:* An ingress will be automatically created.
+
+The ingress to add rules to.
+
+---
+
+### ExposeDeploymentViaServiceOptions <a name="org.cdk8s.plus20.ExposeDeploymentViaServiceOptions"></a>
+
+Options for exposing a deployment via a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus20.ExposeDeploymentViaServiceOptions;
+
+ExposeDeploymentViaServiceOptions.builder()
+//  .name(java.lang.String)
+//  .port(java.lang.Number)
+//  .protocol(Protocol)
+//  .serviceType(ServiceType)
+//  .targetPort(java.lang.Number)
+    .build();
+```
+
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaServiceOptions.property.name"></a>
+
+```java
+public java.lang.String getName();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* undefined Uses the system generated name.
+
+The name of the service to expose.
+
+This will be set on the Service.metadata and must be a DNS_LABEL
+
+---
+
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaServiceOptions.property.port"></a>
+
+```java
+public java.lang.Number getPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaServiceOptions.property.protocol"></a>
+
+```java
+public Protocol getProtocol();
+```
+
+- *Type:* [`org.cdk8s.plus20.Protocol`](#org.cdk8s.plus20.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `serviceType`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaServiceOptions.property.serviceType"></a>
+
+```java
+public ServiceType getServiceType();
+```
+
+- *Type:* [`org.cdk8s.plus20.ServiceType`](#org.cdk8s.plus20.ServiceType)
+- *Default:* ClusterIP.
+
+The type of the exposed service.
+
+---
+
+##### `targetPort`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeDeploymentViaServiceOptions.property.targetPort"></a>
+
+```java
+public java.lang.Number getTargetPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* The port of the first container in the deployment (ie. containers[0].port)
+
+The port number the service will redirect to.
+
+---
+
+### ExposeServiceViaIngressOptions <a name="org.cdk8s.plus20.ExposeServiceViaIngressOptions"></a>
+
+Options for exposing a service using an ingress.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus20.ExposeServiceViaIngressOptions;
+
+ExposeServiceViaIngressOptions.builder()
+//  .ingress(IngressV1Beta1)
+    .build();
+```
+
+##### `ingress`<sup>Optional</sup> <a name="org.cdk8s.plus20.ExposeServiceViaIngressOptions.property.ingress"></a>
+
+```java
+public IngressV1Beta1 getIngress();
+```
+
+- *Type:* [`org.cdk8s.plus20.IngressV1Beta1`](#org.cdk8s.plus20.IngressV1Beta1)
+- *Default:* An ingress will be automatically created.
+
+The ingress to add rules to.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -560,19 +560,29 @@ def add_volume(
 
 ---
 
-##### `expose` <a name="cdk8s_plus_20.Deployment.expose"></a>
+##### `expose_via_ingress` <a name="cdk8s_plus_20.Deployment.expose_via_ingress"></a>
 
 ```python
-def expose(
+def expose_via_ingress(
+  path: str,
   name: str = None,
   port: typing.Union[int, float] = None,
   protocol: Protocol = None,
   service_type: ServiceType = None,
-  target_port: typing.Union[int, float] = None
+  target_port: typing.Union[int, float] = None,
+  ingress: IngressV1Beta1 = None
 )
 ```
 
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.parameter.name"></a>
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_20.Deployment.parameter.path"></a>
+
+- *Type:* `str`
+
+The ingress path to register under.
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.parameter.name"></a>
 
 - *Type:* `str`
 - *Default:* undefined Uses the system generated name.
@@ -583,7 +593,7 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.parameter.port"></a>
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.parameter.port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
@@ -592,7 +602,7 @@ The port that the service should serve on.
 
 ---
 
-###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.parameter.protocol"></a>
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.parameter.protocol"></a>
 
 - *Type:* [`cdk8s_plus_20.Protocol`](#cdk8s_plus_20.Protocol)
 - *Default:* Protocol.TCP
@@ -603,7 +613,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-###### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.parameter.service_type"></a>
+###### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.parameter.service_type"></a>
 
 - *Type:* [`cdk8s_plus_20.ServiceType`](#cdk8s_plus_20.ServiceType)
 - *Default:* ClusterIP.
@@ -612,7 +622,77 @@ The type of the exposed service.
 
 ---
 
-###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.parameter.target_port"></a>
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.parameter.target_port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* The port of the first container in the deployment (ie. containers[0].port)
+
+The port number the service will redirect to.
+
+---
+
+###### `ingress`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.parameter.ingress"></a>
+
+- *Type:* [`cdk8s_plus_20.IngressV1Beta1`](#cdk8s_plus_20.IngressV1Beta1)
+- *Default:* An ingress will be automatically created.
+
+The ingress to add rules to.
+
+---
+
+##### `expose_via_service` <a name="cdk8s_plus_20.Deployment.expose_via_service"></a>
+
+```python
+def expose_via_service(
+  name: str = None,
+  port: typing.Union[int, float] = None,
+  protocol: Protocol = None,
+  service_type: ServiceType = None,
+  target_port: typing.Union[int, float] = None
+)
+```
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* undefined Uses the system generated name.
+
+The name of the service to expose.
+
+This will be set on the Service.metadata and must be a DNS_LABEL
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
+
+---
+
+###### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.parameter.protocol"></a>
+
+- *Type:* [`cdk8s_plus_20.Protocol`](#cdk8s_plus_20.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+###### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.parameter.service_type"></a>
+
+- *Type:* [`cdk8s_plus_20.ServiceType`](#cdk8s_plus_20.ServiceType)
+- *Default:* ClusterIP.
+
+The type of the exposed service.
+
+---
+
+###### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.parameter.target_port"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* The port of the first container in the deployment (ie. containers[0].port)
@@ -2183,6 +2263,32 @@ The label key.
 - *Type:* `str`
 
 The label value.
+
+---
+
+##### `expose_via_ingress` <a name="cdk8s_plus_20.Service.expose_via_ingress"></a>
+
+```python
+def expose_via_ingress(
+  path: str,
+  ingress: IngressV1Beta1 = None
+)
+```
+
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_20.Service.parameter.path"></a>
+
+- *Type:* `str`
+
+The path to expose the service under.
+
+---
+
+###### `ingress`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeServiceViaIngressOptions.parameter.ingress"></a>
+
+- *Type:* [`cdk8s_plus_20.IngressV1Beta1`](#cdk8s_plus_20.IngressV1Beta1)
+- *Default:* An ingress will be automatically created.
+
+The ingress to add rules to.
 
 ---
 
@@ -3779,25 +3885,26 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="cdk8s_plus_20.ExposeOptions"></a>
+### ExposeDeploymentViaIngressOptions <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions"></a>
 
-Options for exposing a deployment via a service.
+Options for exposing a deployment via an ingress.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
 import cdk8s_plus_20
 
-cdk8s_plus_20.ExposeOptions(
+cdk8s_plus_20.ExposeDeploymentViaIngressOptions(
   name: str = None,
   port: typing.Union[int, float] = None,
   protocol: Protocol = None,
   service_type: ServiceType = None,
-  target_port: typing.Union[int, float] = None
+  target_port: typing.Union[int, float] = None,
+  ingress: IngressV1Beta1 = None
 )
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.property.name"></a>
 
 ```python
 name: str
@@ -3812,7 +3919,7 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.property.port"></a>
 
 ```python
 port: typing.Union[int, float]
@@ -3825,7 +3932,7 @@ The port that the service should serve on.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.property.protocol"></a>
 
 ```python
 protocol: Protocol
@@ -3840,7 +3947,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.property.service_type"></a>
+##### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.property.service_type"></a>
 
 ```python
 service_type: ServiceType
@@ -3853,7 +3960,7 @@ The type of the exposed service.
 
 ---
 
-##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeOptions.property.target_port"></a>
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.property.target_port"></a>
 
 ```python
 target_port: typing.Union[int, float]
@@ -3863,6 +3970,133 @@ target_port: typing.Union[int, float]
 - *Default:* The port of the first container in the deployment (ie. containers[0].port)
 
 The port number the service will redirect to.
+
+---
+
+##### `ingress`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaIngressOptions.property.ingress"></a>
+
+```python
+ingress: IngressV1Beta1
+```
+
+- *Type:* [`cdk8s_plus_20.IngressV1Beta1`](#cdk8s_plus_20.IngressV1Beta1)
+- *Default:* An ingress will be automatically created.
+
+The ingress to add rules to.
+
+---
+
+### ExposeDeploymentViaServiceOptions <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions"></a>
+
+Options for exposing a deployment via a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.ExposeDeploymentViaServiceOptions(
+  name: str = None,
+  port: typing.Union[int, float] = None,
+  protocol: Protocol = None,
+  service_type: ServiceType = None,
+  target_port: typing.Union[int, float] = None
+)
+```
+
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.property.name"></a>
+
+```python
+name: str
+```
+
+- *Type:* `str`
+- *Default:* undefined Uses the system generated name.
+
+The name of the service to expose.
+
+This will be set on the Service.metadata and must be a DNS_LABEL
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.property.port"></a>
+
+```python
+port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.property.protocol"></a>
+
+```python
+protocol: Protocol
+```
+
+- *Type:* [`cdk8s_plus_20.Protocol`](#cdk8s_plus_20.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `service_type`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.property.service_type"></a>
+
+```python
+service_type: ServiceType
+```
+
+- *Type:* [`cdk8s_plus_20.ServiceType`](#cdk8s_plus_20.ServiceType)
+- *Default:* ClusterIP.
+
+The type of the exposed service.
+
+---
+
+##### `target_port`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeDeploymentViaServiceOptions.property.target_port"></a>
+
+```python
+target_port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* The port of the first container in the deployment (ie. containers[0].port)
+
+The port number the service will redirect to.
+
+---
+
+### ExposeServiceViaIngressOptions <a name="cdk8s_plus_20.ExposeServiceViaIngressOptions"></a>
+
+Options for exposing a service using an ingress.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.ExposeServiceViaIngressOptions(
+  ingress: IngressV1Beta1 = None
+)
+```
+
+##### `ingress`<sup>Optional</sup> <a name="cdk8s_plus_20.ExposeServiceViaIngressOptions.property.ingress"></a>
+
+```python
+ingress: IngressV1Beta1
+```
+
+- *Type:* [`cdk8s_plus_20.IngressV1Beta1`](#cdk8s_plus_20.IngressV1Beta1)
+- *Default:* An ingress will be automatically created.
+
+The ingress to add rules to.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -254,15 +254,37 @@ public addVolume(volume: Volume)
 
 ---
 
-##### `expose` <a name="cdk8s-plus-20.Deployment.expose"></a>
+##### `exposeViaIngress` <a name="cdk8s-plus-20.Deployment.exposeViaIngress"></a>
 
 ```typescript
-public expose(options?: ExposeOptions)
+public exposeViaIngress(path: string, options?: ExposeDeploymentViaIngressOptions)
+```
+
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.parameter.path"></a>
+
+- *Type:* `string`
+
+The ingress path to register under.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.Deployment.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-20.ExposeDeploymentViaIngressOptions`](#cdk8s-plus-20.ExposeDeploymentViaIngressOptions)
+
+Additional options.
+
+---
+
+##### `exposeViaService` <a name="cdk8s-plus-20.Deployment.exposeViaService"></a>
+
+```typescript
+public exposeViaService(options?: ExposeDeploymentViaServiceOptions)
 ```
 
 ###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.Deployment.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-20.ExposeOptions`](#cdk8s-plus-20.ExposeOptions)
+- *Type:* [`cdk8s-plus-20.ExposeDeploymentViaServiceOptions`](#cdk8s-plus-20.ExposeDeploymentViaServiceOptions)
 
 Options to determine details of the service and port exposed.
 
@@ -1077,6 +1099,28 @@ The label key.
 - *Type:* `string`
 
 The label value.
+
+---
+
+##### `exposeViaIngress` <a name="cdk8s-plus-20.Service.exposeViaIngress"></a>
+
+```typescript
+public exposeViaIngress(path: string, options?: ExposeServiceViaIngressOptions)
+```
+
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-20.Service.parameter.path"></a>
+
+- *Type:* `string`
+
+The path to expose the service under.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.Service.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-20.ExposeServiceViaIngressOptions`](#cdk8s-plus-20.ExposeServiceViaIngressOptions)
+
+Additional options.
 
 ---
 
@@ -2284,19 +2328,19 @@ Specify whether the Secret or its key must be defined.
 
 ---
 
-### ExposeOptions <a name="cdk8s-plus-20.ExposeOptions"></a>
+### ExposeDeploymentViaIngressOptions <a name="cdk8s-plus-20.ExposeDeploymentViaIngressOptions"></a>
 
-Options for exposing a deployment via a service.
+Options for exposing a deployment via an ingress.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { ExposeOptions } from 'cdk8s-plus-20'
+import { ExposeDeploymentViaIngressOptions } from 'cdk8s-plus-20'
 
-const exposeOptions: ExposeOptions = { ... }
+const exposeDeploymentViaIngressOptions: ExposeDeploymentViaIngressOptions = { ... }
 ```
 
-##### `name`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeOptions.property.name"></a>
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaIngressOptions.property.name"></a>
 
 ```typescript
 public readonly name: string;
@@ -2311,7 +2355,7 @@ This will be set on the Service.metadata and must be a DNS_LABEL
 
 ---
 
-##### `port`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeOptions.property.port"></a>
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaIngressOptions.property.port"></a>
 
 ```typescript
 public readonly port: number;
@@ -2324,7 +2368,7 @@ The port that the service should serve on.
 
 ---
 
-##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeOptions.property.protocol"></a>
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaIngressOptions.property.protocol"></a>
 
 ```typescript
 public readonly protocol: Protocol;
@@ -2339,7 +2383,7 @@ Supports "TCP", "UDP", and "SCTP". Default is TCP.
 
 ---
 
-##### `serviceType`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeOptions.property.serviceType"></a>
+##### `serviceType`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaIngressOptions.property.serviceType"></a>
 
 ```typescript
 public readonly serviceType: ServiceType;
@@ -2352,7 +2396,7 @@ The type of the exposed service.
 
 ---
 
-##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeOptions.property.targetPort"></a>
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaIngressOptions.property.targetPort"></a>
 
 ```typescript
 public readonly targetPort: number;
@@ -2362,6 +2406,125 @@ public readonly targetPort: number;
 - *Default:* The port of the first container in the deployment (ie. containers[0].port)
 
 The port number the service will redirect to.
+
+---
+
+##### `ingress`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaIngressOptions.property.ingress"></a>
+
+```typescript
+public readonly ingress: IngressV1Beta1;
+```
+
+- *Type:* [`cdk8s-plus-20.IngressV1Beta1`](#cdk8s-plus-20.IngressV1Beta1)
+- *Default:* An ingress will be automatically created.
+
+The ingress to add rules to.
+
+---
+
+### ExposeDeploymentViaServiceOptions <a name="cdk8s-plus-20.ExposeDeploymentViaServiceOptions"></a>
+
+Options for exposing a deployment via a service.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { ExposeDeploymentViaServiceOptions } from 'cdk8s-plus-20'
+
+const exposeDeploymentViaServiceOptions: ExposeDeploymentViaServiceOptions = { ... }
+```
+
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaServiceOptions.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* `string`
+- *Default:* undefined Uses the system generated name.
+
+The name of the service to expose.
+
+This will be set on the Service.metadata and must be a DNS_LABEL
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaServiceOptions.property.port"></a>
+
+```typescript
+public readonly port: number;
+```
+
+- *Type:* `number`
+- *Default:* Copied from the container of the deployment. If a port could not be determined, throws an error.
+
+The port that the service should serve on.
+
+---
+
+##### `protocol`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaServiceOptions.property.protocol"></a>
+
+```typescript
+public readonly protocol: Protocol;
+```
+
+- *Type:* [`cdk8s-plus-20.Protocol`](#cdk8s-plus-20.Protocol)
+- *Default:* Protocol.TCP
+
+The IP protocol for this port.
+
+Supports "TCP", "UDP", and "SCTP". Default is TCP.
+
+---
+
+##### `serviceType`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaServiceOptions.property.serviceType"></a>
+
+```typescript
+public readonly serviceType: ServiceType;
+```
+
+- *Type:* [`cdk8s-plus-20.ServiceType`](#cdk8s-plus-20.ServiceType)
+- *Default:* ClusterIP.
+
+The type of the exposed service.
+
+---
+
+##### `targetPort`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeDeploymentViaServiceOptions.property.targetPort"></a>
+
+```typescript
+public readonly targetPort: number;
+```
+
+- *Type:* `number`
+- *Default:* The port of the first container in the deployment (ie. containers[0].port)
+
+The port number the service will redirect to.
+
+---
+
+### ExposeServiceViaIngressOptions <a name="cdk8s-plus-20.ExposeServiceViaIngressOptions"></a>
+
+Options for exposing a service using an ingress.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { ExposeServiceViaIngressOptions } from 'cdk8s-plus-20'
+
+const exposeServiceViaIngressOptions: ExposeServiceViaIngressOptions = { ... }
+```
+
+##### `ingress`<sup>Optional</sup> <a name="cdk8s-plus-20.ExposeServiceViaIngressOptions.property.ingress"></a>
+
+```typescript
+public readonly ingress: IngressV1Beta1;
+```
+
+- *Type:* [`cdk8s-plus-20.IngressV1Beta1`](#cdk8s-plus-20.IngressV1Beta1)
+- *Default:* An ingress will be automatically created.
+
+The ingress to add rules to.
 
 ---
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -3,6 +3,7 @@ import { Construct } from 'constructs';
 import { ResourceProps, Resource } from './base';
 import { Deployment } from './deployment';
 import * as k8s from './imports/k8s';
+import { IngressV1Beta1, IngressV1Beta1Backend } from './ingress-v1beta1';
 
 /**
  * Properties for initialization of `Service`.
@@ -66,6 +67,19 @@ export interface ServiceProps extends ResourceProps {
    */
   readonly loadBalancerSourceRanges?: string[];
 
+}
+
+/**
+ * Options for exposing a service using an ingress.
+ */
+export interface ExposeServiceViaIngressOptions {
+
+  /**
+   * The ingress to add rules to.
+   *
+   * @default - An ingress will be automatically created.
+   */
+  readonly ingress?: IngressV1Beta1;
 }
 
 /**
@@ -187,6 +201,20 @@ export class Service extends Resource {
       this.serve(portAndOptions.port, portAndOptions);
     }
 
+  }
+
+  /**
+   * Expose a service via an ingress using the specified path.
+   *
+   * @param path The path to expose the service under.
+   * @param options Additional options.
+   *
+   * @returns The `Ingress` resource that was used.
+   */
+  public exposeViaIngress(path: string, options: ExposeServiceViaIngressOptions = {}): IngressV1Beta1 {
+    const ingress = options.ingress ?? new IngressV1Beta1(this, 'Ingress');
+    ingress.addRule(path, IngressV1Beta1Backend.fromService(this));
+    return ingress;
   }
 
   /**

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Can be exposed as via ingress 1`] = `
+Array [
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-deployment-c898c72d",
+    },
+    "spec": Object {
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "cdk8s.deployment": "test-Deployment-c83f5e59",
+        },
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "cdk8s.deployment": "test-Deployment-c83f5e59",
+          },
+        },
+        "spec": Object {
+          "containers": Array [
+            Object {
+              "env": Array [],
+              "image": "image",
+              "imagePullPolicy": "Always",
+              "name": "main",
+              "ports": Array [
+                Object {
+                  "containerPort": 9300,
+                },
+              ],
+              "volumeMounts": Array [],
+            },
+          ],
+          "volumes": Array [],
+        },
+      },
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": Object {
+      "name": "test-deployment-service-c870ff98",
+    },
+    "spec": Object {
+      "externalIPs": Array [],
+      "ports": Array [
+        Object {
+          "port": 9300,
+          "targetPort": 9300,
+        },
+      ],
+      "selector": Object {
+        "cdk8s.deployment": "test-Deployment-c83f5e59",
+      },
+      "type": "ClusterIP",
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1beta1",
+    "kind": "Ingress",
+    "metadata": Object {
+      "name": "test-deployment-service-ingress-c8520013",
+    },
+    "spec": Object {
+      "rules": Array [
+        Object {
+          "http": Object {
+            "paths": Array [
+              Object {
+                "backend": Object {
+                  "serviceName": "test-deployment-service-c870ff98",
+                  "servicePort": 9300,
+                },
+                "path": "/hello",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+]
+`;

--- a/test/__snapshots__/service.test.ts.snap
+++ b/test/__snapshots__/service.test.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can be exposed by an ingress 1`] = `
+Object {
+  "apiVersion": "networking.k8s.io/v1beta1",
+  "kind": "Ingress",
+  "metadata": Object {
+    "name": "test-service-ingress-c8a1c328",
+  },
+  "spec": Object {
+    "rules": Array [
+      Object {
+        "http": Object {
+          "paths": Array [
+            Object {
+              "backend": Object {
+                "serviceName": "test-service-c85b0531",
+                "servicePort": 80,
+              },
+              "path": "/hello",
+            },
+          ],
+        },
+      },
+    ],
+  },
+}
+`;

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -90,7 +90,7 @@ test('Can be exposed as via service', () => {
     ],
   });
 
-  deployment.expose({ port: 9200, serviceType: kplus.ServiceType.LOAD_BALANCER });
+  deployment.exposeViaService({ port: 9200, serviceType: kplus.ServiceType.LOAD_BALANCER });
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('LoadBalancer');
@@ -98,6 +98,24 @@ test('Can be exposed as via service', () => {
   expect(spec.ports![0].port).toEqual(9200);
   expect(spec.ports![0].targetPort).toEqual(9300);
 
+});
+
+test('Can be exposed as via ingress', () => {
+
+  const chart = Testing.chart();
+
+  const deployment = new kplus.Deployment(chart, 'Deployment', {
+    containers: [
+      {
+        image: 'image',
+        port: 9300,
+      },
+    ],
+  });
+
+  deployment.exposeViaIngress('/hello');
+
+  expect(Testing.synth(chart)).toMatchSnapshot();
 });
 
 test('Expose uses the correct default values', () => {
@@ -113,7 +131,7 @@ test('Expose uses the correct default values', () => {
     ],
   });
 
-  deployment.expose();
+  deployment.exposeViaService();
 
   const spec = Testing.synth(chart)[1].spec;
   expect(spec.type).toEqual('ClusterIP');
@@ -134,7 +152,7 @@ test('Expose can set service and port details', () => {
     ],
   });
 
-  deployment.expose({
+  deployment.exposeViaService({
     port: 9200,
     name: 'test-srv',
     serviceType: kplus.ServiceType.CLUSTER_IP,
@@ -162,7 +180,7 @@ test('Cannot be exposed if there are no containers in spec', () => {
 
   const deployment = new kplus.Deployment(chart, 'Deployment');
 
-  expect(() => deployment.expose()).toThrowError('Cannot expose a deployment without containers');
+  expect(() => deployment.exposeViaService()).toThrowError('Cannot expose a deployment without containers');
 });
 
 test('Synthesizes spec lazily', () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -226,3 +226,15 @@ test('Can restrict CIDR IP addresses for a LoadBalancer type', () => {
   expect(spec.loadBalancerSourceRanges).toEqual(sourceRanges);
 
 });
+
+test('can be exposed by an ingress', () => {
+
+  const chart = Testing.chart();
+
+  const service = new kplus.Service(chart, 'Service');
+  service.serve(80);
+
+  service.exposeViaIngress('/hello');
+  const ingress = Testing.synth(chart)[1];
+  expect(ingress).toMatchSnapshot();
+});


### PR DESCRIPTION
Backport of https://github.com/cdk8s-team/cdk8s-plus/pull/57 to `k8s-20/main`

BREAKING CHANGE: `deployment.expose` renamed to `deployment.exposeViaService`
