### PR TITLE
feat: init containers (#451)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -247,6 +247,7 @@ import org.cdk8s.plus20.Deployment;
 Deployment.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -287,6 +288,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.parameter.initContainers"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -367,6 +389,18 @@ Number of desired pods.
 
 ```java
 public addContainer(ContainerProps container)
+```
+
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.parameter.container"></a>
+
+- *Type:* [`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)
+
+---
+
+##### `addInitContainer` <a name="org.cdk8s.plus20.Deployment.addInitContainer"></a>
+
+```java
+public addInitContainer(ContainerProps container)
 ```
 
 ###### `container`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.parameter.container"></a>
@@ -461,6 +495,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.property.initContainers"></a>
+
+```java
+public java.util.List<Container> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.Container`](#org.cdk8s.plus20.Container)>
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -761,6 +809,7 @@ import org.cdk8s.plus20.Job;
 Job.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -802,6 +851,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.parameter.initContainers"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -903,6 +973,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addInitContainer` <a name="org.cdk8s.plus20.Job.addInitContainer"></a>
+
+```java
+public addInitContainer(ContainerProps container)
+```
+
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus20.Job.parameter.container"></a>
+
+- *Type:* [`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="org.cdk8s.plus20.Job.addVolume"></a>
 
 ```java
@@ -929,6 +1011,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="org.cdk8s.plus20.Job.property.initContainers"></a>
+
+```java
+public java.util.List<Container> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.Container`](#org.cdk8s.plus20.Container)>
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -1038,6 +1134,7 @@ import org.cdk8s.plus20.Pod;
 Pod.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -1075,6 +1172,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.parameter.initContainers"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -1134,6 +1252,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addInitContainer` <a name="org.cdk8s.plus20.Pod.addInitContainer"></a>
+
+```java
+public addInitContainer(ContainerProps container)
+```
+
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus20.Pod.parameter.container"></a>
+
+- *Type:* [`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="org.cdk8s.plus20.Pod.addVolume"></a>
 
 ```java
@@ -1160,6 +1290,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="org.cdk8s.plus20.Pod.property.initContainers"></a>
+
+```java
+public java.util.List<Container> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.Container`](#org.cdk8s.plus20.Container)>
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -1829,6 +1973,7 @@ import org.cdk8s.plus20.StatefulSet;
 StatefulSet.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -1871,6 +2016,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.parameter.initContainers"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -1976,6 +2142,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addInitContainer` <a name="org.cdk8s.plus20.StatefulSet.addInitContainer"></a>
+
+```java
+public addInitContainer(ContainerProps container)
+```
+
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus20.StatefulSet.parameter.container"></a>
+
+- *Type:* [`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="org.cdk8s.plus20.StatefulSet.addVolume"></a>
 
 ```java
@@ -2024,6 +2202,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="org.cdk8s.plus20.StatefulSet.property.initContainers"></a>
+
+```java
+public java.util.List<Container> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.Container`](#org.cdk8s.plus20.Container)>
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -2768,6 +2960,7 @@ import org.cdk8s.plus20.DeploymentProps;
 DeploymentProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -2804,6 +2997,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.property.initContainers"></a>
+
+```java
+public java.util.List<ContainerProps> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -3648,6 +3866,7 @@ import org.cdk8s.plus20.JobProps;
 JobProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -3685,6 +3904,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.property.initContainers"></a>
+
+```java
+public java.util.List<ContainerProps> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -3976,6 +4220,7 @@ import org.cdk8s.plus20.PodProps;
 PodProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -4009,6 +4254,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.property.initContainers"></a>
+
+```java
+public java.util.List<ContainerProps> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -4077,6 +4347,7 @@ import org.cdk8s.plus20.PodSpecProps;
 
 PodSpecProps.builder()
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -4098,6 +4369,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.property.initContainers"></a>
+
+```java
+public java.util.List<ContainerProps> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -4168,6 +4464,7 @@ import org.cdk8s.plus20.PodTemplateProps;
 
 PodTemplateProps.builder()
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -4190,6 +4487,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.property.initContainers"></a>
+
+```java
+public java.util.List<ContainerProps> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -4985,6 +5307,7 @@ import org.cdk8s.plus20.StatefulSetProps;
 StatefulSetProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -5023,6 +5346,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.property.initContainers"></a>
+
+```java
+public java.util.List<ContainerProps> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -6008,6 +6356,7 @@ import org.cdk8s.plus20.PodSpec;
 
 PodSpec.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -6025,6 +6374,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.parameter.initContainers"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -6084,6 +6454,18 @@ public addContainer(ContainerProps container)
 
 ---
 
+##### `addInitContainer` <a name="org.cdk8s.plus20.PodSpec.addInitContainer"></a>
+
+```java
+public addInitContainer(ContainerProps container)
+```
+
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus20.PodSpec.parameter.container"></a>
+
+- *Type:* [`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="org.cdk8s.plus20.PodSpec.addVolume"></a>
 
 ```java
@@ -6110,6 +6492,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="org.cdk8s.plus20.PodSpec.property.initContainers"></a>
+
+```java
+public java.util.List<Container> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.Container`](#org.cdk8s.plus20.Container)>
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -6165,6 +6561,7 @@ import org.cdk8s.plus20.PodTemplate;
 
 PodTemplate.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
+//  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
 //  .serviceAccount(IServiceAccount)
 //  .volumes(java.util.List<Volume>)
@@ -6183,6 +6580,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.parameter.initContainers"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)>
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -6528,6 +6946,20 @@ The container.
 
 ---
 
+##### `addInitContainer` <a name="org.cdk8s.plus20.IPodSpec.addInitContainer"></a>
+
+```java
+public addInitContainer(ContainerProps container)
+```
+
+###### `container`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodSpec.parameter.container"></a>
+
+- *Type:* [`org.cdk8s.plus20.ContainerProps`](#org.cdk8s.plus20.ContainerProps)
+
+The container.
+
+---
+
 ##### `addVolume` <a name="org.cdk8s.plus20.IPodSpec.addVolume"></a>
 
 ```java
@@ -6555,6 +6987,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodSpec.property.initContainers"></a>
+
+```java
+public java.util.List<Container> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.Container`](#org.cdk8s.plus20.Container)>
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -6620,6 +7066,20 @@ public java.util.List<Container> getContainers();
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodTemplate.property.initContainers"></a>
+
+```java
+public java.util.List<Container> getInitContainers();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.Container`](#org.cdk8s.plus20.Container)>
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -274,6 +274,7 @@ cdk8s_plus_20.Deployment(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None,
@@ -314,6 +315,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.parameter.init_containers"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -394,6 +416,171 @@ Number of desired pods.
 
 ```python
 def add_container(
+  image: str,
+  args: typing.List[str] = None,
+  command: typing.List[str] = None,
+  env: typing.Mapping[EnvValue] = None,
+  image_pull_policy: ImagePullPolicy = None,
+  liveness: Probe = None,
+  name: str = None,
+  port: typing.Union[int, float] = None,
+  readiness: Probe = None,
+  resources: Resources = None,
+  startup: Probe = None,
+  volume_mounts: typing.List[VolumeMount] = None,
+  working_dir: str = None
+)
+```
+
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image"></a>
+
+- *Type:* `str`
+
+Docker image name.
+
+---
+
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.args"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* []
+
+Arguments to the entrypoint. The docker image's CMD is used if `command` is not provided.
+
+Variable references $(VAR_NAME) are expanded using the container's
+environment. If a variable cannot be resolved, the reference in the input
+string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+regardless of whether the variable exists or not.
+
+Cannot be updated.
+
+> https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.command"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* The docker image's ENTRYPOINT.
+
+Entrypoint array.
+
+Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment.
+If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.env"></a>
+
+- *Type:* typing.Mapping[[`cdk8s_plus_20.EnvValue`](#cdk8s_plus_20.EnvValue)]
+- *Default:* No environment variables.
+
+List of environment variables to set in the container.
+
+Cannot be updated.
+
+---
+
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image_pull_policy"></a>
+
+- *Type:* [`cdk8s_plus_20.ImagePullPolicy`](#cdk8s_plus_20.ImagePullPolicy)
+- *Default:* ImagePullPolicy.ALWAYS
+
+Image pull policy for this container.
+
+---
+
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.liveness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no liveness probe is defined
+
+Periodic probe of container liveness.
+
+Container will be restarted if the probe fails.
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* 'main'
+
+Name of the container specified as a DNS_LABEL.
+
+Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No port is exposed.
+
+Number of port to expose on the pod's IP address.
+
+This must be a valid port number, 0 < x < 65536.
+
+---
+
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.readiness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no readiness probe is defined
+
+Determines when the container is ready to serve traffic.
+
+---
+
+###### `resources`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.resources"></a>
+
+- *Type:* [`cdk8s_plus_20.Resources`](#cdk8s_plus_20.Resources)
+
+Compute resources (CPU and memory requests and limits) required by the container.
+
+> https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+---
+
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.startup"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no startup probe is defined.
+
+StartupProbe indicates that the Pod has successfully initialized.
+
+If specified, no other probes are executed until this completes successfully
+
+---
+
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.volume_mounts"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.VolumeMount`](#cdk8s_plus_20.VolumeMount)]
+
+Pod volumes to mount into the container's filesystem.
+
+Cannot be updated.
+
+---
+
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.working_dir"></a>
+
+- *Type:* `str`
+- *Default:* The container runtime's default.
+
+Container's working directory.
+
+If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+---
+
+##### `add_init_container` <a name="cdk8s_plus_20.Deployment.add_init_container"></a>
+
+```python
+def add_init_container(
   image: str,
   args: typing.List[str] = None,
   command: typing.List[str] = None,
@@ -752,6 +939,20 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_20.Deployment.property.init_containers"></a>
+
+```python
+init_containers: typing.List[Container]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.Container`](#cdk8s_plus_20.Container)]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
+
+---
+
 ##### `label_selector`<sup>Required</sup> <a name="cdk8s_plus_20.Deployment.property.label_selector"></a>
 
 ```python
@@ -1099,6 +1300,7 @@ cdk8s_plus_20.Job(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None,
@@ -1140,6 +1342,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.parameter.init_containers"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -1394,6 +1617,171 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_init_container` <a name="cdk8s_plus_20.Job.add_init_container"></a>
+
+```python
+def add_init_container(
+  image: str,
+  args: typing.List[str] = None,
+  command: typing.List[str] = None,
+  env: typing.Mapping[EnvValue] = None,
+  image_pull_policy: ImagePullPolicy = None,
+  liveness: Probe = None,
+  name: str = None,
+  port: typing.Union[int, float] = None,
+  readiness: Probe = None,
+  resources: Resources = None,
+  startup: Probe = None,
+  volume_mounts: typing.List[VolumeMount] = None,
+  working_dir: str = None
+)
+```
+
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image"></a>
+
+- *Type:* `str`
+
+Docker image name.
+
+---
+
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.args"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* []
+
+Arguments to the entrypoint. The docker image's CMD is used if `command` is not provided.
+
+Variable references $(VAR_NAME) are expanded using the container's
+environment. If a variable cannot be resolved, the reference in the input
+string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+regardless of whether the variable exists or not.
+
+Cannot be updated.
+
+> https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.command"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* The docker image's ENTRYPOINT.
+
+Entrypoint array.
+
+Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment.
+If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.env"></a>
+
+- *Type:* typing.Mapping[[`cdk8s_plus_20.EnvValue`](#cdk8s_plus_20.EnvValue)]
+- *Default:* No environment variables.
+
+List of environment variables to set in the container.
+
+Cannot be updated.
+
+---
+
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image_pull_policy"></a>
+
+- *Type:* [`cdk8s_plus_20.ImagePullPolicy`](#cdk8s_plus_20.ImagePullPolicy)
+- *Default:* ImagePullPolicy.ALWAYS
+
+Image pull policy for this container.
+
+---
+
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.liveness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no liveness probe is defined
+
+Periodic probe of container liveness.
+
+Container will be restarted if the probe fails.
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* 'main'
+
+Name of the container specified as a DNS_LABEL.
+
+Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No port is exposed.
+
+Number of port to expose on the pod's IP address.
+
+This must be a valid port number, 0 < x < 65536.
+
+---
+
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.readiness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no readiness probe is defined
+
+Determines when the container is ready to serve traffic.
+
+---
+
+###### `resources`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.resources"></a>
+
+- *Type:* [`cdk8s_plus_20.Resources`](#cdk8s_plus_20.Resources)
+
+Compute resources (CPU and memory requests and limits) required by the container.
+
+> https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+---
+
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.startup"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no startup probe is defined.
+
+StartupProbe indicates that the Pod has successfully initialized.
+
+If specified, no other probes are executed until this completes successfully
+
+---
+
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.volume_mounts"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.VolumeMount`](#cdk8s_plus_20.VolumeMount)]
+
+Pod volumes to mount into the container's filesystem.
+
+Cannot be updated.
+
+---
+
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.working_dir"></a>
+
+- *Type:* `str`
+- *Default:* The container runtime's default.
+
+Container's working directory.
+
+If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+---
+
 ##### `add_volume` <a name="cdk8s_plus_20.Job.add_volume"></a>
 
 ```python
@@ -1422,6 +1810,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_20.Job.property.init_containers"></a>
+
+```python
+init_containers: typing.List[Container]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.Container`](#cdk8s_plus_20.Container)]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -1533,6 +1935,7 @@ cdk8s_plus_20.Pod(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None
@@ -1570,6 +1973,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.parameter.init_containers"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -1782,6 +2206,171 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_init_container` <a name="cdk8s_plus_20.Pod.add_init_container"></a>
+
+```python
+def add_init_container(
+  image: str,
+  args: typing.List[str] = None,
+  command: typing.List[str] = None,
+  env: typing.Mapping[EnvValue] = None,
+  image_pull_policy: ImagePullPolicy = None,
+  liveness: Probe = None,
+  name: str = None,
+  port: typing.Union[int, float] = None,
+  readiness: Probe = None,
+  resources: Resources = None,
+  startup: Probe = None,
+  volume_mounts: typing.List[VolumeMount] = None,
+  working_dir: str = None
+)
+```
+
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image"></a>
+
+- *Type:* `str`
+
+Docker image name.
+
+---
+
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.args"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* []
+
+Arguments to the entrypoint. The docker image's CMD is used if `command` is not provided.
+
+Variable references $(VAR_NAME) are expanded using the container's
+environment. If a variable cannot be resolved, the reference in the input
+string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+regardless of whether the variable exists or not.
+
+Cannot be updated.
+
+> https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.command"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* The docker image's ENTRYPOINT.
+
+Entrypoint array.
+
+Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment.
+If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.env"></a>
+
+- *Type:* typing.Mapping[[`cdk8s_plus_20.EnvValue`](#cdk8s_plus_20.EnvValue)]
+- *Default:* No environment variables.
+
+List of environment variables to set in the container.
+
+Cannot be updated.
+
+---
+
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image_pull_policy"></a>
+
+- *Type:* [`cdk8s_plus_20.ImagePullPolicy`](#cdk8s_plus_20.ImagePullPolicy)
+- *Default:* ImagePullPolicy.ALWAYS
+
+Image pull policy for this container.
+
+---
+
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.liveness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no liveness probe is defined
+
+Periodic probe of container liveness.
+
+Container will be restarted if the probe fails.
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* 'main'
+
+Name of the container specified as a DNS_LABEL.
+
+Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No port is exposed.
+
+Number of port to expose on the pod's IP address.
+
+This must be a valid port number, 0 < x < 65536.
+
+---
+
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.readiness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no readiness probe is defined
+
+Determines when the container is ready to serve traffic.
+
+---
+
+###### `resources`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.resources"></a>
+
+- *Type:* [`cdk8s_plus_20.Resources`](#cdk8s_plus_20.Resources)
+
+Compute resources (CPU and memory requests and limits) required by the container.
+
+> https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+---
+
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.startup"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no startup probe is defined.
+
+StartupProbe indicates that the Pod has successfully initialized.
+
+If specified, no other probes are executed until this completes successfully
+
+---
+
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.volume_mounts"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.VolumeMount`](#cdk8s_plus_20.VolumeMount)]
+
+Pod volumes to mount into the container's filesystem.
+
+Cannot be updated.
+
+---
+
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.working_dir"></a>
+
+- *Type:* `str`
+- *Default:* The container runtime's default.
+
+Container's working directory.
+
+If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+---
+
 ##### `add_volume` <a name="cdk8s_plus_20.Pod.add_volume"></a>
 
 ```python
@@ -1810,6 +2399,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_20.Pod.property.init_containers"></a>
+
+```python
+init_containers: typing.List[Container]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.Container`](#cdk8s_plus_20.Container)]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -2610,6 +3213,7 @@ cdk8s_plus_20.StatefulSet(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None,
@@ -2652,6 +3256,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.parameter.init_containers"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -2910,6 +3535,171 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_init_container` <a name="cdk8s_plus_20.StatefulSet.add_init_container"></a>
+
+```python
+def add_init_container(
+  image: str,
+  args: typing.List[str] = None,
+  command: typing.List[str] = None,
+  env: typing.Mapping[EnvValue] = None,
+  image_pull_policy: ImagePullPolicy = None,
+  liveness: Probe = None,
+  name: str = None,
+  port: typing.Union[int, float] = None,
+  readiness: Probe = None,
+  resources: Resources = None,
+  startup: Probe = None,
+  volume_mounts: typing.List[VolumeMount] = None,
+  working_dir: str = None
+)
+```
+
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image"></a>
+
+- *Type:* `str`
+
+Docker image name.
+
+---
+
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.args"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* []
+
+Arguments to the entrypoint. The docker image's CMD is used if `command` is not provided.
+
+Variable references $(VAR_NAME) are expanded using the container's
+environment. If a variable cannot be resolved, the reference in the input
+string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+regardless of whether the variable exists or not.
+
+Cannot be updated.
+
+> https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.command"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* The docker image's ENTRYPOINT.
+
+Entrypoint array.
+
+Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment.
+If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.env"></a>
+
+- *Type:* typing.Mapping[[`cdk8s_plus_20.EnvValue`](#cdk8s_plus_20.EnvValue)]
+- *Default:* No environment variables.
+
+List of environment variables to set in the container.
+
+Cannot be updated.
+
+---
+
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image_pull_policy"></a>
+
+- *Type:* [`cdk8s_plus_20.ImagePullPolicy`](#cdk8s_plus_20.ImagePullPolicy)
+- *Default:* ImagePullPolicy.ALWAYS
+
+Image pull policy for this container.
+
+---
+
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.liveness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no liveness probe is defined
+
+Periodic probe of container liveness.
+
+Container will be restarted if the probe fails.
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* 'main'
+
+Name of the container specified as a DNS_LABEL.
+
+Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No port is exposed.
+
+Number of port to expose on the pod's IP address.
+
+This must be a valid port number, 0 < x < 65536.
+
+---
+
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.readiness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no readiness probe is defined
+
+Determines when the container is ready to serve traffic.
+
+---
+
+###### `resources`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.resources"></a>
+
+- *Type:* [`cdk8s_plus_20.Resources`](#cdk8s_plus_20.Resources)
+
+Compute resources (CPU and memory requests and limits) required by the container.
+
+> https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+---
+
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.startup"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no startup probe is defined.
+
+StartupProbe indicates that the Pod has successfully initialized.
+
+If specified, no other probes are executed until this completes successfully
+
+---
+
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.volume_mounts"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.VolumeMount`](#cdk8s_plus_20.VolumeMount)]
+
+Pod volumes to mount into the container's filesystem.
+
+Cannot be updated.
+
+---
+
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.working_dir"></a>
+
+- *Type:* `str`
+- *Default:* The container runtime's default.
+
+Container's working directory.
+
+If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+---
+
 ##### `add_volume` <a name="cdk8s_plus_20.StatefulSet.add_volume"></a>
 
 ```python
@@ -2963,6 +3753,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_20.StatefulSet.property.init_containers"></a>
+
+```python
+init_containers: typing.List[Container]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.Container`](#cdk8s_plus_20.Container)]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -3707,6 +4511,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.DeploymentProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None,
@@ -3743,6 +4548,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.property.init_containers"></a>
+
+```python
+init_containers: typing.List[ContainerProps]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -4587,6 +5417,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.JobProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None,
@@ -4624,6 +5455,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.property.init_containers"></a>
+
+```python
+init_containers: typing.List[ContainerProps]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -4915,6 +5771,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.PodProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None
@@ -4948,6 +5805,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.property.init_containers"></a>
+
+```python
+init_containers: typing.List[ContainerProps]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -5016,6 +5898,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodSpecProps(
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None
@@ -5037,6 +5920,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.property.init_containers"></a>
+
+```python
+init_containers: typing.List[ContainerProps]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -5107,6 +6015,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodTemplateProps(
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None,
@@ -5129,6 +6038,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.property.init_containers"></a>
+
+```python
+init_containers: typing.List[ContainerProps]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -5924,6 +6858,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.StatefulSetProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None,
@@ -5962,6 +6897,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.property.init_containers"></a>
+
+```python
+init_containers: typing.List[ContainerProps]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -7058,6 +8018,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodSpec(
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None
@@ -7075,6 +8036,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.parameter.init_containers"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -7287,6 +8269,171 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_init_container` <a name="cdk8s_plus_20.PodSpec.add_init_container"></a>
+
+```python
+def add_init_container(
+  image: str,
+  args: typing.List[str] = None,
+  command: typing.List[str] = None,
+  env: typing.Mapping[EnvValue] = None,
+  image_pull_policy: ImagePullPolicy = None,
+  liveness: Probe = None,
+  name: str = None,
+  port: typing.Union[int, float] = None,
+  readiness: Probe = None,
+  resources: Resources = None,
+  startup: Probe = None,
+  volume_mounts: typing.List[VolumeMount] = None,
+  working_dir: str = None
+)
+```
+
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image"></a>
+
+- *Type:* `str`
+
+Docker image name.
+
+---
+
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.args"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* []
+
+Arguments to the entrypoint. The docker image's CMD is used if `command` is not provided.
+
+Variable references $(VAR_NAME) are expanded using the container's
+environment. If a variable cannot be resolved, the reference in the input
+string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+regardless of whether the variable exists or not.
+
+Cannot be updated.
+
+> https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.command"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* The docker image's ENTRYPOINT.
+
+Entrypoint array.
+
+Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment.
+If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.env"></a>
+
+- *Type:* typing.Mapping[[`cdk8s_plus_20.EnvValue`](#cdk8s_plus_20.EnvValue)]
+- *Default:* No environment variables.
+
+List of environment variables to set in the container.
+
+Cannot be updated.
+
+---
+
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image_pull_policy"></a>
+
+- *Type:* [`cdk8s_plus_20.ImagePullPolicy`](#cdk8s_plus_20.ImagePullPolicy)
+- *Default:* ImagePullPolicy.ALWAYS
+
+Image pull policy for this container.
+
+---
+
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.liveness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no liveness probe is defined
+
+Periodic probe of container liveness.
+
+Container will be restarted if the probe fails.
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* 'main'
+
+Name of the container specified as a DNS_LABEL.
+
+Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No port is exposed.
+
+Number of port to expose on the pod's IP address.
+
+This must be a valid port number, 0 < x < 65536.
+
+---
+
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.readiness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no readiness probe is defined
+
+Determines when the container is ready to serve traffic.
+
+---
+
+###### `resources`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.resources"></a>
+
+- *Type:* [`cdk8s_plus_20.Resources`](#cdk8s_plus_20.Resources)
+
+Compute resources (CPU and memory requests and limits) required by the container.
+
+> https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+---
+
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.startup"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no startup probe is defined.
+
+StartupProbe indicates that the Pod has successfully initialized.
+
+If specified, no other probes are executed until this completes successfully
+
+---
+
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.volume_mounts"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.VolumeMount`](#cdk8s_plus_20.VolumeMount)]
+
+Pod volumes to mount into the container's filesystem.
+
+Cannot be updated.
+
+---
+
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.working_dir"></a>
+
+- *Type:* `str`
+- *Default:* The container runtime's default.
+
+Container's working directory.
+
+If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+---
+
 ##### `add_volume` <a name="cdk8s_plus_20.PodSpec.add_volume"></a>
 
 ```python
@@ -7315,6 +8462,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_20.PodSpec.property.init_containers"></a>
+
+```python
+init_containers: typing.List[Container]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.Container`](#cdk8s_plus_20.Container)]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -7370,6 +8531,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodTemplate(
   containers: typing.List[ContainerProps] = None,
+  init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
   service_account: IServiceAccount = None,
   volumes: typing.List[Volume] = None,
@@ -7388,6 +8550,27 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `init_containers`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.parameter.init_containers"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.ContainerProps`](#cdk8s_plus_20.ContainerProps)]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -8197,6 +9380,171 @@ If not specified, the container runtime's default will be used, which might be c
 
 ---
 
+##### `add_init_container` <a name="cdk8s_plus_20.IPodSpec.add_init_container"></a>
+
+```python
+def add_init_container(
+  image: str,
+  args: typing.List[str] = None,
+  command: typing.List[str] = None,
+  env: typing.Mapping[EnvValue] = None,
+  image_pull_policy: ImagePullPolicy = None,
+  liveness: Probe = None,
+  name: str = None,
+  port: typing.Union[int, float] = None,
+  readiness: Probe = None,
+  resources: Resources = None,
+  startup: Probe = None,
+  volume_mounts: typing.List[VolumeMount] = None,
+  working_dir: str = None
+)
+```
+
+###### `image`<sup>Required</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image"></a>
+
+- *Type:* `str`
+
+Docker image name.
+
+---
+
+###### `args`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.args"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* []
+
+Arguments to the entrypoint. The docker image's CMD is used if `command` is not provided.
+
+Variable references $(VAR_NAME) are expanded using the container's
+environment. If a variable cannot be resolved, the reference in the input
+string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+regardless of whether the variable exists or not.
+
+Cannot be updated.
+
+> https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `command`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.command"></a>
+
+- *Type:* typing.List[`str`]
+- *Default:* The docker image's ENTRYPOINT.
+
+Entrypoint array.
+
+Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment.
+If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated.
+More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+
+---
+
+###### `env`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.env"></a>
+
+- *Type:* typing.Mapping[[`cdk8s_plus_20.EnvValue`](#cdk8s_plus_20.EnvValue)]
+- *Default:* No environment variables.
+
+List of environment variables to set in the container.
+
+Cannot be updated.
+
+---
+
+###### `image_pull_policy`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.image_pull_policy"></a>
+
+- *Type:* [`cdk8s_plus_20.ImagePullPolicy`](#cdk8s_plus_20.ImagePullPolicy)
+- *Default:* ImagePullPolicy.ALWAYS
+
+Image pull policy for this container.
+
+---
+
+###### `liveness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.liveness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no liveness probe is defined
+
+Periodic probe of container liveness.
+
+Container will be restarted if the probe fails.
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* 'main'
+
+Name of the container specified as a DNS_LABEL.
+
+Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No port is exposed.
+
+Number of port to expose on the pod's IP address.
+
+This must be a valid port number, 0 < x < 65536.
+
+---
+
+###### `readiness`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.readiness"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no readiness probe is defined
+
+Determines when the container is ready to serve traffic.
+
+---
+
+###### `resources`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.resources"></a>
+
+- *Type:* [`cdk8s_plus_20.Resources`](#cdk8s_plus_20.Resources)
+
+Compute resources (CPU and memory requests and limits) required by the container.
+
+> https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+---
+
+###### `startup`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.startup"></a>
+
+- *Type:* [`cdk8s_plus_20.Probe`](#cdk8s_plus_20.Probe)
+- *Default:* no startup probe is defined.
+
+StartupProbe indicates that the Pod has successfully initialized.
+
+If specified, no other probes are executed until this completes successfully
+
+---
+
+###### `volume_mounts`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.volume_mounts"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.VolumeMount`](#cdk8s_plus_20.VolumeMount)]
+
+Pod volumes to mount into the container's filesystem.
+
+Cannot be updated.
+
+---
+
+###### `working_dir`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.working_dir"></a>
+
+- *Type:* `str`
+- *Default:* The container runtime's default.
+
+Container's working directory.
+
+If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+
+---
+
 ##### `add_volume` <a name="cdk8s_plus_20.IPodSpec.add_volume"></a>
 
 ```python
@@ -8226,6 +9574,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_20.IPodSpec.property.init_containers"></a>
+
+```python
+init_containers: typing.List[Container]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.Container`](#cdk8s_plus_20.Container)]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -8291,6 +9653,20 @@ containers: typing.List[Container]
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `init_containers`<sup>Required</sup> <a name="cdk8s_plus_20.IPodTemplate.property.init_containers"></a>
+
+```python
+init_containers: typing.List[Container]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.Container`](#cdk8s_plus_20.Container)]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -242,6 +242,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addInitContainer` <a name="cdk8s-plus-20.Deployment.addInitContainer"></a>
+
+```typescript
+public addInitContainer(container: ContainerProps)
+```
+
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.parameter.container"></a>
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="cdk8s-plus-20.Deployment.addVolume"></a>
 
 ```typescript
@@ -326,6 +338,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: Container[];
+```
+
+- *Type:* [`cdk8s-plus-20.Container`](#cdk8s-plus-20.Container)[]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -611,6 +637,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addInitContainer` <a name="cdk8s-plus-20.Job.addInitContainer"></a>
+
+```typescript
+public addInitContainer(container: ContainerProps)
+```
+
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-20.Job.parameter.container"></a>
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="cdk8s-plus-20.Job.addVolume"></a>
 
 ```typescript
@@ -637,6 +675,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="cdk8s-plus-20.Job.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: Container[];
+```
+
+- *Type:* [`cdk8s-plus-20.Container`](#cdk8s-plus-20.Container)[]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -778,6 +830,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addInitContainer` <a name="cdk8s-plus-20.Pod.addInitContainer"></a>
+
+```typescript
+public addInitContainer(container: ContainerProps)
+```
+
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-20.Pod.parameter.container"></a>
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="cdk8s-plus-20.Pod.addVolume"></a>
 
 ```typescript
@@ -804,6 +868,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="cdk8s-plus-20.Pod.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: Container[];
+```
+
+- *Type:* [`cdk8s-plus-20.Container`](#cdk8s-plus-20.Container)[]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -1371,6 +1449,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addInitContainer` <a name="cdk8s-plus-20.StatefulSet.addInitContainer"></a>
+
+```typescript
+public addInitContainer(container: ContainerProps)
+```
+
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-20.StatefulSet.parameter.container"></a>
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="cdk8s-plus-20.StatefulSet.addVolume"></a>
 
 ```typescript
@@ -1419,6 +1509,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="cdk8s-plus-20.StatefulSet.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: Container[];
+```
+
+- *Type:* [`cdk8s-plus-20.Container`](#cdk8s-plus-20.Container)[]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -2149,6 +2253,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentProps.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: ContainerProps[];
+```
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)[]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -2974,6 +3103,31 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-20.JobProps.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: ContainerProps[];
+```
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)[]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+
+---
+
 ##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-20.JobProps.property.restartPolicy"></a>
 
 ```typescript
@@ -3281,6 +3435,31 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-20.PodProps.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: ContainerProps[];
+```
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)[]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+
+---
+
 ##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-20.PodProps.property.restartPolicy"></a>
 
 ```typescript
@@ -3362,6 +3541,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpecProps.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: ContainerProps[];
+```
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)[]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -3448,6 +3652,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-20.PodTemplateProps.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: ContainerProps[];
+```
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)[]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -4223,6 +4452,31 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `initContainers`<sup>Optional</sup> <a name="cdk8s-plus-20.StatefulSetProps.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: ContainerProps[];
+```
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)[]
+- *Default:* No init containers.
+
+List of initialization containers belonging to the pod.
+
+Init containers are executed in order prior to containers being started.
+If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+The name for an init container or normal container must be unique among all containers.
+Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+for each resource type, and then using the max of of that value or the sum of the normal containers.
+Limits are applied to init containers in a similar fashion.
+
+Init containers cannot currently be added ,removed or updated.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 
 ---
 
@@ -5054,6 +5308,18 @@ public addContainer(container: ContainerProps)
 
 ---
 
+##### `addInitContainer` <a name="cdk8s-plus-20.PodSpec.addInitContainer"></a>
+
+```typescript
+public addInitContainer(container: ContainerProps)
+```
+
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-20.PodSpec.parameter.container"></a>
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)
+
+---
+
 ##### `addVolume` <a name="cdk8s-plus-20.PodSpec.addVolume"></a>
 
 ```typescript
@@ -5080,6 +5346,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="cdk8s-plus-20.PodSpec.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: Container[];
+```
+
+- *Type:* [`cdk8s-plus-20.Container`](#cdk8s-plus-20.Container)[]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -5428,6 +5708,20 @@ The container.
 
 ---
 
+##### `addInitContainer` <a name="cdk8s-plus-20.IPodSpec.addInitContainer"></a>
+
+```typescript
+public addInitContainer(container: ContainerProps)
+```
+
+###### `container`<sup>Required</sup> <a name="cdk8s-plus-20.IPodSpec.parameter.container"></a>
+
+- *Type:* [`cdk8s-plus-20.ContainerProps`](#cdk8s-plus-20.ContainerProps)
+
+The container.
+
+---
+
 ##### `addVolume` <a name="cdk8s-plus-20.IPodSpec.addVolume"></a>
 
 ```typescript
@@ -5455,6 +5749,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="cdk8s-plus-20.IPodSpec.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: Container[];
+```
+
+- *Type:* [`cdk8s-plus-20.Container`](#cdk8s-plus-20.Container)[]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 
@@ -5520,6 +5828,20 @@ public readonly containers: Container[];
 The containers belonging to the pod.
 
 Use `addContainer` to add containers.
+
+---
+
+##### `initContainers`<sup>Required</sup> <a name="cdk8s-plus-20.IPodTemplate.property.initContainers"></a>
+
+```typescript
+public readonly initContainers: Container[];
+```
+
+- *Type:* [`cdk8s-plus-20.Container`](#cdk8s-plus-20.Container)[]
+
+The init containers belonging to the pod.
+
+Use `addInitContainer` to add init containers.
 
 ---
 

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -160,6 +160,10 @@ export class Deployment extends Resource implements IPodTemplate {
     return this._podTemplate.containers;
   }
 
+  public get initContainers(): Container[] {
+    return this._podTemplate.initContainers;
+  }
+
   public get volumes(): Volume[] {
     return this._podTemplate.volumes;
   }
@@ -214,6 +218,10 @@ export class Deployment extends Resource implements IPodTemplate {
 
   public addContainer(container: ContainerProps): Container {
     return this._podTemplate.addContainer(container);
+  }
+
+  public addInitContainer(container: ContainerProps): Container {
+    return this._podTemplate.addInitContainer(container);
   }
 
   public addVolume(volume: Volume): void {

--- a/src/job.ts
+++ b/src/job.ts
@@ -100,6 +100,10 @@ export class Job extends Resource implements IPodTemplate {
     return this._podTemplate.containers;
   }
 
+  public get initContainers(): Container[] {
+    return this._podTemplate.initContainers;
+  }
+
   public get volumes(): Volume[] {
     return this._podTemplate.volumes;
   }
@@ -114,6 +118,10 @@ export class Job extends Resource implements IPodTemplate {
 
   public addContainer(container: ContainerProps): Container {
     return this._podTemplate.addContainer(container);
+  }
+
+  public addInitContainer(container: ContainerProps): Container {
+    return this._podTemplate.addInitContainer(container);
   }
 
   public addVolume(volume: Volume): void {

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -21,6 +21,13 @@ export interface IPodSpec {
   readonly containers: Container[];
 
   /**
+   * The init containers belonging to the pod.
+   *
+   * Use `addInitContainer` to add init containers.
+   */
+  readonly initContainers: Container[];
+
+  /**
    * The volumes associated with this pod.
    *
    * Use `addVolume` to add volumes.
@@ -43,6 +50,13 @@ export interface IPodSpec {
    * @param container The container.
    */
   addContainer(container: ContainerProps): Container;
+
+  /**
+   * Add an init container to the pod.
+   *
+   * @param container The container.
+   */
+  addInitContainer(container: ContainerProps): Container;
 
   /**
    * Add a volume to the pod.
@@ -75,6 +89,7 @@ export class PodSpec implements IPodSpec {
   public readonly serviceAccount?: IServiceAccount;
 
   private readonly _containers: Container[] = [];
+  private readonly _initContainers: Container[] = [];
   private readonly _volumes: Map<string, Volume> = new Map();
 
   constructor(props: PodSpecProps = {}) {
@@ -89,10 +104,18 @@ export class PodSpec implements IPodSpec {
       props.volumes.forEach(v => this.addVolume(v));
     }
 
+    if (props.initContainers) {
+      props.initContainers.forEach(c => this.addInitContainer(c));
+    }
+
   }
 
   public get containers(): Container[] {
     return [...this._containers];
+  }
+
+  public get initContainers(): Container[] {
+    return [...this._initContainers];
   }
 
   public get volumes(): Volume[] {
@@ -102,6 +125,30 @@ export class PodSpec implements IPodSpec {
   public addContainer(container: ContainerProps): Container {
     const impl = new Container(container);
     this._containers.push(impl);
+    return impl;
+  }
+
+  public addInitContainer(container: ContainerProps): Container {
+
+    // https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#differences-from-regular-containers
+    if (container.readiness) {
+      throw new Error('Init containers must not have a readiness probe');
+    }
+
+    if (container.liveness) {
+      throw new Error('Init containers must not have a liveness probe');
+    }
+
+    if (container.startup) {
+      throw new Error('Init containers must not have a startup probe');
+    }
+
+    const impl = new Container({
+      ...container,
+      name: container.name ?? `init-${this._initContainers.length}`,
+    });
+
+    this._initContainers.push(impl);
     return impl;
   }
 
@@ -124,6 +171,7 @@ export class PodSpec implements IPodSpec {
 
     const volumes: Map<string, Volume> = new Map();
     const containers: k8s.Container[] = [];
+    const initContainers: k8s.Container[] = [];
 
     for (const container of this.containers) {
       // automatically add volume from the container mount
@@ -132,6 +180,15 @@ export class PodSpec implements IPodSpec {
         addVolume(mount.volume);
       }
       containers.push(container._toKube());
+    }
+
+    for (const container of this.initContainers) {
+      // automatically add volume from the container mount
+      // to this pod so thats its available to the container.
+      for (const mount of container.mounts) {
+        addVolume(mount.volume);
+      }
+      initContainers.push(container._toKube());
     }
 
     for (const volume of this.volumes) {
@@ -152,6 +209,7 @@ export class PodSpec implements IPodSpec {
       restartPolicy: this.restartPolicy,
       serviceAccountName: this.serviceAccount?.name,
       containers: containers,
+      initContainers: initContainers,
       volumes: Array.from(volumes.values()).map(v => v._toKube()),
     };
 
@@ -215,6 +273,23 @@ export interface PodSpecProps {
    * @default - No containers. Note that a pod spec must include at least one container.
    */
   readonly containers?: ContainerProps[];
+
+  /**
+   * List of initialization containers belonging to the pod.
+   * Init containers are executed in order prior to containers being started.
+   * If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy.
+   * The name for an init container or normal container must be unique among all containers.
+   * Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+   * The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit
+   * for each resource type, and then using the max of of that value or the sum of the normal containers.
+   * Limits are applied to init containers in a similar fashion.
+   *
+   * Init containers cannot currently be added ,removed or updated.
+   *
+   * @see https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+   * @default - No init containers.
+   */
+  readonly initContainers?: ContainerProps[];
 
   /**
    * List of volumes that can be mounted by containers belonging to the pod.
@@ -282,6 +357,10 @@ export class Pod extends Resource implements IPodSpec {
     return this._spec.containers;
   }
 
+  public get initContainers(): Container[] {
+    return this._spec.initContainers;
+  }
+
   public get volumes(): Volume[] {
     return this._spec.volumes;
   }
@@ -296,6 +375,10 @@ export class Pod extends Resource implements IPodSpec {
 
   public addContainer(container: ContainerProps): Container {
     return this._spec.addContainer(container);
+  }
+
+  public addInitContainer(container: ContainerProps): Container {
+    return this._spec.addInitContainer(container);
   }
 
   public addVolume(volume: Volume): void {

--- a/src/statefulset.ts
+++ b/src/statefulset.ts
@@ -152,6 +152,10 @@ export class StatefulSet extends Resource implements IPodTemplate {
     return this._podTemplate.containers;
   }
 
+  public get initContainers(): Container[] {
+    return this._podTemplate.initContainers;
+  }
+
   public get volumes(): Volume[] {
     return this._podTemplate.volumes;
   }
@@ -177,6 +181,10 @@ export class StatefulSet extends Resource implements IPodTemplate {
 
   public addContainer(container: ContainerProps): Container {
     return this._podTemplate.addContainer(container);
+  }
+
+  public addInitContainer(container: ContainerProps): Container {
+    return this._podTemplate.addInitContainer(container);
   }
 
   public addVolume(volume: Volume): void {

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -36,6 +36,7 @@ Array [
               "volumeMounts": Array [],
             },
           ],
+          "initContainers": Array [],
           "volumes": Array [],
         },
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [feat: init containers (#451)](https://github.com/cdk8s-team/cdk8s-plus/pull/451)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)