### PR TITLE
chore: remove unneeded k8s version references

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -49,8 +49,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -2410,8 +2409,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -3849,8 +3847,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus22.MountOptions.property.readOnly"></a>
@@ -3894,11 +3890,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 
@@ -5131,8 +5125,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus22.VolumeMount.property.readOnly"></a>
@@ -5176,11 +5168,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -51,8 +51,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -3339,8 +3338,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -4778,8 +4776,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.property.read_only"></a>
@@ -4823,11 +4819,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 
@@ -6060,8 +6054,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.VolumeMount.property.read_only"></a>
@@ -6105,11 +6097,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 
@@ -6370,8 +6360,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_22.MountOptions.parameter.read_only"></a>
@@ -6403,11 +6391,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1783,8 +1783,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -3128,8 +3127,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-22.MountOptions.property.readOnly"></a>
@@ -3173,11 +3170,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 
@@ -4328,8 +4323,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-22.VolumeMount.property.readOnly"></a>
@@ -4373,11 +4366,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 

--- a/src/config-map.ts
+++ b/src/config-map.ts
@@ -17,8 +17,7 @@ export interface ConfigMapProps extends ResourceProps {
    * Each key must consist of alphanumeric characters, '-', '_' or '.'.
    * BinaryData can contain byte sequences that are not in the UTF-8 range. The
    * keys stored in BinaryData must not overlap with the ones in the Data field,
-   * this is enforced during validation process. Using this field will require
-   * 1.10+ apiserver and kubelet.
+   * this is enforced during validation process.
    *
    * You can also add binary data using `configMap.addBinaryData()`.
    */

--- a/src/container.ts
+++ b/src/container.ts
@@ -564,8 +564,6 @@ export interface MountOptions {
    * Mount propagation allows for sharing volumes mounted by a Container to
    * other Containers in the same Pod, or even to other Pods on the same node.
    *
-   * This field is beta in 1.10.
-   *
    * @default MountPropagation.NONE
    */
   readonly propagation?: MountPropagation;
@@ -589,11 +587,9 @@ export interface MountOptions {
    * Expanded path within the volume from which the container's volume should be
    * mounted. Behaves similarly to SubPath but environment variable references
    * $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-   * (volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-   * is beta in 1.15.
+   * (volume's root).
    *
-   * `subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-   * 1.15.
+   * `subPathExpr` and `subPath` are mutually exclusive.
    *
    * @default "" volume's root.
    */


### PR DESCRIPTION
Cleans up some docs that unnecessarily reference outdated k8s versions. mountPropagation has been GA since 1.12 and subPathExpr has been GA since 1.17. ([Source](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/))

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>