### PR TITLE
chore: remove unneeded k8s version references (#324)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -49,8 +49,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -2392,8 +2391,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -3785,8 +3783,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.MountOptions.property.readOnly"></a>
@@ -3830,11 +3826,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 
@@ -5190,8 +5184,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.VolumeMount.property.readOnly"></a>
@@ -5235,11 +5227,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -51,8 +51,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -3287,8 +3286,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -4680,8 +4678,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.property.read_only"></a>
@@ -4725,11 +4721,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 
@@ -6085,8 +6079,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.VolumeMount.property.read_only"></a>
@@ -6130,11 +6122,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 
@@ -6395,8 +6385,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.MountOptions.parameter.read_only"></a>
@@ -6428,11 +6416,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1767,8 +1767,7 @@ BinaryData contains the binary data.
 Each key must consist of alphanumeric characters, '-', '_' or '.'.
 BinaryData can contain byte sequences that are not in the UTF-8 range. The
 keys stored in BinaryData must not overlap with the ones in the Data field,
-this is enforced during validation process. Using this field will require
-1.10+ apiserver and kubelet.
+this is enforced during validation process.
 
 You can also add binary data using `configMap.addBinaryData()`.
 
@@ -3069,8 +3068,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.MountOptions.property.readOnly"></a>
@@ -3114,11 +3111,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 
@@ -4384,8 +4379,6 @@ When not set, MountPropagationNone is used.
 Mount propagation allows for sharing volumes mounted by a Container to
 other Containers in the same Pod, or even to other Pods on the same node.
 
-This field is beta in 1.10.
-
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.VolumeMount.property.readOnly"></a>
@@ -4429,11 +4422,9 @@ Expanded path within the volume from which the container's volume should be moun
 
 Behaves similarly to SubPath but environment variable references
 $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-(volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-is beta in 1.15.
+(volume's root).
 
-`subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-1.15.
+`subPathExpr` and `subPath` are mutually exclusive.
 
 ---
 

--- a/src/config-map.ts
+++ b/src/config-map.ts
@@ -17,8 +17,7 @@ export interface ConfigMapProps extends ResourceProps {
    * Each key must consist of alphanumeric characters, '-', '_' or '.'.
    * BinaryData can contain byte sequences that are not in the UTF-8 range. The
    * keys stored in BinaryData must not overlap with the ones in the Data field,
-   * this is enforced during validation process. Using this field will require
-   * 1.10+ apiserver and kubelet.
+   * this is enforced during validation process.
    *
    * You can also add binary data using `configMap.addBinaryData()`.
    */

--- a/src/container.ts
+++ b/src/container.ts
@@ -564,8 +564,6 @@ export interface MountOptions {
    * Mount propagation allows for sharing volumes mounted by a Container to
    * other Containers in the same Pod, or even to other Pods on the same node.
    *
-   * This field is beta in 1.10.
-   *
    * @default MountPropagation.NONE
    */
   readonly propagation?: MountPropagation;
@@ -589,11 +587,9 @@ export interface MountOptions {
    * Expanded path within the volume from which the container's volume should be
    * mounted. Behaves similarly to SubPath but environment variable references
    * $(VAR_NAME) are expanded using the container's environment. Defaults to ""
-   * (volume's root). SubPathExpr and SubPath are mutually exclusive. This field
-   * is beta in 1.15.
+   * (volume's root).
    *
-   * `subPathExpr` and `subPath` are mutually exclusive. This field is beta in
-   * 1.15.
+   * `subPathExpr` and `subPath` are mutually exclusive.
    *
    * @default "" volume's root.
    */


### PR DESCRIPTION
Backport of #324 to cdk8s-plus-21.