### PR TITLE
chore: add OWNERS.md (#436)

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,5 @@
+# Maintainers
+
+* Eli Polonsky [@iliapolo](https://github.com/iliapolo)
+* Chris Rybicki [@Chriscbr](https://github.com/Chriscbr)
+* Nathan Taber [@tabern](https://github.com/tabern)


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [chore: add OWNERS.md (#436)](https://github.com/cdk8s-team/cdk8s-plus/pull/436)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)