### PR TITLE
feat: classes for common secret types (#473)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -2,6 +2,64 @@
 
 ## Constructs <a name="Constructs"></a>
 
+### BasicAuthSecret <a name="org.cdk8s.plus21.BasicAuthSecret"></a>
+
+Create a secret for basic authentication.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+
+#### Initializers <a name="org.cdk8s.plus21.BasicAuthSecret.Initializer"></a>
+
+```java
+import org.cdk8s.plus21.BasicAuthSecret;
+
+BasicAuthSecret.Builder.create(Construct scope, java.lang.String id)
+//  .metadata(ApiObjectMetadata)
+    .password(java.lang.String)
+    .username(java.lang.String)
+    .build();
+```
+
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecret.parameter.scope"></a>
+
+- *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecret.parameter.id"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.parameter.metadata"></a>
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `password`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.parameter.password"></a>
+
+- *Type:* `java.lang.String`
+
+The password or token for authentication.
+
+---
+
+##### `username`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.parameter.username"></a>
+
+- *Type:* `java.lang.String`
+
+The user name for authentication.
+
+---
+
+
+
+
+
 ### ConfigMap <a name="org.cdk8s.plus21.ConfigMap"></a>
 
 - *Implements:* [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap)
@@ -643,6 +701,57 @@ public IServiceAccount getServiceAccount();
 The service account used to run this pod.
 
 ---
+
+
+### DockerConfigSecret <a name="org.cdk8s.plus21.DockerConfigSecret"></a>
+
+Create a secret for storing credentials for accessing a container image registry.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
+
+#### Initializers <a name="org.cdk8s.plus21.DockerConfigSecret.Initializer"></a>
+
+```java
+import org.cdk8s.plus21.DockerConfigSecret;
+
+DockerConfigSecret.Builder.create(Construct scope, java.lang.String id)
+//  .metadata(ApiObjectMetadata)
+    .data(java.util.Map<java.lang.String, java.lang.Object>)
+    .build();
+```
+
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.DockerConfigSecret.parameter.scope"></a>
+
+- *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.DockerConfigSecret.parameter.id"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.parameter.metadata"></a>
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `data`<sup>Required</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.parameter.data"></a>
+
+- *Type:* java.util.Map<java.lang.String, `java.lang.Object`>
+
+JSON content to provide for the `~/.docker/config.json` file. This will be stringified and inserted as stringData.
+
+> https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file
+
+---
+
+
+
 
 
 ### IngressV1Beta1 <a name="org.cdk8s.plus21.IngressV1Beta1"></a>
@@ -2104,6 +2213,104 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
+### ServiceAccountTokenSecret <a name="org.cdk8s.plus21.ServiceAccountTokenSecret"></a>
+
+Create a secret for a service account token.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets
+
+#### Initializers <a name="org.cdk8s.plus21.ServiceAccountTokenSecret.Initializer"></a>
+
+```java
+import org.cdk8s.plus21.ServiceAccountTokenSecret;
+
+ServiceAccountTokenSecret.Builder.create(Construct scope, java.lang.String id)
+//  .metadata(ApiObjectMetadata)
+    .serviceAccount(IServiceAccount)
+    .build();
+```
+
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecret.parameter.scope"></a>
+
+- *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecret.parameter.id"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.parameter.metadata"></a>
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.parameter.serviceAccount"></a>
+
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+
+The service account to store a secret for.
+
+---
+
+
+
+
+
+### SshAuthSecret <a name="org.cdk8s.plus21.SshAuthSecret"></a>
+
+Create a secret for ssh authentication.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+
+#### Initializers <a name="org.cdk8s.plus21.SshAuthSecret.Initializer"></a>
+
+```java
+import org.cdk8s.plus21.SshAuthSecret;
+
+SshAuthSecret.Builder.create(Construct scope, java.lang.String id)
+//  .metadata(ApiObjectMetadata)
+    .sshPrivateKey(java.lang.String)
+    .build();
+```
+
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.SshAuthSecret.parameter.scope"></a>
+
+- *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.SshAuthSecret.parameter.id"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.parameter.metadata"></a>
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.parameter.sshPrivateKey"></a>
+
+- *Type:* `java.lang.String`
+
+The SSH private key to use.
+
+---
+
+
+
+
+
 ### StatefulSet <a name="org.cdk8s.plus21.StatefulSet"></a>
 
 - *Implements:* [`org.cdk8s.plus21.IPodTemplate`](#org.cdk8s.plus21.IPodTemplate)
@@ -2532,6 +2739,64 @@ The service account used to run this pod.
 ---
 
 
+### TlsSecret <a name="org.cdk8s.plus21.TlsSecret"></a>
+
+Create a secret for storing a TLS certificate and its associated key.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
+
+#### Initializers <a name="org.cdk8s.plus21.TlsSecret.Initializer"></a>
+
+```java
+import org.cdk8s.plus21.TlsSecret;
+
+TlsSecret.Builder.create(Construct scope, java.lang.String id)
+//  .metadata(ApiObjectMetadata)
+    .tlsCert(java.lang.String)
+    .tlsKey(java.lang.String)
+    .build();
+```
+
+##### `scope`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecret.parameter.scope"></a>
+
+- *Type:* [`software.constructs.Construct`](#software.constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecret.parameter.id"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.TlsSecretProps.parameter.metadata"></a>
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecretProps.parameter.tlsCert"></a>
+
+- *Type:* `java.lang.String`
+
+The TLS cert.
+
+---
+
+##### `tlsKey`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecretProps.parameter.tlsKey"></a>
+
+- *Type:* `java.lang.String`
+
+The TLS key.
+
+---
+
+
+
+
+
 ## Structs <a name="Structs"></a>
 
 ### AddDeploymentOptions <a name="org.cdk8s.plus21.AddDeploymentOptions"></a>
@@ -2668,6 +2933,58 @@ public java.lang.String getKeyPrefix();
 - *Default:* ""
 
 A prefix to add to all keys in the config map.
+
+---
+
+### BasicAuthSecretProps <a name="org.cdk8s.plus21.BasicAuthSecretProps"></a>
+
+Options for `BasicAuthSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.BasicAuthSecretProps;
+
+BasicAuthSecretProps.builder()
+//  .metadata(ApiObjectMetadata)
+    .password(java.lang.String)
+    .username(java.lang.String)
+    .build();
+```
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.property.metadata"></a>
+
+```java
+public ApiObjectMetadata getMetadata();
+```
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `password`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.property.password"></a>
+
+```java
+public java.lang.String getPassword();
+```
+
+- *Type:* `java.lang.String`
+
+The password or token for authentication.
+
+---
+
+##### `username`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.property.username"></a>
+
+```java
+public java.lang.String getUsername();
+```
+
+- *Type:* `java.lang.String`
+
+The user name for authentication.
 
 ---
 
@@ -3477,6 +3794,47 @@ public java.lang.Number getReplicas();
 - *Default:* 1
 
 Number of desired pods.
+
+---
+
+### DockerConfigSecretProps <a name="org.cdk8s.plus21.DockerConfigSecretProps"></a>
+
+Options for `DockerConfigSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.DockerConfigSecretProps;
+
+DockerConfigSecretProps.builder()
+//  .metadata(ApiObjectMetadata)
+    .data(java.util.Map<java.lang.String, java.lang.Object>)
+    .build();
+```
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.property.metadata"></a>
+
+```java
+public ApiObjectMetadata getMetadata();
+```
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `data`<sup>Required</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.property.data"></a>
+
+```java
+public java.util.Map<java.lang.String, java.lang.Object> getData();
+```
+
+- *Type:* java.util.Map<java.lang.String, `java.lang.Object`>
+
+JSON content to provide for the `~/.docker/config.json` file. This will be stringified and inserted as stringData.
+
+> https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file
 
 ---
 
@@ -5355,6 +5713,8 @@ public MemoryResources getMemory();
 
 ### SecretProps <a name="org.cdk8s.plus21.SecretProps"></a>
 
+Options for `Secret`.
+
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
@@ -5573,6 +5933,45 @@ public java.util.List<ISecret> getSecrets();
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
+
+---
+
+### ServiceAccountTokenSecretProps <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps"></a>
+
+Options for `ServiceAccountTokenSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.ServiceAccountTokenSecretProps;
+
+ServiceAccountTokenSecretProps.builder()
+//  .metadata(ApiObjectMetadata)
+    .serviceAccount(IServiceAccount)
+    .build();
+```
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.property.metadata"></a>
+
+```java
+public ApiObjectMetadata getMetadata();
+```
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
+
+```java
+public IServiceAccount getServiceAccount();
+```
+
+- *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+
+The service account to store a secret for.
 
 ---
 
@@ -5908,6 +6307,45 @@ public ServiceType getType();
 Determines how the Service is exposed.
 
 More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+---
+
+### SshAuthSecretProps <a name="org.cdk8s.plus21.SshAuthSecretProps"></a>
+
+Options for `SshAuthSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.SshAuthSecretProps;
+
+SshAuthSecretProps.builder()
+//  .metadata(ApiObjectMetadata)
+    .sshPrivateKey(java.lang.String)
+    .build();
+```
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.property.metadata"></a>
+
+```java
+public ApiObjectMetadata getMetadata();
+```
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.property.sshPrivateKey"></a>
+
+```java
+public java.lang.String getSshPrivateKey();
+```
+
+- *Type:* `java.lang.String`
+
+The SSH private key to use.
 
 ---
 
@@ -6297,6 +6735,58 @@ public java.lang.Number getPort();
 - *Default:* defaults to `container.port`.
 
 The TCP port to connect to on the container.
+
+---
+
+### TlsSecretProps <a name="org.cdk8s.plus21.TlsSecretProps"></a>
+
+Options for `TlsSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.TlsSecretProps;
+
+TlsSecretProps.builder()
+//  .metadata(ApiObjectMetadata)
+    .tlsCert(java.lang.String)
+    .tlsKey(java.lang.String)
+    .build();
+```
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.TlsSecretProps.property.metadata"></a>
+
+```java
+public ApiObjectMetadata getMetadata();
+```
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecretProps.property.tlsCert"></a>
+
+```java
+public java.lang.String getTlsCert();
+```
+
+- *Type:* `java.lang.String`
+
+The TLS cert.
+
+---
+
+##### `tlsKey`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecretProps.property.tlsKey"></a>
+
+```java
+public java.lang.String getTlsKey();
+```
+
+- *Type:* `java.lang.String`
+
+The TLS key.
 
 ---
 
@@ -8219,7 +8709,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ### IResource <a name="org.cdk8s.plus21.IResource"></a>
 
-- *Implemented By:* [`org.cdk8s.plus21.ConfigMap`](#org.cdk8s.plus21.ConfigMap), [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment), [`org.cdk8s.plus21.IngressV1Beta1`](#org.cdk8s.plus21.IngressV1Beta1), [`org.cdk8s.plus21.Job`](#org.cdk8s.plus21.Job), [`org.cdk8s.plus21.Pod`](#org.cdk8s.plus21.Pod), [`org.cdk8s.plus21.Resource`](#org.cdk8s.plus21.Resource), [`org.cdk8s.plus21.Secret`](#org.cdk8s.plus21.Secret), [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service), [`org.cdk8s.plus21.ServiceAccount`](#org.cdk8s.plus21.ServiceAccount), [`org.cdk8s.plus21.StatefulSet`](#org.cdk8s.plus21.StatefulSet), [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap), [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource), [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret), [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
+- *Implemented By:* [`org.cdk8s.plus21.BasicAuthSecret`](#org.cdk8s.plus21.BasicAuthSecret), [`org.cdk8s.plus21.ConfigMap`](#org.cdk8s.plus21.ConfigMap), [`org.cdk8s.plus21.Deployment`](#org.cdk8s.plus21.Deployment), [`org.cdk8s.plus21.DockerConfigSecret`](#org.cdk8s.plus21.DockerConfigSecret), [`org.cdk8s.plus21.IngressV1Beta1`](#org.cdk8s.plus21.IngressV1Beta1), [`org.cdk8s.plus21.Job`](#org.cdk8s.plus21.Job), [`org.cdk8s.plus21.Pod`](#org.cdk8s.plus21.Pod), [`org.cdk8s.plus21.Resource`](#org.cdk8s.plus21.Resource), [`org.cdk8s.plus21.Secret`](#org.cdk8s.plus21.Secret), [`org.cdk8s.plus21.Service`](#org.cdk8s.plus21.Service), [`org.cdk8s.plus21.ServiceAccount`](#org.cdk8s.plus21.ServiceAccount), [`org.cdk8s.plus21.ServiceAccountTokenSecret`](#org.cdk8s.plus21.ServiceAccountTokenSecret), [`org.cdk8s.plus21.SshAuthSecret`](#org.cdk8s.plus21.SshAuthSecret), [`org.cdk8s.plus21.StatefulSet`](#org.cdk8s.plus21.StatefulSet), [`org.cdk8s.plus21.TlsSecret`](#org.cdk8s.plus21.TlsSecret), [`org.cdk8s.plus21.IConfigMap`](#org.cdk8s.plus21.IConfigMap), [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource), [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret), [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
 Represents a resource.
 
@@ -8242,7 +8732,7 @@ The Kubernetes name of this resource.
 
 - *Extends:* [`org.cdk8s.plus21.IResource`](#org.cdk8s.plus21.IResource)
 
-- *Implemented By:* [`org.cdk8s.plus21.Secret`](#org.cdk8s.plus21.Secret), [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
+- *Implemented By:* [`org.cdk8s.plus21.BasicAuthSecret`](#org.cdk8s.plus21.BasicAuthSecret), [`org.cdk8s.plus21.DockerConfigSecret`](#org.cdk8s.plus21.DockerConfigSecret), [`org.cdk8s.plus21.Secret`](#org.cdk8s.plus21.Secret), [`org.cdk8s.plus21.ServiceAccountTokenSecret`](#org.cdk8s.plus21.ServiceAccountTokenSecret), [`org.cdk8s.plus21.SshAuthSecret`](#org.cdk8s.plus21.SshAuthSecret), [`org.cdk8s.plus21.TlsSecret`](#org.cdk8s.plus21.TlsSecret), [`org.cdk8s.plus21.ISecret`](#org.cdk8s.plus21.ISecret)
 
 
 #### Properties <a name="Properties"></a>

--- a/docs/python.md
+++ b/docs/python.md
@@ -2,6 +2,66 @@
 
 ## Constructs <a name="Constructs"></a>
 
+### BasicAuthSecret <a name="cdk8s_plus_21.BasicAuthSecret"></a>
+
+Create a secret for basic authentication.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+
+#### Initializers <a name="cdk8s_plus_21.BasicAuthSecret.Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.BasicAuthSecret(
+  scope: Construct,
+  id: str,
+  metadata: ApiObjectMetadata = None,
+  password: str,
+  username: str
+)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecret.parameter.id"></a>
+
+- *Type:* `str`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.parameter.metadata"></a>
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `password`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.parameter.password"></a>
+
+- *Type:* `str`
+
+The password or token for authentication.
+
+---
+
+##### `username`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.parameter.username"></a>
+
+- *Type:* `str`
+
+The user name for authentication.
+
+---
+
+
+
+
+
 ### ConfigMap <a name="cdk8s_plus_21.ConfigMap"></a>
 
 - *Implements:* [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap)
@@ -1129,6 +1189,59 @@ service_account: IServiceAccount
 The service account used to run this pod.
 
 ---
+
+
+### DockerConfigSecret <a name="cdk8s_plus_21.DockerConfigSecret"></a>
+
+Create a secret for storing credentials for accessing a container image registry.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
+
+#### Initializers <a name="cdk8s_plus_21.DockerConfigSecret.Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.DockerConfigSecret(
+  scope: Construct,
+  id: str,
+  metadata: ApiObjectMetadata = None,
+  data: typing.Mapping[typing.Any]
+)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.DockerConfigSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.DockerConfigSecret.parameter.id"></a>
+
+- *Type:* `str`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DockerConfigSecretProps.parameter.metadata"></a>
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `data`<sup>Required</sup> <a name="cdk8s_plus_21.DockerConfigSecretProps.parameter.data"></a>
+
+- *Type:* typing.Mapping[`typing.Any`]
+
+JSON content to provide for the `~/.docker/config.json` file. This will be stringified and inserted as stringData.
+
+> https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file
+
+---
+
+
+
 
 
 ### IngressV1Beta1 <a name="cdk8s_plus_21.IngressV1Beta1"></a>
@@ -3477,6 +3590,108 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
+### ServiceAccountTokenSecret <a name="cdk8s_plus_21.ServiceAccountTokenSecret"></a>
+
+Create a secret for a service account token.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets
+
+#### Initializers <a name="cdk8s_plus_21.ServiceAccountTokenSecret.Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.ServiceAccountTokenSecret(
+  scope: Construct,
+  id: str,
+  metadata: ApiObjectMetadata = None,
+  service_account: IServiceAccount
+)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecret.parameter.id"></a>
+
+- *Type:* `str`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.parameter.metadata"></a>
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.parameter.service_account"></a>
+
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+
+The service account to store a secret for.
+
+---
+
+
+
+
+
+### SshAuthSecret <a name="cdk8s_plus_21.SshAuthSecret"></a>
+
+Create a secret for ssh authentication.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+
+#### Initializers <a name="cdk8s_plus_21.SshAuthSecret.Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.SshAuthSecret(
+  scope: Construct,
+  id: str,
+  metadata: ApiObjectMetadata = None,
+  ssh_private_key: str
+)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.SshAuthSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.SshAuthSecret.parameter.id"></a>
+
+- *Type:* `str`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.parameter.metadata"></a>
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.parameter.ssh_private_key"></a>
+
+- *Type:* `str`
+
+The SSH private key to use.
+
+---
+
+
+
+
+
 ### StatefulSet <a name="cdk8s_plus_21.StatefulSet"></a>
 
 - *Implements:* [`cdk8s_plus_21.IPodTemplate`](#cdk8s_plus_21.IPodTemplate)
@@ -4263,6 +4478,66 @@ The service account used to run this pod.
 ---
 
 
+### TlsSecret <a name="cdk8s_plus_21.TlsSecret"></a>
+
+Create a secret for storing a TLS certificate and its associated key.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
+
+#### Initializers <a name="cdk8s_plus_21.TlsSecret.Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.TlsSecret(
+  scope: Construct,
+  id: str,
+  metadata: ApiObjectMetadata = None,
+  tls_cert: str,
+  tls_key: str
+)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecret.parameter.id"></a>
+
+- *Type:* `str`
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.TlsSecretProps.parameter.metadata"></a>
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecretProps.parameter.tls_cert"></a>
+
+- *Type:* `str`
+
+The TLS cert.
+
+---
+
+##### `tls_key`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecretProps.parameter.tls_key"></a>
+
+- *Type:* `str`
+
+The TLS key.
+
+---
+
+
+
+
+
 ## Structs <a name="Structs"></a>
 
 ### AddDeploymentOptions <a name="cdk8s_plus_21.AddDeploymentOptions"></a>
@@ -4399,6 +4674,58 @@ key_prefix: str
 - *Default:* ""
 
 A prefix to add to all keys in the config map.
+
+---
+
+### BasicAuthSecretProps <a name="cdk8s_plus_21.BasicAuthSecretProps"></a>
+
+Options for `BasicAuthSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.BasicAuthSecretProps(
+  metadata: ApiObjectMetadata = None,
+  password: str,
+  username: str
+)
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.property.metadata"></a>
+
+```python
+metadata: ApiObjectMetadata
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `password`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.property.password"></a>
+
+```python
+password: str
+```
+
+- *Type:* `str`
+
+The password or token for authentication.
+
+---
+
+##### `username`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.property.username"></a>
+
+```python
+username: str
+```
+
+- *Type:* `str`
+
+The user name for authentication.
 
 ---
 
@@ -5208,6 +5535,47 @@ replicas: typing.Union[int, float]
 - *Default:* 1
 
 Number of desired pods.
+
+---
+
+### DockerConfigSecretProps <a name="cdk8s_plus_21.DockerConfigSecretProps"></a>
+
+Options for `DockerConfigSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.DockerConfigSecretProps(
+  metadata: ApiObjectMetadata = None,
+  data: typing.Mapping[typing.Any]
+)
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.DockerConfigSecretProps.property.metadata"></a>
+
+```python
+metadata: ApiObjectMetadata
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `data`<sup>Required</sup> <a name="cdk8s_plus_21.DockerConfigSecretProps.property.data"></a>
+
+```python
+data: typing.Mapping[typing.Any]
+```
+
+- *Type:* typing.Mapping[`typing.Any`]
+
+JSON content to provide for the `~/.docker/config.json` file. This will be stringified and inserted as stringData.
+
+> https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file
 
 ---
 
@@ -7086,6 +7454,8 @@ memory: MemoryResources
 
 ### SecretProps <a name="cdk8s_plus_21.SecretProps"></a>
 
+Options for `Secret`.
+
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
@@ -7304,6 +7674,45 @@ secrets: typing.List[ISecret]
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
+
+---
+
+### ServiceAccountTokenSecretProps <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps"></a>
+
+Options for `ServiceAccountTokenSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.ServiceAccountTokenSecretProps(
+  metadata: ApiObjectMetadata = None,
+  service_account: IServiceAccount
+)
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.property.metadata"></a>
+
+```python
+metadata: ApiObjectMetadata
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.property.service_account"></a>
+
+```python
+service_account: IServiceAccount
+```
+
+- *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+
+The service account to store a secret for.
 
 ---
 
@@ -7639,6 +8048,45 @@ type: ServiceType
 Determines how the Service is exposed.
 
 More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+---
+
+### SshAuthSecretProps <a name="cdk8s_plus_21.SshAuthSecretProps"></a>
+
+Options for `SshAuthSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.SshAuthSecretProps(
+  metadata: ApiObjectMetadata = None,
+  ssh_private_key: str
+)
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.property.metadata"></a>
+
+```python
+metadata: ApiObjectMetadata
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.property.ssh_private_key"></a>
+
+```python
+ssh_private_key: str
+```
+
+- *Type:* `str`
+
+The SSH private key to use.
 
 ---
 
@@ -8028,6 +8476,58 @@ port: typing.Union[int, float]
 - *Default:* defaults to `container.port`.
 
 The TCP port to connect to on the container.
+
+---
+
+### TlsSecretProps <a name="cdk8s_plus_21.TlsSecretProps"></a>
+
+Options for `TlsSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.TlsSecretProps(
+  metadata: ApiObjectMetadata = None,
+  tls_cert: str,
+  tls_key: str
+)
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.TlsSecretProps.property.metadata"></a>
+
+```python
+metadata: ApiObjectMetadata
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecretProps.property.tls_cert"></a>
+
+```python
+tls_cert: str
+```
+
+- *Type:* `str`
+
+The TLS cert.
+
+---
+
+##### `tls_key`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecretProps.property.tls_key"></a>
+
+```python
+tls_key: str
+```
+
+- *Type:* `str`
+
+The TLS key.
 
 ---
 
@@ -11063,7 +11563,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ### IResource <a name="cdk8s_plus_21.IResource"></a>
 
-- *Implemented By:* [`cdk8s_plus_21.ConfigMap`](#cdk8s_plus_21.ConfigMap), [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment), [`cdk8s_plus_21.IngressV1Beta1`](#cdk8s_plus_21.IngressV1Beta1), [`cdk8s_plus_21.Job`](#cdk8s_plus_21.Job), [`cdk8s_plus_21.Pod`](#cdk8s_plus_21.Pod), [`cdk8s_plus_21.Resource`](#cdk8s_plus_21.Resource), [`cdk8s_plus_21.Secret`](#cdk8s_plus_21.Secret), [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service), [`cdk8s_plus_21.ServiceAccount`](#cdk8s_plus_21.ServiceAccount), [`cdk8s_plus_21.StatefulSet`](#cdk8s_plus_21.StatefulSet), [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap), [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource), [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret), [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
+- *Implemented By:* [`cdk8s_plus_21.BasicAuthSecret`](#cdk8s_plus_21.BasicAuthSecret), [`cdk8s_plus_21.ConfigMap`](#cdk8s_plus_21.ConfigMap), [`cdk8s_plus_21.Deployment`](#cdk8s_plus_21.Deployment), [`cdk8s_plus_21.DockerConfigSecret`](#cdk8s_plus_21.DockerConfigSecret), [`cdk8s_plus_21.IngressV1Beta1`](#cdk8s_plus_21.IngressV1Beta1), [`cdk8s_plus_21.Job`](#cdk8s_plus_21.Job), [`cdk8s_plus_21.Pod`](#cdk8s_plus_21.Pod), [`cdk8s_plus_21.Resource`](#cdk8s_plus_21.Resource), [`cdk8s_plus_21.Secret`](#cdk8s_plus_21.Secret), [`cdk8s_plus_21.Service`](#cdk8s_plus_21.Service), [`cdk8s_plus_21.ServiceAccount`](#cdk8s_plus_21.ServiceAccount), [`cdk8s_plus_21.ServiceAccountTokenSecret`](#cdk8s_plus_21.ServiceAccountTokenSecret), [`cdk8s_plus_21.SshAuthSecret`](#cdk8s_plus_21.SshAuthSecret), [`cdk8s_plus_21.StatefulSet`](#cdk8s_plus_21.StatefulSet), [`cdk8s_plus_21.TlsSecret`](#cdk8s_plus_21.TlsSecret), [`cdk8s_plus_21.IConfigMap`](#cdk8s_plus_21.IConfigMap), [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource), [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret), [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
 Represents a resource.
 
@@ -11086,7 +11586,7 @@ The Kubernetes name of this resource.
 
 - *Extends:* [`cdk8s_plus_21.IResource`](#cdk8s_plus_21.IResource)
 
-- *Implemented By:* [`cdk8s_plus_21.Secret`](#cdk8s_plus_21.Secret), [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
+- *Implemented By:* [`cdk8s_plus_21.BasicAuthSecret`](#cdk8s_plus_21.BasicAuthSecret), [`cdk8s_plus_21.DockerConfigSecret`](#cdk8s_plus_21.DockerConfigSecret), [`cdk8s_plus_21.Secret`](#cdk8s_plus_21.Secret), [`cdk8s_plus_21.ServiceAccountTokenSecret`](#cdk8s_plus_21.ServiceAccountTokenSecret), [`cdk8s_plus_21.SshAuthSecret`](#cdk8s_plus_21.SshAuthSecret), [`cdk8s_plus_21.TlsSecret`](#cdk8s_plus_21.TlsSecret), [`cdk8s_plus_21.ISecret`](#cdk8s_plus_21.ISecret)
 
 
 #### Properties <a name="Properties"></a>

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,6 +2,42 @@
 
 ## Constructs <a name="Constructs"></a>
 
+### BasicAuthSecret <a name="cdk8s-plus-21.BasicAuthSecret"></a>
+
+Create a secret for basic authentication.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+
+#### Initializers <a name="cdk8s-plus-21.BasicAuthSecret.Initializer"></a>
+
+```typescript
+import { BasicAuthSecret } from 'cdk8s-plus-21'
+
+new BasicAuthSecret(scope: Construct, id: string, props: BasicAuthSecretProps)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.BasicAuthSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.BasicAuthSecret.parameter.id"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.BasicAuthSecret.parameter.props"></a>
+
+- *Type:* [`cdk8s-plus-21.BasicAuthSecretProps`](#cdk8s-plus-21.BasicAuthSecretProps)
+
+---
+
+
+
+
+
 ### ConfigMap <a name="cdk8s-plus-21.ConfigMap"></a>
 
 - *Implements:* [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap)
@@ -466,6 +502,42 @@ public readonly serviceAccount: IServiceAccount;
 The service account used to run this pod.
 
 ---
+
+
+### DockerConfigSecret <a name="cdk8s-plus-21.DockerConfigSecret"></a>
+
+Create a secret for storing credentials for accessing a container image registry.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
+
+#### Initializers <a name="cdk8s-plus-21.DockerConfigSecret.Initializer"></a>
+
+```typescript
+import { DockerConfigSecret } from 'cdk8s-plus-21'
+
+new DockerConfigSecret(scope: Construct, id: string, props: DockerConfigSecretProps)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.DockerConfigSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.DockerConfigSecret.parameter.id"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.DockerConfigSecret.parameter.props"></a>
+
+- *Type:* [`cdk8s-plus-21.DockerConfigSecretProps`](#cdk8s-plus-21.DockerConfigSecretProps)
+
+---
+
+
+
 
 
 ### IngressV1Beta1 <a name="cdk8s-plus-21.IngressV1Beta1"></a>
@@ -1488,6 +1560,78 @@ Returns a copy. To add a secret, use `addSecret()`.
 ---
 
 
+### ServiceAccountTokenSecret <a name="cdk8s-plus-21.ServiceAccountTokenSecret"></a>
+
+Create a secret for a service account token.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets
+
+#### Initializers <a name="cdk8s-plus-21.ServiceAccountTokenSecret.Initializer"></a>
+
+```typescript
+import { ServiceAccountTokenSecret } from 'cdk8s-plus-21'
+
+new ServiceAccountTokenSecret(scope: Construct, id: string, props: ServiceAccountTokenSecretProps)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccountTokenSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccountTokenSecret.parameter.id"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccountTokenSecret.parameter.props"></a>
+
+- *Type:* [`cdk8s-plus-21.ServiceAccountTokenSecretProps`](#cdk8s-plus-21.ServiceAccountTokenSecretProps)
+
+---
+
+
+
+
+
+### SshAuthSecret <a name="cdk8s-plus-21.SshAuthSecret"></a>
+
+Create a secret for ssh authentication.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+
+#### Initializers <a name="cdk8s-plus-21.SshAuthSecret.Initializer"></a>
+
+```typescript
+import { SshAuthSecret } from 'cdk8s-plus-21'
+
+new SshAuthSecret(scope: Construct, id: string, props: SshAuthSecretProps)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.SshAuthSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.SshAuthSecret.parameter.id"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.SshAuthSecret.parameter.props"></a>
+
+- *Type:* [`cdk8s-plus-21.SshAuthSecretProps`](#cdk8s-plus-21.SshAuthSecretProps)
+
+---
+
+
+
+
+
 ### StatefulSet <a name="cdk8s-plus-21.StatefulSet"></a>
 
 - *Implements:* [`cdk8s-plus-21.IPodTemplate`](#cdk8s-plus-21.IPodTemplate)
@@ -1759,6 +1903,42 @@ The service account used to run this pod.
 ---
 
 
+### TlsSecret <a name="cdk8s-plus-21.TlsSecret"></a>
+
+Create a secret for storing a TLS certificate and its associated key.
+
+> https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
+
+#### Initializers <a name="cdk8s-plus-21.TlsSecret.Initializer"></a>
+
+```typescript
+import { TlsSecret } from 'cdk8s-plus-21'
+
+new TlsSecret(scope: Construct, id: string, props: TlsSecretProps)
+```
+
+##### `scope`<sup>Required</sup> <a name="cdk8s-plus-21.TlsSecret.parameter.scope"></a>
+
+- *Type:* [`constructs.Construct`](#constructs.Construct)
+
+---
+
+##### `id`<sup>Required</sup> <a name="cdk8s-plus-21.TlsSecret.parameter.id"></a>
+
+- *Type:* `string`
+
+---
+
+##### `props`<sup>Required</sup> <a name="cdk8s-plus-21.TlsSecret.parameter.props"></a>
+
+- *Type:* [`cdk8s-plus-21.TlsSecretProps`](#cdk8s-plus-21.TlsSecretProps)
+
+---
+
+
+
+
+
 ## Structs <a name="Structs"></a>
 
 ### AddDeploymentOptions <a name="cdk8s-plus-21.AddDeploymentOptions"></a>
@@ -1886,6 +2066,54 @@ public readonly keyPrefix: string;
 - *Default:* ""
 
 A prefix to add to all keys in the config map.
+
+---
+
+### BasicAuthSecretProps <a name="cdk8s-plus-21.BasicAuthSecretProps"></a>
+
+Options for `BasicAuthSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { BasicAuthSecretProps } from 'cdk8s-plus-21'
+
+const basicAuthSecretProps: BasicAuthSecretProps = { ... }
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.BasicAuthSecretProps.property.metadata"></a>
+
+```typescript
+public readonly metadata: ApiObjectMetadata;
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `password`<sup>Required</sup> <a name="cdk8s-plus-21.BasicAuthSecretProps.property.password"></a>
+
+```typescript
+public readonly password: string;
+```
+
+- *Type:* `string`
+
+The password or token for authentication.
+
+---
+
+##### `username`<sup>Required</sup> <a name="cdk8s-plus-21.BasicAuthSecretProps.property.username"></a>
+
+```typescript
+public readonly username: string;
+```
+
+- *Type:* `string`
+
+The user name for authentication.
 
 ---
 
@@ -2644,6 +2872,44 @@ public readonly replicas: number;
 - *Default:* 1
 
 Number of desired pods.
+
+---
+
+### DockerConfigSecretProps <a name="cdk8s-plus-21.DockerConfigSecretProps"></a>
+
+Options for `DockerConfigSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { DockerConfigSecretProps } from 'cdk8s-plus-21'
+
+const dockerConfigSecretProps: DockerConfigSecretProps = { ... }
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.DockerConfigSecretProps.property.metadata"></a>
+
+```typescript
+public readonly metadata: ApiObjectMetadata;
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `data`<sup>Required</sup> <a name="cdk8s-plus-21.DockerConfigSecretProps.property.data"></a>
+
+```typescript
+public readonly data: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: `any`}
+
+JSON content to provide for the `~/.docker/config.json` file. This will be stringified and inserted as stringData.
+
+> https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file
 
 ---
 
@@ -4402,6 +4668,8 @@ public readonly memory: MemoryResources;
 
 ### SecretProps <a name="cdk8s-plus-21.SecretProps"></a>
 
+Options for `Secret`.
+
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
@@ -4605,6 +4873,42 @@ public readonly secrets: ISecret[];
 List of secrets allowed to be used by pods running using this ServiceAccount.
 
 > https://kubernetes.io/docs/concepts/configuration/secret
+
+---
+
+### ServiceAccountTokenSecretProps <a name="cdk8s-plus-21.ServiceAccountTokenSecretProps"></a>
+
+Options for `ServiceAccountTokenSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { ServiceAccountTokenSecretProps } from 'cdk8s-plus-21'
+
+const serviceAccountTokenSecretProps: ServiceAccountTokenSecretProps = { ... }
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceAccountTokenSecretProps.property.metadata"></a>
+
+```typescript
+public readonly metadata: ApiObjectMetadata;
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `serviceAccount`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
+
+```typescript
+public readonly serviceAccount: IServiceAccount;
+```
+
+- *Type:* [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+
+The service account to store a secret for.
 
 ---
 
@@ -4919,6 +5223,42 @@ public readonly type: ServiceType;
 Determines how the Service is exposed.
 
 More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+
+---
+
+### SshAuthSecretProps <a name="cdk8s-plus-21.SshAuthSecretProps"></a>
+
+Options for `SshAuthSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { SshAuthSecretProps } from 'cdk8s-plus-21'
+
+const sshAuthSecretProps: SshAuthSecretProps = { ... }
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.SshAuthSecretProps.property.metadata"></a>
+
+```typescript
+public readonly metadata: ApiObjectMetadata;
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `sshPrivateKey`<sup>Required</sup> <a name="cdk8s-plus-21.SshAuthSecretProps.property.sshPrivateKey"></a>
+
+```typescript
+public readonly sshPrivateKey: string;
+```
+
+- *Type:* `string`
+
+The SSH private key to use.
 
 ---
 
@@ -5283,6 +5623,54 @@ public readonly port: number;
 - *Default:* defaults to `container.port`.
 
 The TCP port to connect to on the container.
+
+---
+
+### TlsSecretProps <a name="cdk8s-plus-21.TlsSecretProps"></a>
+
+Options for `TlsSecret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { TlsSecretProps } from 'cdk8s-plus-21'
+
+const tlsSecretProps: TlsSecretProps = { ... }
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.TlsSecretProps.property.metadata"></a>
+
+```typescript
+public readonly metadata: ApiObjectMetadata;
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `tlsCert`<sup>Required</sup> <a name="cdk8s-plus-21.TlsSecretProps.property.tlsCert"></a>
+
+```typescript
+public readonly tlsCert: string;
+```
+
+- *Type:* `string`
+
+The TLS cert.
+
+---
+
+##### `tlsKey`<sup>Required</sup> <a name="cdk8s-plus-21.TlsSecretProps.property.tlsKey"></a>
+
+```typescript
+public readonly tlsKey: string;
+```
+
+- *Type:* `string`
+
+The TLS key.
 
 ---
 
@@ -6700,7 +7088,7 @@ Provides read/write access to the underlying pod metadata of the resource.
 
 ### IResource <a name="cdk8s-plus-21.IResource"></a>
 
-- *Implemented By:* [`cdk8s-plus-21.ConfigMap`](#cdk8s-plus-21.ConfigMap), [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment), [`cdk8s-plus-21.IngressV1Beta1`](#cdk8s-plus-21.IngressV1Beta1), [`cdk8s-plus-21.Job`](#cdk8s-plus-21.Job), [`cdk8s-plus-21.Pod`](#cdk8s-plus-21.Pod), [`cdk8s-plus-21.Resource`](#cdk8s-plus-21.Resource), [`cdk8s-plus-21.Secret`](#cdk8s-plus-21.Secret), [`cdk8s-plus-21.Service`](#cdk8s-plus-21.Service), [`cdk8s-plus-21.ServiceAccount`](#cdk8s-plus-21.ServiceAccount), [`cdk8s-plus-21.StatefulSet`](#cdk8s-plus-21.StatefulSet), [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap), [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource), [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret), [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
+- *Implemented By:* [`cdk8s-plus-21.BasicAuthSecret`](#cdk8s-plus-21.BasicAuthSecret), [`cdk8s-plus-21.ConfigMap`](#cdk8s-plus-21.ConfigMap), [`cdk8s-plus-21.Deployment`](#cdk8s-plus-21.Deployment), [`cdk8s-plus-21.DockerConfigSecret`](#cdk8s-plus-21.DockerConfigSecret), [`cdk8s-plus-21.IngressV1Beta1`](#cdk8s-plus-21.IngressV1Beta1), [`cdk8s-plus-21.Job`](#cdk8s-plus-21.Job), [`cdk8s-plus-21.Pod`](#cdk8s-plus-21.Pod), [`cdk8s-plus-21.Resource`](#cdk8s-plus-21.Resource), [`cdk8s-plus-21.Secret`](#cdk8s-plus-21.Secret), [`cdk8s-plus-21.Service`](#cdk8s-plus-21.Service), [`cdk8s-plus-21.ServiceAccount`](#cdk8s-plus-21.ServiceAccount), [`cdk8s-plus-21.ServiceAccountTokenSecret`](#cdk8s-plus-21.ServiceAccountTokenSecret), [`cdk8s-plus-21.SshAuthSecret`](#cdk8s-plus-21.SshAuthSecret), [`cdk8s-plus-21.StatefulSet`](#cdk8s-plus-21.StatefulSet), [`cdk8s-plus-21.TlsSecret`](#cdk8s-plus-21.TlsSecret), [`cdk8s-plus-21.IConfigMap`](#cdk8s-plus-21.IConfigMap), [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource), [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret), [`cdk8s-plus-21.IServiceAccount`](#cdk8s-plus-21.IServiceAccount)
 
 Represents a resource.
 
@@ -6723,7 +7111,7 @@ The Kubernetes name of this resource.
 
 - *Extends:* [`cdk8s-plus-21.IResource`](#cdk8s-plus-21.IResource)
 
-- *Implemented By:* [`cdk8s-plus-21.Secret`](#cdk8s-plus-21.Secret), [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
+- *Implemented By:* [`cdk8s-plus-21.BasicAuthSecret`](#cdk8s-plus-21.BasicAuthSecret), [`cdk8s-plus-21.DockerConfigSecret`](#cdk8s-plus-21.DockerConfigSecret), [`cdk8s-plus-21.Secret`](#cdk8s-plus-21.Secret), [`cdk8s-plus-21.ServiceAccountTokenSecret`](#cdk8s-plus-21.ServiceAccountTokenSecret), [`cdk8s-plus-21.SshAuthSecret`](#cdk8s-plus-21.SshAuthSecret), [`cdk8s-plus-21.TlsSecret`](#cdk8s-plus-21.TlsSecret), [`cdk8s-plus-21.ISecret`](#cdk8s-plus-21.ISecret)
 
 
 #### Properties <a name="Properties"></a>

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -2,7 +2,11 @@ import * as cdk8s from 'cdk8s';
 import { Construct } from 'constructs';
 import { IResource, Resource, ResourceProps } from './base';
 import * as k8s from './imports/k8s';
+import { IServiceAccount } from './service-account';
 
+/**
+ * Options for `Secret`.
+ */
 export interface SecretProps extends ResourceProps {
   /**
    * stringData allows specifying non-binary secret data in string form. It is
@@ -92,5 +96,153 @@ export class Secret extends Resource implements ISecret {
    */
   public getStringData(key: string): string | undefined {
     return this.stringData[key];
+  }
+}
+
+/**
+ * Options for `BasicAuthSecret`.
+ */
+export interface BasicAuthSecretProps extends ResourceProps {
+  /**
+   * The user name for authentication
+   */
+  readonly username: string;
+
+  /**
+   * The password or token for authentication
+   */
+  readonly password: string;
+}
+
+/**
+ * Create a secret for basic authentication.
+ *
+ * @see https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+ */
+export class BasicAuthSecret extends Secret {
+  public constructor(scope: Construct, id: string, props: BasicAuthSecretProps) {
+    super(scope, id, {
+      type: 'kubernetes.io/basic-auth',
+      stringData: {
+        username: props.username,
+        password: props.password,
+      },
+    });
+  }
+}
+
+/**
+ * Options for `SshAuthSecret`.
+ */
+export interface SshAuthSecretProps extends ResourceProps {
+  /**
+   * The SSH private key to use
+   */
+  readonly sshPrivateKey: string;
+}
+
+/**
+ * Create a secret for ssh authentication.
+ *
+ * @see https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+ */
+export class SshAuthSecret extends Secret {
+  public constructor(scope: Construct, id: string, props: SshAuthSecretProps) {
+    super(scope, id, {
+      type: 'kubernetes.io/ssh-auth',
+      stringData: {
+        'ssh-privatekey': props.sshPrivateKey,
+      },
+    });
+  }
+}
+
+/**
+ * Options for `ServiceAccountTokenSecret`.
+ */
+export interface ServiceAccountTokenSecretProps extends ResourceProps {
+  /**
+   * The service account to store a secret for
+   */
+  readonly serviceAccount: IServiceAccount;
+}
+
+/**
+ * Create a secret for a service account token.
+ *
+ * @see https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets
+ */
+export class ServiceAccountTokenSecret extends Secret {
+  public constructor(scope: Construct, id: string, props: ServiceAccountTokenSecretProps) {
+    super(scope, id, {
+      type: 'kubernetes.io/service-account-token',
+      metadata: {
+        annotations: {
+          'kubernetes.io/service-account.name': props.serviceAccount.name,
+        },
+      },
+    });
+  }
+}
+
+/**
+ * Options for `TlsSecret`.
+ */
+export interface TlsSecretProps extends ResourceProps {
+  /**
+   * The TLS cert
+   */
+  readonly tlsCert: string;
+
+  /**
+   * The TLS key
+   */
+  readonly tlsKey: string;
+}
+
+/**
+ * Create a secret for storing a TLS certificate and its associated key.
+ *
+ * @see https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets
+ */
+export class TlsSecret extends Secret {
+  public constructor(scope: Construct, id: string, props: TlsSecretProps) {
+    super(scope, id, {
+      type: 'kubernetes.io/tls',
+      stringData: {
+        'tls.crt': props.tlsCert,
+        'tls.key': props.tlsKey,
+      },
+    });
+  }
+}
+
+/**
+ * Options for `DockerConfigSecret`.
+ */
+export interface DockerConfigSecretProps extends ResourceProps {
+  /**
+   * JSON content to provide for the `~/.docker/config.json` file. This will
+   * be stringified and inserted as stringData.
+   *
+   * @see https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file
+   */
+  readonly data: { [key: string]: any };
+}
+
+/**
+ * Create a secret for storing credentials for accessing a container image
+ * registry.
+ *
+ * @see https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
+ */
+export class DockerConfigSecret extends Secret {
+  public constructor(scope: Construct, id: string, props: DockerConfigSecretProps) {
+    super(scope, id, {
+      type: 'kubernetes.io/dockerconfigjson',
+      stringData: {
+        '.dockerconfigjson': JSON.stringify(props.data),
+      },
+    });
   }
 }

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -65,3 +65,150 @@ Array [
 ]
 `);
 });
+
+test('Can create a basic auth secret', () => {
+  const chart = Testing.chart();
+
+  new kplus.BasicAuthSecret(chart, 'BasicAuthSecret', {
+    username: 'admin',
+    password: 't0p-Secret',
+  });
+
+  expect(Testing.synth(chart)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "name": "test-basicauthsecret-c82606a8",
+    },
+    "stringData": Object {
+      "password": "t0p-Secret",
+      "username": "admin",
+    },
+    "type": "kubernetes.io/basic-auth",
+  },
+]
+`);
+});
+
+test('Can create an ssh auth secret', () => {
+  const chart = Testing.chart();
+
+  new kplus.SshAuthSecret(chart, 'SshAuthSecret', {
+    sshPrivateKey: 'fake-private-key',
+  });
+
+  expect(Testing.synth(chart)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "name": "test-sshauthsecret-c8356ec6",
+    },
+    "stringData": Object {
+      "ssh-privatekey": "fake-private-key",
+    },
+    "type": "kubernetes.io/ssh-auth",
+  },
+]
+`);
+});
+
+test('Can create a service account token secret', () => {
+  const chart = Testing.chart();
+
+  const sa = new kplus.ServiceAccount(chart, 'ServiceAccount');
+  const secret = new kplus.ServiceAccountTokenSecret(chart, 'ServiceAccountToken', {
+    serviceAccount: sa,
+  });
+  secret.addStringData('extra', 'foo');
+
+  // the "token" key in "data" should be automatically filled in by a
+  // Kubernetes controller
+  expect(Testing.synth(chart)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": Object {
+      "name": "test-serviceaccount-c8f15383",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "annotations": Object {
+        "kubernetes.io/service-account.name": "test-serviceaccount-c8f15383",
+      },
+      "name": "test-serviceaccounttoken-c8eca6af",
+    },
+    "stringData": Object {
+      "extra": "foo",
+    },
+    "type": "kubernetes.io/service-account-token",
+  },
+]
+`);
+});
+
+test('Can create a TLS secret', () => {
+  const chart = Testing.chart();
+
+  new kplus.TlsSecret(chart, 'TlsSecret', {
+    tlsCert: 'tls-cert-value',
+    tlsKey: 'tls-key-value',
+  });
+
+  expect(Testing.synth(chart)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "name": "test-tlssecret-c8c8af35",
+    },
+    "stringData": Object {
+      "tls.crt": "tls-cert-value",
+      "tls.key": "tls-key-value",
+    },
+    "type": "kubernetes.io/tls",
+  },
+]
+`);
+});
+
+test('Can create a Docker config secret', () => {
+  const chart = Testing.chart();
+
+  new kplus.DockerConfigSecret(chart, 'DockerConfigSecret', {
+    data: {
+      auths: {
+        'hub.xxx.com': {
+          username: 'xxx',
+          password: 'xxx',
+          email: 'xxx',
+          auth: 'xxx',
+        },
+      },
+    },
+  });
+
+  expect(Testing.synth(chart)).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": Object {
+      "name": "test-dockerconfigsecret-c8b65039",
+    },
+    "stringData": Object {
+      ".dockerconfigjson": "{\\"auths\\":{\\"hub.xxx.com\\":{\\"username\\":\\"xxx\\",\\"password\\":\\"xxx\\",\\"email\\":\\"xxx\\",\\"auth\\":\\"xxx\\"}}}",
+    },
+    "type": "kubernetes.io/dockerconfigjson",
+  },
+]
+`);
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [feat: classes for common secret types (#473)](https://github.com/cdk8s-team/cdk8s-plus/pull/473)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)