### PR TITLE
[k8s-21/main] chore(deps): upgrade dependencies (#8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "@types/minimatch": "^3.0.5",
+<<<<<<< HEAD
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
@@ -61,13 +62,39 @@
     "json-schema": "^0.4.0",
     "npm-check-updates": "^12",
     "projen": "^0.52.70",
+=======
+    "@types/node": "^12.13.0",
+    "@typescript-eslint/eslint-plugin": "^4.31.2",
+    "@typescript-eslint/parser": "^4.31.2",
+    "cdk8s": "1.0.0-beta.48",
+    "cdk8s-cli": "1.0.0-beta.52",
+    "constructs": "^3.3.150",
+    "eslint": "^7.32.0",
+    "eslint-import-resolver-node": "^0.3.6",
+    "eslint-import-resolver-typescript": "^2.5.0",
+    "eslint-plugin-import": "^2.24.2",
+    "jest": "^27.2.1",
+    "jest-junit": "^12",
+    "jsii": "^1.34.0",
+    "jsii-diff": "^1.34.0",
+    "jsii-docgen": "^3.6.3",
+    "jsii-pacmak": "^1.34.0",
+    "json-schema": "^0.3.0",
+    "npm-check-updates": "^11",
+    "projen": "^0.28.24",
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     "standard-version": "^9",
     "ts-jest": "^27.1.3",
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
+<<<<<<< HEAD
     "cdk8s": "^1.5.42",
     "constructs": "^3.3.242"
+=======
+    "cdk8s": "1.0.0-beta.48",
+    "constructs": "^3.3.150"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   },
   "dependencies": {
     "minimatch": "^3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,7 @@
     jest-util "^27.5.1"
     slash "^3.0.0"
 
+<<<<<<< HEAD
 "@jest/core@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.5.1.tgz#267ac5f704e09dc52de2922cbf3af9edcd64b626"
@@ -375,11 +376,24 @@
     "@jest/test-result" "^27.5.1"
     "@jest/transform" "^27.5.1"
     "@jest/types" "^27.5.1"
+=======
+"@jest/core@^27.2.1":
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.2.1.tgz#93dc50e2aaba2c944e5765cf658dcd98d804c970"
+  integrity sha512-XcGt9UgPyzylThvezwUIMCNVp8xxN78Ic3WwhJZehZt4n2hPHR6Bd85A1nKFZBeqW58Vd+Cx/LaN6YL4n58KlA==
+  dependencies:
+    "@jest/console" "^27.2.0"
+    "@jest/reporters" "^27.2.1"
+    "@jest/test-result" "^27.2.0"
+    "@jest/transform" "^27.2.1"
+    "@jest/types" "^27.1.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     emittery "^0.8.1"
     exit "^0.1.2"
+<<<<<<< HEAD
     graceful-fs "^4.2.9"
     jest-changed-files "^27.5.1"
     jest-config "^27.5.1"
@@ -394,6 +408,22 @@
     jest-util "^27.5.1"
     jest-validate "^27.5.1"
     jest-watcher "^27.5.1"
+=======
+    graceful-fs "^4.2.4"
+    jest-changed-files "^27.1.1"
+    jest-config "^27.2.1"
+    jest-haste-map "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-regex-util "^27.0.6"
+    jest-resolve "^27.2.0"
+    jest-resolve-dependencies "^27.2.1"
+    jest-runner "^27.2.1"
+    jest-runtime "^27.2.1"
+    jest-snapshot "^27.2.1"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
+    jest-watcher "^27.2.0"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     micromatch "^4.0.4"
     rimraf "^3.0.0"
     slash "^3.0.0"
@@ -421,6 +451,7 @@
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
+<<<<<<< HEAD
 "@jest/globals@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.5.1.tgz#7ac06ce57ab966566c7963431cef458434601b2b"
@@ -441,6 +472,27 @@
     "@jest/transform" "^27.5.1"
     "@jest/types" "^27.5.1"
     "@types/node" "*"
+=======
+"@jest/globals@^27.2.1":
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.2.1.tgz#6842c70b6713fbe2fcaf89eac20d77eeeb0e282c"
+  integrity sha512-4P46Zr4cckSitsWtOMRvgMMn7mOKbBsQdYxHeGSIG3kpI4gNR2vk51balPulZHnBQCQb/XBptprtoSv1REfaew==
+  dependencies:
+    "@jest/environment" "^27.2.0"
+    "@jest/types" "^27.1.1"
+    expect "^27.2.1"
+
+"@jest/reporters@^27.2.1":
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.2.1.tgz#2e43361b962e26975d40eafd7b4f14c70b4fe9a0"
+  integrity sha512-ILqR+bIIBlhaHjDtQR/0Z20YkKAQVM+NVRuJLaWFCoRx/rKQQSxG01ZLiLV0MsA6wkBHf6J9fzFuXp0k5l7epw==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^27.2.0"
+    "@jest/test-result" "^27.2.0"
+    "@jest/transform" "^27.2.1"
+    "@jest/types" "^27.1.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
@@ -480,6 +532,7 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
+<<<<<<< HEAD
 "@jest/test-sequencer@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.5.1.tgz#4057e0e9cea4439e544c6353c6affe58d095745b"
@@ -494,6 +547,22 @@
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.5.1.tgz#6c3501dcc00c4c08915f292a600ece5ecfe1f409"
   integrity sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==
+=======
+"@jest/test-sequencer@^27.2.1":
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.2.1.tgz#1682cd3a16198fa358ff9565b0d2792919f36562"
+  integrity sha512-fWcEgWQXgvU4DFY5YHfQsGwqfJWyuCUzdOzLZTYtyLB3WK1mFPQGYAszM7mCEZjyVon5XRuCa+2/+hif/uMucQ==
+  dependencies:
+    "@jest/test-result" "^27.2.0"
+    graceful-fs "^4.2.4"
+    jest-haste-map "^27.2.0"
+    jest-runtime "^27.2.1"
+
+"@jest/transform@^27.2.1":
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.2.1.tgz#743443adb84b3b7419951fc702515ce20ba6285e"
+  integrity sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     "@babel/core" "^7.1.0"
     "@jest/types" "^27.5.1"
@@ -809,6 +878,7 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*":
+<<<<<<< HEAD
   version "17.0.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
   integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
@@ -817,6 +887,16 @@
   version "12.20.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
   integrity sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==
+=======
+  version "16.9.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz#040a64d7faf9e5d9e940357125f0963012e66f04"
+  integrity sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==
+
+"@types/node@^12.13.0":
+  version "12.20.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.26.tgz#a6db0d0577e40844f0b28c2a9289c09e5b44b541"
+  integrity sha512-gIt+h4u2uTho2bsH1K250fUv5fHU71ET1yWT7bM4523zV/XrFb9jlWBOV4DO8FpscY+Sz/WEr1EEjIP2H4yumQ==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -852,6 +932,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+<<<<<<< HEAD
 "@typescript-eslint/eslint-plugin@^5":
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz#5119b67152356231a0e24b998035288a9cd21335"
@@ -861,12 +942,23 @@
     "@typescript-eslint/type-utils" "5.14.0"
     "@typescript-eslint/utils" "5.14.0"
     debug "^4.3.2"
+=======
+"@typescript-eslint/eslint-plugin@^4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.2.tgz#9f41efaee32cdab7ace94b15bd19b756dd099b0a"
+  integrity sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.31.2"
+    "@typescript-eslint/scope-manager" "4.31.2"
+    debug "^4.3.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
     regexpp "^3.2.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+<<<<<<< HEAD
 "@typescript-eslint/parser@^5":
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.14.0.tgz#7c79f898aa3cff0ceee6f1d34eeed0f034fb9ef3"
@@ -931,6 +1023,63 @@
   dependencies:
     "@typescript-eslint/types" "5.14.0"
     eslint-visitor-keys "^3.0.0"
+=======
+"@typescript-eslint/experimental-utils@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.2.tgz#98727a9c1e977dd5d20c8705e69cd3c2a86553fa"
+  integrity sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.31.2"
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/typescript-estree" "4.31.2"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/parser@^4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.2.tgz#54aa75986e3302d91eff2bbbaa6ecfa8084e9c34"
+  integrity sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.31.2"
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/typescript-estree" "4.31.2"
+    debug "^4.3.1"
+
+"@typescript-eslint/scope-manager@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.31.2.tgz#1d528cb3ed3bcd88019c20a57c18b897b073923a"
+  integrity sha512-2JGwudpFoR/3Czq6mPpE8zBPYdHWFGL6lUNIGolbKQeSNv4EAiHaR5GVDQaLA0FwgcdcMtRk+SBJbFGL7+La5w==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/visitor-keys" "4.31.2"
+
+"@typescript-eslint/types@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.2.tgz#2aea7177d6d744521a168ed4668eddbd912dfadf"
+  integrity sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==
+
+"@typescript-eslint/typescript-estree@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.2.tgz#abfd50594d8056b37e7428df3b2d185ef2d0060c"
+  integrity sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
+    "@typescript-eslint/visitor-keys" "4.31.2"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@4.31.2":
+  version "4.31.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.2.tgz#7d5b4a4705db7fe59ecffb273c1d082760f635cc"
+  integrity sha512-PrBId7EQq2Nibns7dd/ch6S6/M4/iwLM9McbgeEbCXfxdwRUNxJ4UNreJ6Gh3fI2GNKNrWnQxKL7oCPmngKBug==
+  dependencies:
+    "@typescript-eslint/types" "4.31.2"
+    eslint-visitor-keys "^2.0.0"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 "@xmldom/xmldom@^0.8.1":
   version "0.8.1"
@@ -1153,6 +1302,7 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
+<<<<<<< HEAD
 babel-jest@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.5.1.tgz#a1bf8d61928edfefd21da27eb86a695bfd691444"
@@ -1160,6 +1310,25 @@ babel-jest@^27.5.1:
   dependencies:
     "@jest/transform" "^27.5.1"
     "@jest/types" "^27.5.1"
+=======
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+
+aws4@^1.8.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+babel-jest@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.2.1.tgz#48edfa5cf8d59ab293da94321a369ccc7b67a4b1"
+  integrity sha512-kkaekSJHew1zfDW3cA2QiSBPg4uiLpiW0OwJKqFv0r2/mFgym/IBn7hxPntL6FvS66G/ROh+lz4pRiCJAH1/UQ==
+  dependencies:
+    "@jest/transform" "^27.2.1"
+    "@jest/types" "^27.1.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.1.1"
     babel-preset-jest "^27.5.1"
@@ -1364,16 +1533,24 @@ camelcase@^6.2.0, camelcase@^6.3.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+<<<<<<< HEAD
 caniuse-lite@^1.0.30001313:
   version "1.0.30001315"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001315.tgz#f1b1efd1171ee1170d52709a7252632dacbd7c77"
   integrity sha512-5v7LFQU4Sb/qvkz7JcZkvtSH1Ko+1x2kgo3ocdBeMGZSOFpuE1kkm0kpTwLtWeFrw5qw08ulLxJjVIXIS8MkiQ==
+=======
+caniuse-lite@^1.0.30001254:
+  version "1.0.30001259"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz#ae21691d3da9c4be6144403ac40f71d9f6efd790"
+  integrity sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 case@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
+<<<<<<< HEAD
 cdk8s-cli@1.0.123:
   version "1.0.123"
   resolved "https://registry.yarnpkg.com/cdk8s-cli/-/cdk8s-cli-1.0.123.tgz#be10e8ce0910cfc919cf32ccf6fde71b3af406eb"
@@ -1405,9 +1582,56 @@ cdk8s@1.5.42, cdk8s@^1.5.42:
   version "1.5.42"
   resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-1.5.42.tgz#fe2515fda285ddd55ac5a45ad9b24209e0af9a3c"
   integrity sha512-ja+hbNDScJS+NdVesnOfesilfus+e2f8MLs45sLElXyvAg7HWGTZl4PGLxG7OYH1TAt7ZEfkJNyZAyTqSgM16w==
+=======
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+cdk8s-cli@1.0.0-beta.52:
+  version "1.0.0-beta.52"
+  resolved "https://registry.yarnpkg.com/cdk8s-cli/-/cdk8s-cli-1.0.0-beta.52.tgz#1d6f28b3668e24564c4bc114b1524489d745ad65"
+  integrity sha512-fpmL+BLmLgsNcgf7Nv/zBMZqnk0A2s64ij2Ets/CNplXuP2H+ZK8T7pWKGRPIC1smNQngHkz89RyeK7TQuX8bg==
+  dependencies:
+    "@types/node" "^12.13.0"
+    ajv "^8.6.3"
+    cdk8s "1.0.0-beta.46"
+    cdk8s-plus-17 "1.0.0-beta.74"
+    codemaker "^1.34.0"
+    colors "^1.4.0"
+    constructs "^3.3.147"
+    fs-extra "^8"
+    jsii-pacmak "^1.34.0"
+    jsii-srcmak "^0.1.348"
+    json2jsii "^0.2.24"
+    sscaff "^1.2.70"
+    yaml "2.0.0-8"
+    yargs "^15"
+
+cdk8s-plus-17@1.0.0-beta.74:
+  version "1.0.0-beta.74"
+  resolved "https://registry.yarnpkg.com/cdk8s-plus-17/-/cdk8s-plus-17-1.0.0-beta.74.tgz#f1f6a46b7b6d05f6160e76e2827995edce4244f0"
+  integrity sha512-+7+iKqt9Ump9DUm91VouW2H9R7H7cBvbb/hPu8zRflC4OwvSZJb1ONzdUDLahqzFp+l2VQ0zcGMFfD8ONlFMjA==
+  dependencies:
+    minimatch "^3.0.4"
+
+cdk8s@1.0.0-beta.46:
+  version "1.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-1.0.0-beta.46.tgz#4a3967e18949fb4e61386d5f4f7e0355badf50c4"
+  integrity sha512-mThFg5t92Vu/pSpZVXppaokkSVIdFFnIN8pUoojIaiYL5gD1mG37IY1xt2+FDM6nncl1q6IzjKWipnGOoJYlcQ==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     fast-json-patch "^2.2.1"
     follow-redirects "^1.14.9"
+    yaml "2.0.0-7"
+
+cdk8s@1.0.0-beta.48:
+  version "1.0.0-beta.48"
+  resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-1.0.0-beta.48.tgz#fa5737444cefb2c06e9bd1b2ef363d3509c10620"
+  integrity sha512-S6Wu4rl7NodIK2mjriAKVbkdue22EWeno95264sPd/wy5Waho6CBKZ3owWTsSzuB2U2ep+ZnFzOIfkqA8uE0zQ==
+  dependencies:
+    fast-json-patch "^2.2.1"
+    follow-redirects "^1.14.4"
     yaml "2.0.0-7"
 
 chalk@^2.0.0, chalk@^2.4.2:
@@ -1509,10 +1733,22 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
+<<<<<<< HEAD
 codemaker@^1.55.0:
   version "1.55.0"
   resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.55.0.tgz#902dbf5384d16823c7e2fc7e94a5ae632b1c7b22"
   integrity sha512-oVCJ3PUqkMf65pS8TtstLSn5AAGmuDTfrjlZjG8qOcOMHvG/w12iJ4ZlJt/wULaAqlYh9bTemXaGIzT5YbX43A==
+=======
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+codemaker@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.34.0.tgz#dba5dbd9ca6d1d9d9af64d64f17bde45882b0aa0"
+  integrity sha512-NHwy6TxMh21ygch7+K/OwtdN3BjxhAMoP5QXqzkkR0TDP2kEdKCNc31EChz3Xcmxk1qkdJN5CpXMnLjo7f07sQ==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     camelcase "^6.3.0"
     decamelize "^5.0.1"
@@ -1624,10 +1860,17 @@ console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
+<<<<<<< HEAD
 constructs@3.3.242, constructs@^3.3.242:
   version "3.3.242"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.242.tgz#dc63e174d89d62ce0a49bc24114c97d091628368"
   integrity sha512-poS1Xb1Tm6m81iMLVTW8HeevF3FFFPrW4gSwNib/vMvkAm4dmCuuSjabRHkMONb1fKQESLJMwzihGTjDXevxnA==
+=======
+constructs@^3.3.147, constructs@^3.3.150:
+  version "3.3.150"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.150.tgz#3dbb06bc0e9880f84327edca9619e068af3ad296"
+  integrity sha512-i++Z38CgBF7kDsKJ2PtdRpXbqL4vwule8tSxcI/PkCbj6LXmokyr7givjzPavgfMhYncDB6J4RoBjfLFMOKRxA==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"
@@ -2073,10 +2316,25 @@ duplexer3@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
   integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
+<<<<<<< HEAD
 electron-to-chromium@^1.4.76:
   version "1.4.82"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.82.tgz#51e123ca434b1eba8c434ece2b54f095b304a651"
   integrity sha512-Ks+ANzLoIrFDUOJdjxYMH6CMKB8UQo5modAwvSZTxgF+vEs/U7G5IbWFUp6dS4klPkTDVdxbORuk8xAXXhMsWw==
+=======
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
+
+electron-to-chromium@^1.3.830:
+  version "1.3.846"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.846.tgz#a55fd59613dbcaed609e965e3e88f42b08c401d3"
+  integrity sha512-2jtSwgyiRzybHRxrc2nKI+39wH3AwQgn+sogQ+q814gv8hIFwrcZbV07Ea9f8AmK0ufPVZUvvAG1uZJ+obV4Jw==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -2393,10 +2651,17 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
+<<<<<<< HEAD
 expect@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/expect/-/expect-27.5.1.tgz#83ce59f1e5bdf5f9d2b94b61d2050db48f3fef74"
   integrity sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==
+=======
+expect@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-27.2.1.tgz#5f882b308716618613f0106a488b46c303908157"
+  integrity sha512-ekOA2mBtT2phxcoPVHCXIzbJxCvRXhx2fr7m28IgGdZxUOh8UvxvoRz1FcPlfgZMpE92biHB6woIcAKXqR28hA==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     "@jest/types" "^27.5.1"
     jest-get-type "^27.5.1"
@@ -2529,10 +2794,17 @@ flatted@^3.1.0, flatted@^3.2.5:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
+<<<<<<< HEAD
 follow-redirects@^1.14.9:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+=======
+follow-redirects@^1.14.3, follow-redirects@^1.14.4:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
+  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -3334,10 +3606,17 @@ jest-changed-files@^27.5.1:
     execa "^5.0.0"
     throat "^6.0.1"
 
+<<<<<<< HEAD
 jest-circus@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.5.1.tgz#37a5a4459b7bf4406e53d637b49d22c65d125ecc"
   integrity sha512-D95R7x5UtlMA5iBYsOHFFbMD/GVA4R/Kdq15f7xYWUfWHBto9NYRsOvnSauTgdF+ogCpJ4tyKOXhUifxS65gdw==
+=======
+jest-circus@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.2.1.tgz#c5166052b328c0df932cdaf89f5982085e7b4812"
+  integrity sha512-9q/8X8DgJmW8IqXsJNnS2E28iarx990hf6D+frS3P0lB+avhFDD33alLwZzKgm45u0wvEi6iFh43WjNbp5fhjw==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     "@jest/environment" "^27.5.1"
     "@jest/test-result" "^27.5.1"
@@ -3346,6 +3625,7 @@ jest-circus@^27.5.1:
     chalk "^4.0.0"
     co "^4.6.0"
     dedent "^0.7.0"
+<<<<<<< HEAD
     expect "^27.5.1"
     is-generator-fn "^2.0.0"
     jest-each "^27.5.1"
@@ -3355,10 +3635,22 @@ jest-circus@^27.5.1:
     jest-snapshot "^27.5.1"
     jest-util "^27.5.1"
     pretty-format "^27.5.1"
+=======
+    expect "^27.2.1"
+    is-generator-fn "^2.0.0"
+    jest-each "^27.2.0"
+    jest-matcher-utils "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-runtime "^27.2.1"
+    jest-snapshot "^27.2.1"
+    jest-util "^27.2.0"
+    pretty-format "^27.2.0"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     slash "^3.0.0"
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
+<<<<<<< HEAD
 jest-cli@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.5.1.tgz#278794a6e6458ea8029547e6c6cbf673bd30b145"
@@ -3367,16 +3659,33 @@ jest-cli@^27.5.1:
     "@jest/core" "^27.5.1"
     "@jest/test-result" "^27.5.1"
     "@jest/types" "^27.5.1"
+=======
+jest-cli@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.2.1.tgz#031e887245945864cc6ed8605c939f1937858c09"
+  integrity sha512-IfxuGkBZS/ogY7yFvvD1dFidzQRXlSBHtUZQ3UTIHydzNMF4/ZRTdGFso6HkbCkemwLh4hnNybONexEqWmYwjw==
+  dependencies:
+    "@jest/core" "^27.2.1"
+    "@jest/test-result" "^27.2.0"
+    "@jest/types" "^27.1.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.9"
     import-local "^3.0.2"
+<<<<<<< HEAD
     jest-config "^27.5.1"
     jest-util "^27.5.1"
     jest-validate "^27.5.1"
+=======
+    jest-config "^27.2.1"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     prompts "^2.0.1"
     yargs "^16.2.0"
 
+<<<<<<< HEAD
 jest-config@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.5.1.tgz#5c387de33dca3f99ad6357ddeccd91bf3a0e4a41"
@@ -3386,10 +3695,22 @@ jest-config@^27.5.1:
     "@jest/test-sequencer" "^27.5.1"
     "@jest/types" "^27.5.1"
     babel-jest "^27.5.1"
+=======
+jest-config@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.2.1.tgz#2e727e023fc4b77a9f067a40c5448a939aa8386b"
+  integrity sha512-BAOemP8udmFw9nkgaLAac7vXORdvrt4yrJWoh7uYb0nPZeSsu0kGwJU18SwtY4paq9fed5OgAssC3A+Bf4WMQA==
+  dependencies:
+    "@babel/core" "^7.1.0"
+    "@jest/test-sequencer" "^27.2.1"
+    "@jest/types" "^27.1.1"
+    babel-jest "^27.2.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     chalk "^4.0.0"
     ci-info "^3.2.0"
     deepmerge "^4.2.2"
     glob "^7.1.1"
+<<<<<<< HEAD
     graceful-fs "^4.2.9"
     jest-circus "^27.5.1"
     jest-environment-jsdom "^27.5.1"
@@ -3401,6 +3722,20 @@ jest-config@^27.5.1:
     jest-runner "^27.5.1"
     jest-util "^27.5.1"
     jest-validate "^27.5.1"
+=======
+    graceful-fs "^4.2.4"
+    is-ci "^3.0.0"
+    jest-circus "^27.2.1"
+    jest-environment-jsdom "^27.2.0"
+    jest-environment-node "^27.2.0"
+    jest-get-type "^27.0.6"
+    jest-jasmine2 "^27.2.1"
+    jest-regex-util "^27.0.6"
+    jest-resolve "^27.2.0"
+    jest-runner "^27.2.1"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     micromatch "^4.0.4"
     parse-json "^5.2.0"
     pretty-format "^27.5.1"
@@ -3500,10 +3835,17 @@ jest-haste-map@^27.5.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
+<<<<<<< HEAD
 jest-jasmine2@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.5.1.tgz#a037b0034ef49a9f3d71c4375a796f3b230d1ac4"
   integrity sha512-jtq7VVyG8SqAorDpApwiJJImd0V2wv1xzdheGHRGyuT7gZm6gG47QEskOlzsN1PG/6WNaCo5pmwMHDf3AkG2pQ==
+=======
+jest-jasmine2@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.2.1.tgz#30ee71f38670a621ecf3b6dcb89875933f780de6"
+  integrity sha512-3vytj3+S49+XYsxGJyjlchDo4xblYzjDY4XK7pV2IAdspbMFOpmeNMOeDonYuvlbUtcV8yrFLA6XtliXapDmMA==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     "@jest/environment" "^27.5.1"
     "@jest/source-map" "^27.5.1"
@@ -3512,6 +3854,7 @@ jest-jasmine2@^27.5.1:
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
+<<<<<<< HEAD
     expect "^27.5.1"
     is-generator-fn "^2.0.0"
     jest-each "^27.5.1"
@@ -3527,6 +3870,23 @@ jest-junit@^13:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-13.0.0.tgz#479be347457aad98ae8a5983a23d7c3ec526c9a3"
   integrity sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==
+=======
+    expect "^27.2.1"
+    is-generator-fn "^2.0.0"
+    jest-each "^27.2.0"
+    jest-matcher-utils "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-runtime "^27.2.1"
+    jest-snapshot "^27.2.1"
+    jest-util "^27.2.0"
+    pretty-format "^27.2.0"
+    throat "^6.0.1"
+
+jest-junit@^12:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-12.3.0.tgz#ee41a74e439eecdc8965f163f83035cce5998d6d"
+  integrity sha512-+NmE5ogsEjFppEl90GChrk7xgz8xzvF0f+ZT5AnhW6suJC93gvQtmQjfyjDnE0Z2nXJqEkxF0WXlvjG/J+wn/g==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     mkdirp "^1.0.4"
     strip-ansi "^6.0.1"
@@ -3584,6 +3944,7 @@ jest-regex-util@^27.5.1:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.5.1.tgz#4da143f7e9fd1e542d4aa69617b38e4a78365b95"
   integrity sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==
 
+<<<<<<< HEAD
 jest-resolve-dependencies@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.5.1.tgz#d811ecc8305e731cc86dd79741ee98fed06f1da8"
@@ -3592,6 +3953,16 @@ jest-resolve-dependencies@^27.5.1:
     "@jest/types" "^27.5.1"
     jest-regex-util "^27.5.1"
     jest-snapshot "^27.5.1"
+=======
+jest-resolve-dependencies@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.1.tgz#239be969ece749d4dc2e1efcf3d2b86c99525c2e"
+  integrity sha512-9bKEwmz4YshGPjGZAVZOVw6jt7pq2/FjWJmyhnWhvDuiRCHVZBcJhycinX+e/EJ7jafsq26bTpzBIQas3xql1g==
+  dependencies:
+    "@jest/types" "^27.1.1"
+    jest-regex-util "^27.0.6"
+    jest-snapshot "^27.2.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 jest-resolve@^27.5.1:
   version "27.5.1"
@@ -3609,6 +3980,7 @@ jest-resolve@^27.5.1:
     resolve.exports "^1.1.0"
     slash "^3.0.0"
 
+<<<<<<< HEAD
 jest-runner@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.5.1.tgz#071b27c1fa30d90540805c5645a0ec167c7b62e5"
@@ -3648,11 +4020,56 @@ jest-runtime@^27.5.1:
     "@jest/test-result" "^27.5.1"
     "@jest/transform" "^27.5.1"
     "@jest/types" "^27.5.1"
+=======
+jest-runner@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.2.1.tgz#3443b1fc08b8a50f305dfc2d41dd2badf335843b"
+  integrity sha512-USHitkUUzcB3Y5mRdzlp+KHgRRR2VsXDq5OeATuDmq1qXfT/RwwnQykUhn+KVx3FotxK3pID74UY7o6HYIR8vA==
+  dependencies:
+    "@jest/console" "^27.2.0"
+    "@jest/environment" "^27.2.0"
+    "@jest/test-result" "^27.2.0"
+    "@jest/transform" "^27.2.1"
+    "@jest/types" "^27.1.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.8.1"
+    exit "^0.1.2"
+    graceful-fs "^4.2.4"
+    jest-docblock "^27.0.6"
+    jest-environment-jsdom "^27.2.0"
+    jest-environment-node "^27.2.0"
+    jest-haste-map "^27.2.0"
+    jest-leak-detector "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-resolve "^27.2.0"
+    jest-runtime "^27.2.1"
+    jest-util "^27.2.0"
+    jest-worker "^27.2.0"
+    source-map-support "^0.5.6"
+    throat "^6.0.1"
+
+jest-runtime@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.2.1.tgz#db506f679356f5b94b7be20e770f2541b7c2b339"
+  integrity sha512-QJNnwL4iteDE/Jq4TfQK7AjhPoUZflBKTtUIkRnFYFkTAZTP/o8k7ekaROiVjmo+NYop5+DQPqX6pz4vWbZSOQ==
+  dependencies:
+    "@jest/console" "^27.2.0"
+    "@jest/environment" "^27.2.0"
+    "@jest/fake-timers" "^27.2.0"
+    "@jest/globals" "^27.2.1"
+    "@jest/source-map" "^27.0.6"
+    "@jest/test-result" "^27.2.0"
+    "@jest/transform" "^27.2.1"
+    "@jest/types" "^27.1.1"
+    "@types/yargs" "^16.0.0"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
     execa "^5.0.0"
     glob "^7.1.3"
+<<<<<<< HEAD
     graceful-fs "^4.2.9"
     jest-haste-map "^27.5.1"
     jest-message-util "^27.5.1"
@@ -3661,6 +4078,17 @@ jest-runtime@^27.5.1:
     jest-resolve "^27.5.1"
     jest-snapshot "^27.5.1"
     jest-util "^27.5.1"
+=======
+    graceful-fs "^4.2.4"
+    jest-haste-map "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-mock "^27.1.1"
+    jest-regex-util "^27.0.6"
+    jest-resolve "^27.2.0"
+    jest-snapshot "^27.2.1"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
@@ -3672,22 +4100,35 @@ jest-serializer@^27.5.1:
     "@types/node" "*"
     graceful-fs "^4.2.9"
 
+<<<<<<< HEAD
 jest-snapshot@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.5.1.tgz#b668d50d23d38054a51b42c4039cab59ae6eb6a1"
   integrity sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==
+=======
+jest-snapshot@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.2.1.tgz#385accf3bb71ac84e9a6bda4fc9bb458d53abb35"
+  integrity sha512-8CTg2YrgZuQbPHW7G0YvLTj4yTRXLmSeEO+ka3eC5lbu5dsTRyoDNS1L7x7EFUTyYQhFH9HQG1/TNlbUgR9Lug==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     "@babel/core" "^7.7.2"
     "@babel/generator" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.0.0"
+<<<<<<< HEAD
     "@jest/transform" "^27.5.1"
     "@jest/types" "^27.5.1"
+=======
+    "@jest/transform" "^27.2.1"
+    "@jest/types" "^27.1.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     "@types/babel__traverse" "^7.0.4"
     "@types/prettier" "^2.1.5"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
+<<<<<<< HEAD
     expect "^27.5.1"
     graceful-fs "^4.2.9"
     jest-diff "^27.5.1"
@@ -3696,6 +4137,17 @@ jest-snapshot@^27.5.1:
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
     jest-util "^27.5.1"
+=======
+    expect "^27.2.1"
+    graceful-fs "^4.2.4"
+    jest-diff "^27.2.0"
+    jest-get-type "^27.0.6"
+    jest-haste-map "^27.2.0"
+    jest-matcher-utils "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-resolve "^27.2.0"
+    jest-util "^27.2.0"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
     natural-compare "^1.4.0"
     pretty-format "^27.5.1"
     semver "^7.3.2"
@@ -3746,6 +4198,7 @@ jest-worker@^27.5.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+<<<<<<< HEAD
 jest@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest/-/jest-27.5.1.tgz#dadf33ba70a779be7a6fc33015843b51494f63fc"
@@ -3754,6 +4207,16 @@ jest@^27.5.1:
     "@jest/core" "^27.5.1"
     import-local "^3.0.2"
     jest-cli "^27.5.1"
+=======
+jest@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-27.2.1.tgz#9263102056fe152fd2478d181cf9bbbd2a6a8da4"
+  integrity sha512-0MyvNS7J1HbkeotYaqKNGioN+p1/AAPtI1Z8iwMtCBE+PwBT+M4l25D9Pve8/KdhktYLgZaGyyj9CoDytD+R2Q==
+  dependencies:
+    "@jest/core" "^27.2.1"
+    import-local "^3.0.2"
+    jest-cli "^27.2.1"
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 jju@^1.1.0:
   version "1.4.0"
@@ -3854,10 +4317,17 @@ jsii-docgen@^3.8.31:
     semver "^7.3.5"
     yargs "^16.2.0"
 
+<<<<<<< HEAD
 jsii-pacmak@^1.55.0:
   version "1.55.0"
   resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.55.0.tgz#b8b448ca6dd5319becbe4ba87f383e22fc4bf393"
   integrity sha512-2i1VQVGQIC0JUSryw9gV2VqcMNbR/KLQOwsfNb7gTs6qKccR5Pmf4eXuIC+HxpyIiecu1UeEbToz5q8fMdVcig==
+=======
+jsii-pacmak@^1.34.0:
+  version "1.34.0"
+  resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.34.0.tgz#7fc6a79fb72bd791a0cac5877339253fd26e14e3"
+  integrity sha512-OngbNHieb5g7B1VkRSZkZq1vgoflhjX4heTJnQJZYbG59j2qVgD7E/o/Dl2OTBLrGRms8e2oCsYc7XROt2htSA==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     "@jsii/check-node" "1.55.0"
     "@jsii/spec" "^1.55.0"
@@ -3904,10 +4374,17 @@ jsii-rosetta@^1.44.0, jsii-rosetta@^1.55.0:
     workerpool "^6.2.0"
     yargs "^16.2.0"
 
+<<<<<<< HEAD
 jsii-srcmak@^0.1.502:
   version "0.1.502"
   resolved "https://registry.yarnpkg.com/jsii-srcmak/-/jsii-srcmak-0.1.502.tgz#9dcb25ce18c49c4cc4e9783e82e73f36799c6d32"
   integrity sha512-u9k6PjVDVYQAlmE8ZvzDQgLfKeuF+tHTzznrQcW2UkdAC/o/zgNRJMafHG7WloYJ+wvp7hatBeSDg/dzpz6jhQ==
+=======
+jsii-srcmak@^0.1.348:
+  version "0.1.351"
+  resolved "https://registry.yarnpkg.com/jsii-srcmak/-/jsii-srcmak-0.1.351.tgz#5f45eb689482c8e619dca555832783a2031293a1"
+  integrity sha512-ZiXB7nvNrxylnbf8gUWgcHwciizWLGrVlO9xVdqoAOqAxSEwLPZk721nYwp7LHTi6c4HAiBtAHsNZC4Dd4As5Q==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     fs-extra "^9.1.0"
     jsii "^1.55.0"
@@ -3981,10 +4458,17 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+<<<<<<< HEAD
 json2jsii@^0.2.162:
   version "0.2.162"
   resolved "https://registry.yarnpkg.com/json2jsii/-/json2jsii-0.2.162.tgz#6eef6aa120a838a6be36cebbf90121306ea08090"
   integrity sha512-ypYB3BE3CGJWnTPa9WHL4zMpzIUYMkaTo+Q/ML8WY9qYSkk99wQpDGim35Y09to4sShJchEGvGvxkn6RRZRmjQ==
+=======
+json2jsii@^0.2.24:
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/json2jsii/-/json2jsii-0.2.27.tgz#0b21fc3bcbe2070c6419f934258f180a8f3c172c"
+  integrity sha512-dl1jji4Z+YHm08ckQdW2f6gS7WF+f4UEEqPbduFpP8wTAxBvKnYFxuzPEUQCONi2MjSLBBPHgmtisUYqCONTYw==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     camelcase "^6.3.0"
     json-schema "^0.4.0"
@@ -4476,10 +4960,22 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
+<<<<<<< HEAD
 node-releases@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
   integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
+=======
+node-modules-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
+  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+
+node-releases@^1.1.75:
+  version "1.1.76"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.76.tgz#df245b062b0cafbd5282ab6792f7dccc2d97f36e"
+  integrity sha512-9/IECtNr8dXNmPWmFXepT0/7o5eolGesHUa3mtr0KlgnCvnZxwh2qensKL42JJY2vQKC3nIBXetFAqR+PW1CmA==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -4982,10 +5478,17 @@ progress@^2.0.3:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+<<<<<<< HEAD
 projen@^0.52.70:
   version "0.52.70"
   resolved "https://registry.yarnpkg.com/projen/-/projen-0.52.70.tgz#a0e6ffe87b300ae74f4f456612abe4b89c8047d0"
   integrity sha512-e/HADsRPNq1zSyerkkgGBjeoic/RWt8EZ2f8UA/lX4WYZqjZkJ9KQYj9k0Ny4rFfOxau2SnBMIVhyb4tZpTJ0Q==
+=======
+projen@^0.28.24:
+  version "0.28.24"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.28.24.tgz#5d28a7e3db19eefb5125307fe180164a8f87b257"
+  integrity sha512-oKn7pZWqFNLl1oFBPJL9CXmAD5p8LCqGT11t5zbfTcvmNvuHixLe+d+dK0kM399plwi1OfOXcf5qxrYAxdP01w==
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   dependencies:
     "@iarna/toml" "^2.2.5"
     case "^1.6.3"
@@ -5524,12 +6027,36 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
+<<<<<<< HEAD
 sscaff@^1.2.228:
   version "1.2.228"
   resolved "https://registry.yarnpkg.com/sscaff/-/sscaff-1.2.228.tgz#85c1a96a77c803fceedcba78602b1f0343f1c5c8"
   integrity sha512-OoT9cQr+EVY+Q2/AcWj+pR3h+lpe3YMY1Y8G6rDovg54ckRCgwDEeA7Ys+Af4+L9OxpQt+tgNiFkTpcrXjhj+g==
 
 ssri@^8.0.1:
+=======
+sscaff@^1.2.70:
+  version "1.2.73"
+  resolved "https://registry.yarnpkg.com/sscaff/-/sscaff-1.2.73.tgz#77646ad54d012954f363890ef5a7c78c38a4bb1d"
+  integrity sha512-mOFmcSfJq6Ck4G+qE3CcZzNFUhYsG9aonMN4fNY65aiiLQL9pufMVj/s85BjMrLmdVavnh7/CZ/FXYldPeBUjA==
+
+sshpk@^1.7.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
+
+ssri@^8.0.0, ssri@^8.0.1:
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
@@ -6261,15 +6788,23 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+<<<<<<< HEAD
 yaml@2.0.0-10, yaml@next:
   version "2.0.0-10"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-10.tgz#d5b59e2d14b8683313a534f2bbc648e211a2753e"
   integrity sha512-FHV8s5ODFFQXX/enJEU2EkanNl1UDBUz8oa4k5Qo/sR+Iq7VmhCDkRMb0/mjJCNeAWQ31W8WV6PYStDE4d9EIw==
 
+=======
+>>>>>>> 3647391 (chore(deps): upgrade dependencies (#8))
 yaml@2.0.0-7:
   version "2.0.0-7"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-7.tgz#9799d9d85dfc8f01e4cc425e18e09215364beef1"
   integrity sha512-RbI2Tm3hl9AoHY4wWyWvGvJfFIbHOzuzaxum6ez1A0vve+uXgNor03Wys4t+2sgjJSVSe+B2xerd1/dnvqHlOA==
+
+yaml@2.0.0-8:
+  version "2.0.0-8"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-8.tgz#226365f0d804ba7fb8cc2b527a00a7a4a3d8ea5f"
+  integrity sha512-QaYgJZMfWD6fKN/EYMk6w1oLWPCr1xj9QaPSZW5qkDb3y8nGCXhy2Ono+AF4F+CSL/vGcqswcAT0BaS//pgD2A==
 
 yaml@^1.10.2:
   version "1.10.2"


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [chore(deps): upgrade dependencies (#8)](https://github.com/cdk8s-team/cdk8s-plus/pull/8)

<!--- Backport version: 8.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)