### PR TITLE
feat: pod host aliases (#469)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -247,6 +247,7 @@ import org.cdk8s.plus21.Deployment;
 Deployment.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -289,6 +290,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.parameter.hostAliases"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -408,6 +417,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addHostAlias` <a name="org.cdk8s.plus21.Deployment.addHostAlias"></a>
+
+```java
+public addHostAlias(HostAlias hostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.parameter.hostAlias"></a>
+
+- *Type:* [`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="org.cdk8s.plus21.Deployment.addInitContainer"></a>
 
 ```java
@@ -506,6 +527,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus21.Deployment.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -830,6 +865,7 @@ import org.cdk8s.plus21.Job;
 Job.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -873,6 +909,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.parameter.hostAliases"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -1005,6 +1049,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addHostAlias` <a name="org.cdk8s.plus21.Job.addHostAlias"></a>
+
+```java
+public addHostAlias(HostAlias hostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.parameter.hostAlias"></a>
+
+- *Type:* [`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="org.cdk8s.plus21.Job.addInitContainer"></a>
 
 ```java
@@ -1043,6 +1099,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus21.Job.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -1176,6 +1246,7 @@ import org.cdk8s.plus21.Pod;
 Pod.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -1215,6 +1286,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.parameter.hostAliases"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -1305,6 +1384,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addHostAlias` <a name="org.cdk8s.plus21.Pod.addHostAlias"></a>
+
+```java
+public addHostAlias(HostAlias hostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.parameter.hostAlias"></a>
+
+- *Type:* [`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="org.cdk8s.plus21.Pod.addInitContainer"></a>
 
 ```java
@@ -1343,6 +1434,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus21.Pod.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -2036,6 +2141,7 @@ import org.cdk8s.plus21.StatefulSet;
 StatefulSet.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -2080,6 +2186,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.parameter.hostAliases"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -2216,6 +2330,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addHostAlias` <a name="org.cdk8s.plus21.StatefulSet.addHostAlias"></a>
+
+```java
+public addHostAlias(HostAlias hostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.parameter.hostAlias"></a>
+
+- *Type:* [`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="org.cdk8s.plus21.StatefulSet.addInitContainer"></a>
 
 ```java
@@ -2276,6 +2402,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus21.StatefulSet.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -3152,6 +3292,7 @@ import org.cdk8s.plus21.DeploymentProps;
 DeploymentProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -3190,6 +3331,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.DeploymentProps.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -3755,6 +3908,45 @@ The ingress to add rules to.
 
 ---
 
+### HostAlias <a name="org.cdk8s.plus21.HostAlias"></a>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's /etc/hosts file.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.HostAlias;
+
+HostAlias.builder()
+    .hostnames(java.util.List<java.lang.String>)
+    .ip(java.lang.String)
+    .build();
+```
+
+##### `hostnames`<sup>Required</sup> <a name="org.cdk8s.plus21.HostAlias.property.hostnames"></a>
+
+```java
+public java.util.List<java.lang.String> getHostnames();
+```
+
+- *Type:* java.util.List<`java.lang.String`>
+
+Hostnames for the chosen IP address.
+
+---
+
+##### `ip`<sup>Required</sup> <a name="org.cdk8s.plus21.HostAlias.property.ip"></a>
+
+```java
+public java.lang.String getIp();
+```
+
+- *Type:* `java.lang.String`
+
+IP address of the host file entry.
+
+---
+
 ### HttpGetProbeOptions <a name="org.cdk8s.plus21.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
@@ -4073,6 +4265,7 @@ import org.cdk8s.plus21.JobProps;
 JobProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -4112,6 +4305,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.JobProps.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -4442,6 +4647,7 @@ import org.cdk8s.plus21.PodProps;
 PodProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -4477,6 +4683,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodProps.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -4689,6 +4907,7 @@ import org.cdk8s.plus21.PodSpecProps;
 
 PodSpecProps.builder()
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -4712,6 +4931,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -4821,6 +5052,7 @@ import org.cdk8s.plus21.PodTemplateProps;
 
 PodTemplateProps.builder()
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -4845,6 +5077,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -5679,6 +5923,7 @@ import org.cdk8s.plus21.StatefulSetProps;
 StatefulSetProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -5719,6 +5964,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.StatefulSetProps.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -7079,6 +7336,7 @@ import org.cdk8s.plus21.PodSpec;
 
 PodSpec.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -7098,6 +7356,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodSpecProps.parameter.hostAliases"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -7188,6 +7454,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addHostAlias` <a name="org.cdk8s.plus21.PodSpec.addHostAlias"></a>
+
+```java
+public addHostAlias(HostAlias hostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.parameter.hostAlias"></a>
+
+- *Type:* [`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="org.cdk8s.plus21.PodSpec.addInitContainer"></a>
 
 ```java
@@ -7226,6 +7504,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus21.PodSpec.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -7305,6 +7597,7 @@ import org.cdk8s.plus21.PodTemplate;
 
 PodTemplate.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
+//  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .securityContext(PodSecurityContextProps)
@@ -7325,6 +7618,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus21.PodTemplateProps.parameter.hostAliases"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -7745,6 +8046,20 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
+
+---
+
 ##### `initContainers`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodSpec.property.initContainers"></a>
 
 ```java
@@ -7821,6 +8136,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus21.IPodTemplate.property.hostAliases"></a>
+
+```java
+public java.util.List<HostAlias> getHostAliases();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus21.HostAlias`](#org.cdk8s.plus21.HostAlias)>
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -274,6 +274,7 @@ cdk8s_plus_21.Deployment(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -316,6 +317,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.host_aliases"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -601,6 +610,31 @@ Cannot be updated.
 Container's working directory.
 
 If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+---
+
+##### `add_host_alias` <a name="cdk8s_plus_21.Deployment.add_host_alias"></a>
+
+```python
+def add_host_alias(
+  hostnames: typing.List[str],
+  ip: str
+)
+```
+
+###### `hostnames`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.hostnames"></a>
+
+- *Type:* typing.List[`str`]
+
+Hostnames for the chosen IP address.
+
+---
+
+###### `ip`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.ip"></a>
+
+- *Type:* `str`
+
+IP address of the host file entry.
 
 ---
 
@@ -982,6 +1016,20 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
+
+---
+
 ##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_21.Deployment.property.init_containers"></a>
 
 ```python
@@ -1353,6 +1401,7 @@ cdk8s_plus_21.Job(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -1396,6 +1445,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.parameter.host_aliases"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -1697,6 +1754,31 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_host_alias` <a name="cdk8s_plus_21.Job.add_host_alias"></a>
+
+```python
+def add_host_alias(
+  hostnames: typing.List[str],
+  ip: str
+)
+```
+
+###### `hostnames`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.hostnames"></a>
+
+- *Type:* typing.List[`str`]
+
+Hostnames for the chosen IP address.
+
+---
+
+###### `ip`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.ip"></a>
+
+- *Type:* `str`
+
+IP address of the host file entry.
+
+---
+
 ##### `add_init_container` <a name="cdk8s_plus_21.Job.add_init_container"></a>
 
 ```python
@@ -1909,6 +1991,20 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_21.Job.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
+
+---
+
 ##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_21.Job.property.init_containers"></a>
 
 ```python
@@ -2041,6 +2137,7 @@ cdk8s_plus_21.Pod(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -2080,6 +2177,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.parameter.host_aliases"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -2339,6 +2444,31 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_host_alias` <a name="cdk8s_plus_21.Pod.add_host_alias"></a>
+
+```python
+def add_host_alias(
+  hostnames: typing.List[str],
+  ip: str
+)
+```
+
+###### `hostnames`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.hostnames"></a>
+
+- *Type:* typing.List[`str`]
+
+Hostnames for the chosen IP address.
+
+---
+
+###### `ip`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.ip"></a>
+
+- *Type:* `str`
+
+IP address of the host file entry.
+
+---
+
 ##### `add_init_container` <a name="cdk8s_plus_21.Pod.add_init_container"></a>
 
 ```python
@@ -2548,6 +2678,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_21.Pod.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -3372,6 +3516,7 @@ cdk8s_plus_21.StatefulSet(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -3416,6 +3561,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.parameter.host_aliases"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -3721,6 +3874,31 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_host_alias` <a name="cdk8s_plus_21.StatefulSet.add_host_alias"></a>
+
+```python
+def add_host_alias(
+  hostnames: typing.List[str],
+  ip: str
+)
+```
+
+###### `hostnames`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.hostnames"></a>
+
+- *Type:* typing.List[`str`]
+
+Hostnames for the chosen IP address.
+
+---
+
+###### `ip`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.ip"></a>
+
+- *Type:* `str`
+
+IP address of the host file entry.
+
+---
+
 ##### `add_init_container` <a name="cdk8s_plus_21.StatefulSet.add_init_container"></a>
 
 ```python
@@ -3955,6 +4133,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_21.StatefulSet.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -4831,6 +5023,7 @@ import cdk8s_plus_21
 cdk8s_plus_21.DeploymentProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -4869,6 +5062,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -5434,6 +5639,45 @@ The ingress to add rules to.
 
 ---
 
+### HostAlias <a name="cdk8s_plus_21.HostAlias"></a>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's /etc/hosts file.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.HostAlias(
+  hostnames: typing.List[str],
+  ip: str
+)
+```
+
+##### `hostnames`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.property.hostnames"></a>
+
+```python
+hostnames: typing.List[str]
+```
+
+- *Type:* typing.List[`str`]
+
+Hostnames for the chosen IP address.
+
+---
+
+##### `ip`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.property.ip"></a>
+
+```python
+ip: str
+```
+
+- *Type:* `str`
+
+IP address of the host file entry.
+
+---
+
 ### HttpGetProbeOptions <a name="cdk8s_plus_21.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
@@ -5752,6 +5996,7 @@ import cdk8s_plus_21
 cdk8s_plus_21.JobProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -5791,6 +6036,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.JobProps.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -6121,6 +6378,7 @@ import cdk8s_plus_21
 cdk8s_plus_21.PodProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -6156,6 +6414,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.PodProps.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -6368,6 +6638,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.PodSpecProps(
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -6391,6 +6662,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -6500,6 +6783,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.PodTemplateProps(
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -6524,6 +6808,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -7358,6 +7654,7 @@ import cdk8s_plus_21
 cdk8s_plus_21.StatefulSetProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -7398,6 +7695,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.StatefulSetProps.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -8869,6 +9178,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.PodSpec(
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -8888,6 +9198,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.PodSpecProps.parameter.host_aliases"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -9147,6 +9465,31 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_host_alias` <a name="cdk8s_plus_21.PodSpec.add_host_alias"></a>
+
+```python
+def add_host_alias(
+  hostnames: typing.List[str],
+  ip: str
+)
+```
+
+###### `hostnames`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.hostnames"></a>
+
+- *Type:* typing.List[`str`]
+
+Hostnames for the chosen IP address.
+
+---
+
+###### `ip`<sup>Required</sup> <a name="cdk8s_plus_21.HostAlias.parameter.ip"></a>
+
+- *Type:* `str`
+
+IP address of the host file entry.
+
+---
+
 ##### `add_init_container` <a name="cdk8s_plus_21.PodSpec.add_init_container"></a>
 
 ```python
@@ -9359,6 +9702,20 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_21.PodSpec.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
+
+---
+
 ##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_21.PodSpec.property.init_containers"></a>
 
 ```python
@@ -9435,6 +9792,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.PodTemplate(
   containers: typing.List[ContainerProps] = None,
+  host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   security_context: PodSecurityContextProps = None,
@@ -9455,6 +9813,14 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_21.PodTemplateProps.parameter.host_aliases"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -10524,6 +10890,20 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_21.IPodSpec.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
+
+---
+
 ##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_21.IPodSpec.property.init_containers"></a>
 
 ```python
@@ -10600,6 +10980,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_21.IPodTemplate.property.host_aliases"></a>
+
+```python
+host_aliases: typing.List[HostAlias]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_21.HostAlias`](#cdk8s_plus_21.HostAlias)]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -242,6 +242,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addHostAlias` <a name="cdk8s-plus-21.Deployment.addHostAlias"></a>
+
+```typescript
+public addHostAlias(hostAlias: HostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.parameter.hostAlias"></a>
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="cdk8s-plus-21.Deployment.addInitContainer"></a>
 
 ```typescript
@@ -338,6 +350,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-21.Deployment.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -647,6 +673,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addHostAlias` <a name="cdk8s-plus-21.Job.addHostAlias"></a>
+
+```typescript
+public addHostAlias(hostAlias: HostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="cdk8s-plus-21.Job.parameter.hostAlias"></a>
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="cdk8s-plus-21.Job.addInitContainer"></a>
 
 ```typescript
@@ -685,6 +723,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-21.Job.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -850,6 +902,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addHostAlias` <a name="cdk8s-plus-21.Pod.addHostAlias"></a>
+
+```typescript
+public addHostAlias(hostAlias: HostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.parameter.hostAlias"></a>
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="cdk8s-plus-21.Pod.addInitContainer"></a>
 
 ```typescript
@@ -888,6 +952,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-21.Pod.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -1479,6 +1557,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addHostAlias` <a name="cdk8s-plus-21.StatefulSet.addHostAlias"></a>
+
+```typescript
+public addHostAlias(hostAlias: HostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.parameter.hostAlias"></a>
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="cdk8s-plus-21.StatefulSet.addInitContainer"></a>
 
 ```typescript
@@ -1539,6 +1629,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-21.StatefulSet.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -2397,6 +2501,18 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+
+---
+
 ##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-21.DeploymentProps.property.initContainers"></a>
 
 ```typescript
@@ -2929,6 +3045,42 @@ The ingress to add rules to.
 
 ---
 
+### HostAlias <a name="cdk8s-plus-21.HostAlias"></a>
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's /etc/hosts file.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { HostAlias } from 'cdk8s-plus-21'
+
+const hostAlias: HostAlias = { ... }
+```
+
+##### `hostnames`<sup>Required</sup> <a name="cdk8s-plus-21.HostAlias.property.hostnames"></a>
+
+```typescript
+public readonly hostnames: string[];
+```
+
+- *Type:* `string`[]
+
+Hostnames for the chosen IP address.
+
+---
+
+##### `ip`<sup>Required</sup> <a name="cdk8s-plus-21.HostAlias.property.ip"></a>
+
+```typescript
+public readonly ip: string;
+```
+
+- *Type:* `string`
+
+IP address of the host file entry.
+
+---
+
 ### HttpGetProbeOptions <a name="cdk8s-plus-21.HttpGetProbeOptions"></a>
 
 Options for `Probe.fromHttpGet()`.
@@ -3255,6 +3407,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-21.JobProps.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -3604,6 +3768,18 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+
+---
+
 ##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-21.PodProps.property.initContainers"></a>
 
 ```typescript
@@ -3825,6 +4001,18 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+
+---
+
 ##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-21.PodSpecProps.property.initContainers"></a>
 
 ```typescript
@@ -3947,6 +4135,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-21.PodTemplateProps.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -4761,6 +4961,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-21.StatefulSetProps.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
 
 ---
 
@@ -5835,6 +6047,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addHostAlias` <a name="cdk8s-plus-21.PodSpec.addHostAlias"></a>
+
+```typescript
+public addHostAlias(hostAlias: HostAlias)
+```
+
+###### `hostAlias`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.parameter.hostAlias"></a>
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)
+
+---
+
 ##### `addInitContainer` <a name="cdk8s-plus-21.PodSpec.addInitContainer"></a>
 
 ```typescript
@@ -5873,6 +6097,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-21.PodSpec.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 
@@ -6289,6 +6527,20 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
+
+---
+
 ##### `initContainers`<sup>Required</sup> <a name="cdk8s-plus-21.IPodSpec.property.initContainers"></a>
 
 ```typescript
@@ -6365,6 +6617,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-21.IPodTemplate.property.hostAliases"></a>
+
+```typescript
+public readonly hostAliases: HostAlias[];
+```
+
+- *Type:* [`cdk8s-plus-21.HostAlias`](#cdk8s-plus-21.HostAlias)[]
+
+An optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+
+This is only valid for non-hostNetwork pods.
 
 ---
 

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -4,7 +4,7 @@ import { Resource, ResourceProps } from './base';
 import { Container, ContainerProps } from './container';
 import * as k8s from './imports/k8s';
 import { IngressV1Beta1 } from './ingress-v1beta1';
-import { RestartPolicy, PodTemplate, IPodTemplate, PodTemplateProps, PodSecurityContext } from './pod';
+import { RestartPolicy, PodTemplate, IPodTemplate, PodTemplateProps, PodSecurityContext, HostAlias } from './pod';
 import { ExposeServiceViaIngressOptions, Protocol, Service, ServiceType } from './service';
 import { IServiceAccount } from './service-account';
 import { Volume } from './volume';
@@ -164,6 +164,10 @@ export class Deployment extends Resource implements IPodTemplate {
     return this._podTemplate.initContainers;
   }
 
+  public get hostAliases(): HostAlias[] {
+    return this._podTemplate.hostAliases;
+  }
+
   public get volumes(): Volume[] {
     return this._podTemplate.volumes;
   }
@@ -226,6 +230,10 @@ export class Deployment extends Resource implements IPodTemplate {
 
   public addInitContainer(container: ContainerProps): Container {
     return this._podTemplate.addInitContainer(container);
+  }
+
+  public addHostAlias(hostAlias: HostAlias): void {
+    return this._podTemplate.addHostAlias(hostAlias);
   }
 
   public addVolume(volume: Volume): void {

--- a/src/job.ts
+++ b/src/job.ts
@@ -3,7 +3,7 @@ import { Construct } from 'constructs';
 import { Resource, ResourceProps } from './base';
 import { Container, ContainerProps } from './container';
 import * as k8s from './imports/k8s';
-import { RestartPolicy, PodTemplateProps, IPodTemplate, PodTemplate, PodSecurityContext } from './pod';
+import { RestartPolicy, PodTemplateProps, IPodTemplate, PodTemplate, PodSecurityContext, HostAlias } from './pod';
 import { IServiceAccount } from './service-account';
 import { Volume } from './volume';
 
@@ -104,6 +104,10 @@ export class Job extends Resource implements IPodTemplate {
     return this._podTemplate.initContainers;
   }
 
+  public get hostAliases(): HostAlias[] {
+    return this._podTemplate.hostAliases;
+  }
+
   public get volumes(): Volume[] {
     return this._podTemplate.volumes;
   }
@@ -126,6 +130,10 @@ export class Job extends Resource implements IPodTemplate {
 
   public addInitContainer(container: ContainerProps): Container {
     return this._podTemplate.addInitContainer(container);
+  }
+
+  public addHostAlias(hostAlias: HostAlias): void {
+    return this._podTemplate.addHostAlias(hostAlias);
   }
 
   public addVolume(volume: Volume): void {

--- a/src/statefulset.ts
+++ b/src/statefulset.ts
@@ -3,7 +3,7 @@ import { Construct } from 'constructs';
 import { Resource, ResourceProps } from './base';
 import { Container, ContainerProps } from './container';
 import * as k8s from './imports/k8s';
-import { RestartPolicy, PodTemplate, IPodTemplate, PodTemplateProps, PodSecurityContext } from './pod';
+import { RestartPolicy, PodTemplate, IPodTemplate, PodTemplateProps, PodSecurityContext, HostAlias } from './pod';
 import { Service } from './service';
 import { IServiceAccount } from './service-account';
 import { Volume } from './volume';
@@ -156,6 +156,10 @@ export class StatefulSet extends Resource implements IPodTemplate {
     return this._podTemplate.initContainers;
   }
 
+  public get hostAliases(): HostAlias[] {
+    return this._podTemplate.hostAliases;
+  }
+
   public get volumes(): Volume[] {
     return this._podTemplate.volumes;
   }
@@ -185,6 +189,10 @@ export class StatefulSet extends Resource implements IPodTemplate {
 
   public addInitContainer(container: ContainerProps): Container {
     return this._podTemplate.addInitContainer(container);
+  }
+
+  public addHostAlias(hostAlias: HostAlias): void {
+    return this._podTemplate.addHostAlias(hostAlias);
   }
 
   public addVolume(volume: Volume): void {

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -41,6 +41,7 @@ Array [
               "volumeMounts": Array [],
             },
           ],
+          "hostAliases": Array [],
           "initContainers": Array [],
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",

--- a/test/pod.test.ts
+++ b/test/pod.test.ts
@@ -342,3 +342,22 @@ test('custom security context', () => {
   expect(pod.securityContext.group).toEqual(2000);
 
 });
+
+test('custom host aliases', () => {
+
+  const chart = Testing.chart();
+
+  const pod = new kplus.Pod(chart, 'Pod', {
+    containers: [{ image: 'image' }],
+    hostAliases: [{ ip: '127.0.0.1', hostnames: ['foo.local', 'bar.local'] }],
+  });
+  pod.addHostAlias({ ip: '10.1.2.3', hostnames: ['foo.remote', 'bar.remote'] });
+
+  const spec = Testing.synth(chart)[0].spec;
+
+  expect(spec.hostAliases).toEqual([
+    { ip: '127.0.0.1', hostnames: ['foo.local', 'bar.local'] },
+    { ip: '10.1.2.3', hostnames: ['foo.remote', 'bar.remote'] },
+  ]);
+
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [feat: pod host aliases (#469)](https://github.com/cdk8s-team/cdk8s-plus/pull/469)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)