### PR TITLE
chore: hardcode k8s spec version (#242)

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,21 +1,12 @@
-const child = require('child_process');
 const path = require('path');
 const { cdk } = require('projen');
 
-const DEFAULT_K8S_VERSION = '22';
-const SPEC_VERSION = k8sVersion();
-const K8S_VERSION = `1.${SPEC_VERSION}.0`;
+// the latest version of k8s we support
+const LATEST_SUPPORTED_K8S_VERSION = '22';
 
-function k8sVersion() {
-  const branch = child.execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-  const match = branch.match(/k8s-(\d\d)/);
-  if (!match) {
-    // if we cannot determine the spec version from the branch name, we're probably targetting
-    // the default spec version.
-    return DEFAULT_K8S_VERSION;
-  }
-  return match[1];
-}
+// the version of k8s this branch supports
+const SPEC_VERSION = '21';
+const K8S_VERSION = `1.${SPEC_VERSION}.0`;
 
 const project = new cdk.JsiiProject({
   name: `cdk8s-plus-${SPEC_VERSION}`,
@@ -90,9 +81,9 @@ const project = new cdk.JsiiProject({
   depsUpgradeOptions: {
     workflowOptions: {
       branches: [
-        `k8s-${DEFAULT_K8S_VERSION}/main`,
-        `k8s-${DEFAULT_K8S_VERSION - 1}/main`,
-        `k8s-${DEFAULT_K8S_VERSION - 2}/main`,
+        `k8s-${LATEST_SUPPORTED_K8S_VERSION}/main`,
+        `k8s-${LATEST_SUPPORTED_K8S_VERSION - 1}/main`,
+        `k8s-${LATEST_SUPPORTED_K8S_VERSION - 2}/main`,
       ],
     },
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,12 +156,9 @@ once the changes are merged to cdk8s-plus-22.
 targeting an older kubernetes version. For example, `IngressV1Beta` is not
 available in cdk8s-plus-22, so changing it would require making a change to
 cdk8s-plus-21 and cdk8s-plus-20. If you need to make a pull request to a version
-of cdk8s-plus that isn't the latest version, then **the branch name of your pull
-request must contain `k8s-XX`** where XX is the version number. For example,
-to make a pull request to cdk8s-plus-21, you could name the branch
-`k8s-21/bug-fix`. When you submit the pull request on GitHub, make sure the
-target branch matches your branch name (in this example, it would be
-`k8s-21/main`). The pull request should target the latest branch that your fix
+of cdk8s-plus that isn't the latest version, create your branch from the corresponding
+`k8s-XX/main` branch, and when you submit the pull request on GitHub, make sure the
+target branch matches your base branch. The pull request should target the latest branch that your fix
 applies for - so in the example above, only a PR to `k8s-21/main` is required,
 and we will backport it to `k8s-20/main`.
 


### PR DESCRIPTION
(backport of #242)

Every branch in this project corresponds to a different k8s version. This meant that every branch needs to set a different value for the `SPEC_VERSION` constant in the `.projenrc.js` file.

We tried to avoid differences in this file between branches by being smart and auto detecting the version based on the branch name. But this turned out to be more of a hassle then a benefit since it required a naming convention for feature branches.

> See https://github.com/cdk8s-team/cdk8s-plus/blob/k8s-22/main/CONTRIBUTING.md#making-a-pull-request

Also, our current mechanism doesn't capture tag names. Which means that checking out to a tag would always built the default version, instead of the one the tag was created from.

Instead of this madness, lets just hardcode the version in the file and thats it. The diff it creates between `.projenrc.js` files across branches is very minimal and isn't likely to create conflicts when performing backports.

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>