### PR TITLE
feat: TCP socket probes

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -5096,6 +5096,129 @@ Number of desired pods.
 
 ---
 
+### TcpSocketProbeOptions <a name="org.cdk8s.plus22.TcpSocketProbeOptions"></a>
+
+Options for `Probe.fromTcpSocket()`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus22.TcpSocketProbeOptions;
+
+TcpSocketProbeOptions.builder()
+//  .failureThreshold(java.lang.Number)
+//  .initialDelaySeconds(Duration)
+//  .periodSeconds(Duration)
+//  .successThreshold(java.lang.Number)
+//  .timeoutSeconds(Duration)
+//  .host(java.lang.String)
+//  .port(java.lang.Number)
+    .build();
+```
+
+##### `failureThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.TcpSocketProbeOptions.property.failureThreshold"></a>
+
+```java
+public java.lang.Number getFailureThreshold();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* 3
+
+Minimum consecutive failures for the probe to be considered failed after having succeeded.
+
+Defaults to 3. Minimum value is 1.
+
+---
+
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.TcpSocketProbeOptions.property.initialDelaySeconds"></a>
+
+```java
+public Duration getInitialDelaySeconds();
+```
+
+- *Type:* [`org.cdk8s.Duration`](#org.cdk8s.Duration)
+- *Default:* immediate
+
+Number of seconds after the container has started before liveness probes are initiated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+---
+
+##### `periodSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.TcpSocketProbeOptions.property.periodSeconds"></a>
+
+```java
+public Duration getPeriodSeconds();
+```
+
+- *Type:* [`org.cdk8s.Duration`](#org.cdk8s.Duration)
+- *Default:* Duration.seconds(10) Minimum value is 1.
+
+How often (in seconds) to perform the probe.
+
+Default to 10 seconds. Minimum value is 1.
+
+---
+
+##### `successThreshold`<sup>Optional</sup> <a name="org.cdk8s.plus22.TcpSocketProbeOptions.property.successThreshold"></a>
+
+```java
+public java.lang.Number getSuccessThreshold();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* 1 Must be 1 for liveness and startup. Minimum value is 1.
+
+Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
+
+Must be 1 for liveness and startup. Minimum value is 1.
+
+---
+
+##### `timeoutSeconds`<sup>Optional</sup> <a name="org.cdk8s.plus22.TcpSocketProbeOptions.property.timeoutSeconds"></a>
+
+```java
+public Duration getTimeoutSeconds();
+```
+
+- *Type:* [`org.cdk8s.Duration`](#org.cdk8s.Duration)
+- *Default:* Duration.seconds(1)
+
+Number of seconds after which the probe times out.
+
+Defaults to 1 second. Minimum value is 1.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+---
+
+##### `host`<sup>Optional</sup> <a name="org.cdk8s.plus22.TcpSocketProbeOptions.property.host"></a>
+
+```java
+public java.lang.String getHost();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* defaults to the pod IP
+
+The host name to connect to on the container.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus22.TcpSocketProbeOptions.property.port"></a>
+
+```java
+public java.lang.Number getPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* defaults to `container.port`.
+
+The TCP port to connect to on the container.
+
+---
+
 ### VolumeMount <a name="org.cdk8s.plus22.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
@@ -6069,6 +6192,23 @@ The URL path to hit.
 ###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Probe.parameter.options"></a>
 
 - *Type:* [`org.cdk8s.plus22.HttpGetProbeOptions`](#org.cdk8s.plus22.HttpGetProbeOptions)
+
+Options.
+
+---
+
+##### `fromTcpSocket` <a name="org.cdk8s.plus22.Probe.fromTcpSocket"></a>
+
+```java
+import org.cdk8s.plus22.Probe;
+
+Probe.fromTcpSocket()
+Probe.fromTcpSocket(TcpSocketProbeOptions options)
+```
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.Probe.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus22.TcpSocketProbeOptions`](#org.cdk8s.plus22.TcpSocketProbeOptions)
 
 Options.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -6025,6 +6025,129 @@ Number of desired pods.
 
 ---
 
+### TcpSocketProbeOptions <a name="cdk8s_plus_22.TcpSocketProbeOptions"></a>
+
+Options for `Probe.fromTcpSocket()`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.TcpSocketProbeOptions(
+  failure_threshold: typing.Union[int, float] = None,
+  initial_delay_seconds: Duration = None,
+  period_seconds: Duration = None,
+  success_threshold: typing.Union[int, float] = None,
+  timeout_seconds: Duration = None,
+  host: str = None,
+  port: typing.Union[int, float] = None
+)
+```
+
+##### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.property.failure_threshold"></a>
+
+```python
+failure_threshold: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* 3
+
+Minimum consecutive failures for the probe to be considered failed after having succeeded.
+
+Defaults to 3. Minimum value is 1.
+
+---
+
+##### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.property.initial_delay_seconds"></a>
+
+```python
+initial_delay_seconds: Duration
+```
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* immediate
+
+Number of seconds after the container has started before liveness probes are initiated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+---
+
+##### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.property.period_seconds"></a>
+
+```python
+period_seconds: Duration
+```
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* Duration.seconds(10) Minimum value is 1.
+
+How often (in seconds) to perform the probe.
+
+Default to 10 seconds. Minimum value is 1.
+
+---
+
+##### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.property.success_threshold"></a>
+
+```python
+success_threshold: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* 1 Must be 1 for liveness and startup. Minimum value is 1.
+
+Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
+
+Must be 1 for liveness and startup. Minimum value is 1.
+
+---
+
+##### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.property.timeout_seconds"></a>
+
+```python
+timeout_seconds: Duration
+```
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* Duration.seconds(1)
+
+Number of seconds after which the probe times out.
+
+Defaults to 1 second. Minimum value is 1.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+---
+
+##### `host`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.property.host"></a>
+
+```python
+host: str
+```
+
+- *Type:* `str`
+- *Default:* defaults to the pod IP
+
+The host name to connect to on the container.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.property.port"></a>
+
+```python
+port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* defaults to `container.port`.
+
+The TCP port to connect to on the container.
+
+---
+
 ### VolumeMount <a name="cdk8s_plus_22.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
@@ -7375,6 +7498,97 @@ Defaults to 1 second. Minimum value is 1.
 - *Default:* defaults to `container.port`.
 
 The TCP port to use when sending the GET request.
+
+---
+
+##### `from_tcp_socket` <a name="cdk8s_plus_22.Probe.from_tcp_socket"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.Probe.from_tcp_socket(
+  failure_threshold: typing.Union[int, float] = None,
+  initial_delay_seconds: Duration = None,
+  period_seconds: Duration = None,
+  success_threshold: typing.Union[int, float] = None,
+  timeout_seconds: Duration = None,
+  host: str = None,
+  port: typing.Union[int, float] = None
+)
+```
+
+###### `failure_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.parameter.failure_threshold"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* 3
+
+Minimum consecutive failures for the probe to be considered failed after having succeeded.
+
+Defaults to 3. Minimum value is 1.
+
+---
+
+###### `initial_delay_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.parameter.initial_delay_seconds"></a>
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* immediate
+
+Number of seconds after the container has started before liveness probes are initiated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+---
+
+###### `period_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.parameter.period_seconds"></a>
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* Duration.seconds(10) Minimum value is 1.
+
+How often (in seconds) to perform the probe.
+
+Default to 10 seconds. Minimum value is 1.
+
+---
+
+###### `success_threshold`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.parameter.success_threshold"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* 1 Must be 1 for liveness and startup. Minimum value is 1.
+
+Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
+
+Must be 1 for liveness and startup. Minimum value is 1.
+
+---
+
+###### `timeout_seconds`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.parameter.timeout_seconds"></a>
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* Duration.seconds(1)
+
+Number of seconds after which the probe times out.
+
+Defaults to 1 second. Minimum value is 1.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+---
+
+###### `host`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.parameter.host"></a>
+
+- *Type:* `str`
+- *Default:* defaults to the pod IP
+
+The host name to connect to on the container.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_22.TcpSocketProbeOptions.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* defaults to `container.port`.
+
+The TCP port to connect to on the container.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -4300,6 +4300,121 @@ Number of desired pods.
 
 ---
 
+### TcpSocketProbeOptions <a name="cdk8s-plus-22.TcpSocketProbeOptions"></a>
+
+Options for `Probe.fromTcpSocket()`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { TcpSocketProbeOptions } from 'cdk8s-plus-22'
+
+const tcpSocketProbeOptions: TcpSocketProbeOptions = { ... }
+```
+
+##### `failureThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.TcpSocketProbeOptions.property.failureThreshold"></a>
+
+```typescript
+public readonly failureThreshold: number;
+```
+
+- *Type:* `number`
+- *Default:* 3
+
+Minimum consecutive failures for the probe to be considered failed after having succeeded.
+
+Defaults to 3. Minimum value is 1.
+
+---
+
+##### `initialDelaySeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.TcpSocketProbeOptions.property.initialDelaySeconds"></a>
+
+```typescript
+public readonly initialDelaySeconds: Duration;
+```
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* immediate
+
+Number of seconds after the container has started before liveness probes are initiated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+---
+
+##### `periodSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.TcpSocketProbeOptions.property.periodSeconds"></a>
+
+```typescript
+public readonly periodSeconds: Duration;
+```
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* Duration.seconds(10) Minimum value is 1.
+
+How often (in seconds) to perform the probe.
+
+Default to 10 seconds. Minimum value is 1.
+
+---
+
+##### `successThreshold`<sup>Optional</sup> <a name="cdk8s-plus-22.TcpSocketProbeOptions.property.successThreshold"></a>
+
+```typescript
+public readonly successThreshold: number;
+```
+
+- *Type:* `number`
+- *Default:* 1 Must be 1 for liveness and startup. Minimum value is 1.
+
+Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
+
+Must be 1 for liveness and startup. Minimum value is 1.
+
+---
+
+##### `timeoutSeconds`<sup>Optional</sup> <a name="cdk8s-plus-22.TcpSocketProbeOptions.property.timeoutSeconds"></a>
+
+```typescript
+public readonly timeoutSeconds: Duration;
+```
+
+- *Type:* [`cdk8s.Duration`](#cdk8s.Duration)
+- *Default:* Duration.seconds(1)
+
+Number of seconds after which the probe times out.
+
+Defaults to 1 second. Minimum value is 1.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+
+---
+
+##### `host`<sup>Optional</sup> <a name="cdk8s-plus-22.TcpSocketProbeOptions.property.host"></a>
+
+```typescript
+public readonly host: string;
+```
+
+- *Type:* `string`
+- *Default:* defaults to the pod IP
+
+The host name to connect to on the container.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-22.TcpSocketProbeOptions.property.port"></a>
+
+```typescript
+public readonly port: number;
+```
+
+- *Type:* `number`
+- *Default:* defaults to `container.port`.
+
+The TCP port to connect to on the container.
+
+---
+
 ### VolumeMount <a name="cdk8s-plus-22.VolumeMount"></a>
 
 Mount a volume from the pod to the container.
@@ -4996,6 +5111,22 @@ The URL path to hit.
 ###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Probe.parameter.options"></a>
 
 - *Type:* [`cdk8s-plus-22.HttpGetProbeOptions`](#cdk8s-plus-22.HttpGetProbeOptions)
+
+Options.
+
+---
+
+##### `fromTcpSocket` <a name="cdk8s-plus-22.Probe.fromTcpSocket"></a>
+
+```typescript
+import { Probe } from 'cdk8s-plus-22'
+
+Probe.fromTcpSocket(options?: TcpSocketProbeOptions)
+```
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.Probe.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-22.TcpSocketProbeOptions`](#cdk8s-plus-22.TcpSocketProbeOptions)
 
 Options.
 

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -75,6 +75,25 @@ export interface CommandProbeOptions extends ProbeOptions {
 }
 
 /**
+ * Options for `Probe.fromTcpSocket()`.
+ */
+export interface TcpSocketProbeOptions extends ProbeOptions {
+  /**
+   * The TCP port to connect to on the container.
+   *
+   * @default - defaults to `container.port`.
+   */
+  readonly port?: number;
+
+  /**
+   * The host name to connect to on the container.
+   *
+   * @default - defaults to the pod IP
+   */
+  readonly host?: string;
+}
+
+/**
  * Probe describes a health check to be performed against a container to
  * determine whether it is alive or ready to receive traffic.
  */
@@ -112,6 +131,25 @@ export abstract class Probe {
         ...parseProbeOptions(options),
         exec: { command },
       }),
+    };
+  }
+
+  /**
+   * Defines a probe based opening a connection to a TCP socket on the container.
+   *
+   * @param options Options
+   */
+  public static fromTcpSocket(options: TcpSocketProbeOptions = { }): Probe {
+    return {
+      _toKube(container) {
+        return {
+          ...parseProbeOptions(options),
+          tcpSocket: {
+            port: k8s.IntOrString.fromNumber(options.port ?? container.port ?? 80),
+            host: options.host,
+          },
+        };
+      },
     };
   }
 

--- a/test/probe.test.ts
+++ b/test/probe.test.ts
@@ -119,3 +119,79 @@ describe('fromCommand()', () => {
   });
 
 });
+
+describe('fromTcpSocket()', () => {
+
+  test('minimal usage', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromTcpSocket();
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      tcpSocket: {
+        port: IntOrString.fromNumber(5555),
+        host: undefined,
+      },
+      failureThreshold: 3,
+      initialDelaySeconds: undefined,
+      periodSeconds: undefined,
+      successThreshold: undefined,
+      timeoutSeconds: undefined,
+    });
+  });
+
+  test('specific port and hostname', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromTcpSocket({
+      port: 8080,
+      host: 'hostname',
+    });
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      tcpSocket: {
+        port: IntOrString.fromNumber(8080),
+        host: 'hostname',
+      },
+      failureThreshold: 3,
+      initialDelaySeconds: undefined,
+      periodSeconds: undefined,
+      successThreshold: undefined,
+      timeoutSeconds: undefined,
+    });
+  });
+
+  test('options', () => {
+    // GIVEN
+    const container = new Container({ image: 'foobar', port: 5555 });
+
+    // WHEN
+    const min = Probe.fromTcpSocket({
+      failureThreshold: 11,
+      initialDelaySeconds: Duration.minutes(1),
+      periodSeconds: Duration.seconds(5),
+      successThreshold: 3,
+      timeoutSeconds: Duration.minutes(2),
+    });
+
+    // THEN
+    expect(min._toKube(container)).toEqual({
+      tcpSocket: {
+        port: IntOrString.fromNumber(5555),
+        host: undefined,
+      },
+      failureThreshold: 11,
+      initialDelaySeconds: 60,
+      periodSeconds: 5,
+      successThreshold: 3,
+      timeoutSeconds: 120,
+    });
+  });
+
+});


### PR DESCRIPTION
API written based on the documentation here:
- https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-tcp-liveness-probe
- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#probe-v1-core

I think the default behavior in most cases is to connect to `container.port`, so there are no required arguments for `Probe.fromTcpSocket()`, unlike `Probe.fromCommand()` and `Probe.fromHttpGet()`.

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>

Fixes #345