### PR TITLE
feat: container lifecycle hooks (#484)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -3231,6 +3231,58 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
+### ContainerLifecycle <a name="org.cdk8s.plus20.ContainerLifecycle"></a>
+
+Container lifecycle properties.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus20.ContainerLifecycle;
+
+ContainerLifecycle.builder()
+//  .postStart(Handler)
+//  .preStop(Handler)
+    .build();
+```
+
+##### `postStart`<sup>Optional</sup> <a name="org.cdk8s.plus20.ContainerLifecycle.property.postStart"></a>
+
+```java
+public Handler getPostStart();
+```
+
+- *Type:* [`org.cdk8s.plus20.Handler`](#org.cdk8s.plus20.Handler)
+- *Default:* No post start handler.
+
+This hook is executed immediately after a container is created.
+
+However,
+there is no guarantee that the hook will execute before the container ENTRYPOINT.
+
+---
+
+##### `preStop`<sup>Optional</sup> <a name="org.cdk8s.plus20.ContainerLifecycle.property.preStop"></a>
+
+```java
+public Handler getPreStop();
+```
+
+- *Type:* [`org.cdk8s.plus20.Handler`](#org.cdk8s.plus20.Handler)
+- *Default:* No pre stop handler.
+
+This hook is called immediately before a container is terminated due to an API request or management event such as a liveness/startup probe failure, preemption, resource contention and others.
+
+A call to the PreStop hook fails if the container is already in a terminated or completed state
+and the hook must complete before the TERM signal to stop the container can be sent.
+The Pod's termination grace period countdown begins before the PreStop hook is executed,
+so regardless of the outcome of the handler, the container will eventually terminate
+within the Pod's termination grace period. No parameters are passed to the handler.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+
+---
+
 ### ContainerProps <a name="org.cdk8s.plus20.ContainerProps"></a>
 
 Properties for creating a container.
@@ -3246,6 +3298,7 @@ ContainerProps.builder()
 //  .command(java.util.List<java.lang.String>)
 //  .env(java.util.Map<java.lang.String, EnvValue>)
 //  .imagePullPolicy(ImagePullPolicy)
+//  .lifecycle(ContainerLifecycle)
 //  .liveness(Probe)
 //  .name(java.lang.String)
 //  .port(java.lang.Number)
@@ -3336,6 +3389,18 @@ public ImagePullPolicy getImagePullPolicy();
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="org.cdk8s.plus20.ContainerProps.property.lifecycle"></a>
+
+```java
+public ContainerLifecycle getLifecycle();
+```
+
+- *Type:* [`org.cdk8s.plus20.ContainerLifecycle`](#org.cdk8s.plus20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -4263,6 +4328,74 @@ public IngressV1Beta1 getIngress();
 - *Default:* An ingress will be automatically created.
 
 The ingress to add rules to.
+
+---
+
+### HandlerFromHttpGetOptions <a name="org.cdk8s.plus20.HandlerFromHttpGetOptions"></a>
+
+Options for `Handler.fromHttpGet`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus20.HandlerFromHttpGetOptions;
+
+HandlerFromHttpGetOptions.builder()
+//  .port(java.lang.Number)
+    .build();
+```
+
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus20.HandlerFromHttpGetOptions.property.port"></a>
+
+```java
+public java.lang.Number getPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* defaults to `container.port`.
+
+The TCP port to use when sending the GET request.
+
+---
+
+### HandlerFromTcpSocketOptions <a name="org.cdk8s.plus20.HandlerFromTcpSocketOptions"></a>
+
+Options for `Handler.fromTcpSocket`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus20.HandlerFromTcpSocketOptions;
+
+HandlerFromTcpSocketOptions.builder()
+//  .host(java.lang.String)
+//  .port(java.lang.Number)
+    .build();
+```
+
+##### `host`<sup>Optional</sup> <a name="org.cdk8s.plus20.HandlerFromTcpSocketOptions.property.host"></a>
+
+```java
+public java.lang.String getHost();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* defaults to the pod IP
+
+The host name to connect to on the container.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="org.cdk8s.plus20.HandlerFromTcpSocketOptions.property.port"></a>
+
+```java
+public java.lang.Number getPort();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* defaults to `container.port`.
+
+The TCP port to connect to on the container.
 
 ---
 
@@ -6918,6 +7051,7 @@ Container.Builder.create()
 //  .command(java.util.List<java.lang.String>)
 //  .env(java.util.Map<java.lang.String, EnvValue>)
 //  .imagePullPolicy(ImagePullPolicy)
+//  .lifecycle(ContainerLifecycle)
 //  .liveness(Probe)
 //  .name(java.lang.String)
 //  .port(java.lang.Number)
@@ -6988,6 +7122,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="org.cdk8s.plus20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`org.cdk8s.plus20.ContainerLifecycle`](#org.cdk8s.plus20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -7635,6 +7777,73 @@ public java.lang.Object getValueFrom();
 ---
 
 
+### Handler <a name="org.cdk8s.plus20.Handler"></a>
+
+Defines a specific action that should be taken.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `fromCommand` <a name="org.cdk8s.plus20.Handler.fromCommand"></a>
+
+```java
+import org.cdk8s.plus20.Handler;
+
+Handler.fromCommand(java.util.List<java.lang.String> command)
+```
+
+###### `command`<sup>Required</sup> <a name="org.cdk8s.plus20.Handler.parameter.command"></a>
+
+- *Type:* java.util.List<`java.lang.String`>
+
+The command to execute.
+
+---
+
+##### `fromHttpGet` <a name="org.cdk8s.plus20.Handler.fromHttpGet"></a>
+
+```java
+import org.cdk8s.plus20.Handler;
+
+Handler.fromHttpGet(java.lang.String path)
+Handler.fromHttpGet(java.lang.String path, HandlerFromHttpGetOptions options)
+```
+
+###### `path`<sup>Required</sup> <a name="org.cdk8s.plus20.Handler.parameter.path"></a>
+
+- *Type:* `java.lang.String`
+
+The URL path to hit.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.Handler.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus20.HandlerFromHttpGetOptions`](#org.cdk8s.plus20.HandlerFromHttpGetOptions)
+
+Options.
+
+---
+
+##### `fromTcpSocket` <a name="org.cdk8s.plus20.Handler.fromTcpSocket"></a>
+
+```java
+import org.cdk8s.plus20.Handler;
+
+Handler.fromTcpSocket()
+Handler.fromTcpSocket(HandlerFromTcpSocketOptions options)
+```
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.Handler.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus20.HandlerFromTcpSocketOptions`](#org.cdk8s.plus20.HandlerFromTcpSocketOptions)
+
+Options.
+
+---
+
+
+
 ### IngressV1Beta1Backend <a name="org.cdk8s.plus20.IngressV1Beta1Backend"></a>
 
 The backend for an ingress path.
@@ -8220,14 +8429,6 @@ Provides read/write access to the underlying pod metadata of the resource.
 ### Probe <a name="org.cdk8s.plus20.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
-
-#### Initializers <a name="org.cdk8s.plus20.Probe.Initializer"></a>
-
-```java
-import org.cdk8s.plus20.Probe;
-
-new Probe();
-```
 
 
 #### Static Functions <a name="Static Functions"></a>

--- a/docs/python.md
+++ b/docs/python.md
@@ -501,6 +501,7 @@ def add_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -571,6 +572,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -707,6 +716,7 @@ def add_init_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -777,6 +787,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -1695,6 +1713,7 @@ def add_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -1765,6 +1784,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -1901,6 +1928,7 @@ def add_init_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -1971,6 +1999,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -2385,6 +2421,7 @@ def add_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -2455,6 +2492,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -2591,6 +2636,7 @@ def add_init_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -2661,6 +2707,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -3917,6 +3971,7 @@ def add_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -3987,6 +4042,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -4123,6 +4186,7 @@ def add_init_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -4193,6 +4257,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -4972,6 +5044,58 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
+### ContainerLifecycle <a name="cdk8s_plus_20.ContainerLifecycle"></a>
+
+Container lifecycle properties.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.ContainerLifecycle(
+  post_start: Handler = None,
+  pre_stop: Handler = None
+)
+```
+
+##### `post_start`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerLifecycle.property.post_start"></a>
+
+```python
+post_start: Handler
+```
+
+- *Type:* [`cdk8s_plus_20.Handler`](#cdk8s_plus_20.Handler)
+- *Default:* No post start handler.
+
+This hook is executed immediately after a container is created.
+
+However,
+there is no guarantee that the hook will execute before the container ENTRYPOINT.
+
+---
+
+##### `pre_stop`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerLifecycle.property.pre_stop"></a>
+
+```python
+pre_stop: Handler
+```
+
+- *Type:* [`cdk8s_plus_20.Handler`](#cdk8s_plus_20.Handler)
+- *Default:* No pre stop handler.
+
+This hook is called immediately before a container is terminated due to an API request or management event such as a liveness/startup probe failure, preemption, resource contention and others.
+
+A call to the PreStop hook fails if the container is already in a terminated or completed state
+and the hook must complete before the TERM signal to stop the container can be sent.
+The Pod's termination grace period countdown begins before the PreStop hook is executed,
+so regardless of the outcome of the handler, the container will eventually terminate
+within the Pod's termination grace period. No parameters are passed to the handler.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+
+---
+
 ### ContainerProps <a name="cdk8s_plus_20.ContainerProps"></a>
 
 Properties for creating a container.
@@ -4987,6 +5111,7 @@ cdk8s_plus_20.ContainerProps(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -5077,6 +5202,18 @@ image_pull_policy: ImagePullPolicy
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.property.lifecycle"></a>
+
+```python
+lifecycle: ContainerLifecycle
+```
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -6004,6 +6141,74 @@ ingress: IngressV1Beta1
 - *Default:* An ingress will be automatically created.
 
 The ingress to add rules to.
+
+---
+
+### HandlerFromHttpGetOptions <a name="cdk8s_plus_20.HandlerFromHttpGetOptions"></a>
+
+Options for `Handler.fromHttpGet`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.HandlerFromHttpGetOptions(
+  port: typing.Union[int, float] = None
+)
+```
+
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.HandlerFromHttpGetOptions.property.port"></a>
+
+```python
+port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* defaults to `container.port`.
+
+The TCP port to use when sending the GET request.
+
+---
+
+### HandlerFromTcpSocketOptions <a name="cdk8s_plus_20.HandlerFromTcpSocketOptions"></a>
+
+Options for `Handler.fromTcpSocket`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.HandlerFromTcpSocketOptions(
+  host: str = None,
+  port: typing.Union[int, float] = None
+)
+```
+
+##### `host`<sup>Optional</sup> <a name="cdk8s_plus_20.HandlerFromTcpSocketOptions.property.host"></a>
+
+```python
+host: str
+```
+
+- *Type:* `str`
+- *Default:* defaults to the pod IP
+
+The host name to connect to on the container.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.HandlerFromTcpSocketOptions.property.port"></a>
+
+```python
+port: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* defaults to `container.port`.
+
+The TCP port to connect to on the container.
 
 ---
 
@@ -8659,6 +8864,7 @@ cdk8s_plus_20.Container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -8729,6 +8935,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -9477,6 +9691,90 @@ value_from: typing.Any
 ---
 
 
+### Handler <a name="cdk8s_plus_20.Handler"></a>
+
+Defines a specific action that should be taken.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `from_command` <a name="cdk8s_plus_20.Handler.from_command"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.Handler.from_command(
+  command: typing.List[str]
+)
+```
+
+###### `command`<sup>Required</sup> <a name="cdk8s_plus_20.Handler.parameter.command"></a>
+
+- *Type:* typing.List[`str`]
+
+The command to execute.
+
+---
+
+##### `from_http_get` <a name="cdk8s_plus_20.Handler.from_http_get"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.Handler.from_http_get(
+  path: str,
+  port: typing.Union[int, float] = None
+)
+```
+
+###### `path`<sup>Required</sup> <a name="cdk8s_plus_20.Handler.parameter.path"></a>
+
+- *Type:* `str`
+
+The URL path to hit.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.HandlerFromHttpGetOptions.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* defaults to `container.port`.
+
+The TCP port to use when sending the GET request.
+
+---
+
+##### `from_tcp_socket` <a name="cdk8s_plus_20.Handler.from_tcp_socket"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.Handler.from_tcp_socket(
+  host: str = None,
+  port: typing.Union[int, float] = None
+)
+```
+
+###### `host`<sup>Optional</sup> <a name="cdk8s_plus_20.HandlerFromTcpSocketOptions.parameter.host"></a>
+
+- *Type:* `str`
+- *Default:* defaults to the pod IP
+
+The host name to connect to on the container.
+
+---
+
+###### `port`<sup>Optional</sup> <a name="cdk8s_plus_20.HandlerFromTcpSocketOptions.parameter.port"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* defaults to `container.port`.
+
+The TCP port to connect to on the container.
+
+---
+
+
+
 ### IngressV1Beta1Backend <a name="cdk8s_plus_20.IngressV1Beta1Backend"></a>
 
 The backend for an ingress path.
@@ -9793,6 +10091,7 @@ def add_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -9863,6 +10162,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -9999,6 +10306,7 @@ def add_init_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -10069,6 +10377,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -10425,14 +10741,6 @@ Provides read/write access to the underlying pod metadata of the resource.
 ### Probe <a name="cdk8s_plus_20.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
-
-#### Initializers <a name="cdk8s_plus_20.Probe.Initializer"></a>
-
-```python
-import cdk8s_plus_20
-
-cdk8s_plus_20.Probe()
-```
 
 
 #### Static Functions <a name="Static Functions"></a>
@@ -11005,6 +11313,7 @@ def add_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -11075,6 +11384,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -11186,6 +11503,7 @@ def add_init_container(
   command: typing.List[str] = None,
   env: typing.Mapping[EnvValue] = None,
   image_pull_policy: ImagePullPolicy = None,
+  lifecycle: ContainerLifecycle = None,
   liveness: Probe = None,
   name: str = None,
   port: typing.Union[int, float] = None,
@@ -11256,6 +11574,14 @@ Cannot be updated.
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+###### `lifecycle`<sup>Optional</sup> <a name="cdk8s_plus_20.ContainerProps.parameter.lifecycle"></a>
+
+- *Type:* [`cdk8s_plus_20.ContainerLifecycle`](#cdk8s_plus_20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2345,6 +2345,55 @@ Specify whether the ConfigMap or its keys must be defined.
 
 ---
 
+### ContainerLifecycle <a name="cdk8s-plus-20.ContainerLifecycle"></a>
+
+Container lifecycle properties.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { ContainerLifecycle } from 'cdk8s-plus-20'
+
+const containerLifecycle: ContainerLifecycle = { ... }
+```
+
+##### `postStart`<sup>Optional</sup> <a name="cdk8s-plus-20.ContainerLifecycle.property.postStart"></a>
+
+```typescript
+public readonly postStart: Handler;
+```
+
+- *Type:* [`cdk8s-plus-20.Handler`](#cdk8s-plus-20.Handler)
+- *Default:* No post start handler.
+
+This hook is executed immediately after a container is created.
+
+However,
+there is no guarantee that the hook will execute before the container ENTRYPOINT.
+
+---
+
+##### `preStop`<sup>Optional</sup> <a name="cdk8s-plus-20.ContainerLifecycle.property.preStop"></a>
+
+```typescript
+public readonly preStop: Handler;
+```
+
+- *Type:* [`cdk8s-plus-20.Handler`](#cdk8s-plus-20.Handler)
+- *Default:* No pre stop handler.
+
+This hook is called immediately before a container is terminated due to an API request or management event such as a liveness/startup probe failure, preemption, resource contention and others.
+
+A call to the PreStop hook fails if the container is already in a terminated or completed state
+and the hook must complete before the TERM signal to stop the container can be sent.
+The Pod's termination grace period countdown begins before the PreStop hook is executed,
+so regardless of the outcome of the handler, the container will eventually terminate
+within the Pod's termination grace period. No parameters are passed to the handler.
+
+> https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+
+---
+
 ### ContainerProps <a name="cdk8s-plus-20.ContainerProps"></a>
 
 Properties for creating a container.
@@ -2435,6 +2484,18 @@ public readonly imagePullPolicy: ImagePullPolicy;
 - *Default:* ImagePullPolicy.ALWAYS
 
 Image pull policy for this container.
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="cdk8s-plus-20.ContainerProps.property.lifecycle"></a>
+
+```typescript
+public readonly lifecycle: ContainerLifecycle;
+```
+
+- *Type:* [`cdk8s-plus-20.ContainerLifecycle`](#cdk8s-plus-20.ContainerLifecycle)
+
+Describes actions that the management system should take in response to container lifecycle events.
 
 ---
 
@@ -3308,6 +3369,69 @@ public readonly ingress: IngressV1Beta1;
 - *Default:* An ingress will be automatically created.
 
 The ingress to add rules to.
+
+---
+
+### HandlerFromHttpGetOptions <a name="cdk8s-plus-20.HandlerFromHttpGetOptions"></a>
+
+Options for `Handler.fromHttpGet`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { HandlerFromHttpGetOptions } from 'cdk8s-plus-20'
+
+const handlerFromHttpGetOptions: HandlerFromHttpGetOptions = { ... }
+```
+
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-20.HandlerFromHttpGetOptions.property.port"></a>
+
+```typescript
+public readonly port: number;
+```
+
+- *Type:* `number`
+- *Default:* defaults to `container.port`.
+
+The TCP port to use when sending the GET request.
+
+---
+
+### HandlerFromTcpSocketOptions <a name="cdk8s-plus-20.HandlerFromTcpSocketOptions"></a>
+
+Options for `Handler.fromTcpSocket`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { HandlerFromTcpSocketOptions } from 'cdk8s-plus-20'
+
+const handlerFromTcpSocketOptions: HandlerFromTcpSocketOptions = { ... }
+```
+
+##### `host`<sup>Optional</sup> <a name="cdk8s-plus-20.HandlerFromTcpSocketOptions.property.host"></a>
+
+```typescript
+public readonly host: string;
+```
+
+- *Type:* `string`
+- *Default:* defaults to the pod IP
+
+The host name to connect to on the container.
+
+---
+
+##### `port`<sup>Optional</sup> <a name="cdk8s-plus-20.HandlerFromTcpSocketOptions.property.port"></a>
+
+```typescript
+public readonly port: number;
+```
+
+- *Type:* `number`
+- *Default:* defaults to `container.port`.
+
+The TCP port to connect to on the container.
 
 ---
 
@@ -6287,6 +6411,71 @@ public readonly valueFrom: any;
 ---
 
 
+### Handler <a name="cdk8s-plus-20.Handler"></a>
+
+Defines a specific action that should be taken.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `fromCommand` <a name="cdk8s-plus-20.Handler.fromCommand"></a>
+
+```typescript
+import { Handler } from 'cdk8s-plus-20'
+
+Handler.fromCommand(command: string[])
+```
+
+###### `command`<sup>Required</sup> <a name="cdk8s-plus-20.Handler.parameter.command"></a>
+
+- *Type:* `string`[]
+
+The command to execute.
+
+---
+
+##### `fromHttpGet` <a name="cdk8s-plus-20.Handler.fromHttpGet"></a>
+
+```typescript
+import { Handler } from 'cdk8s-plus-20'
+
+Handler.fromHttpGet(path: string, options?: HandlerFromHttpGetOptions)
+```
+
+###### `path`<sup>Required</sup> <a name="cdk8s-plus-20.Handler.parameter.path"></a>
+
+- *Type:* `string`
+
+The URL path to hit.
+
+---
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.Handler.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-20.HandlerFromHttpGetOptions`](#cdk8s-plus-20.HandlerFromHttpGetOptions)
+
+Options.
+
+---
+
+##### `fromTcpSocket` <a name="cdk8s-plus-20.Handler.fromTcpSocket"></a>
+
+```typescript
+import { Handler } from 'cdk8s-plus-20'
+
+Handler.fromTcpSocket(options?: HandlerFromTcpSocketOptions)
+```
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.Handler.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-20.HandlerFromTcpSocketOptions`](#cdk8s-plus-20.HandlerFromTcpSocketOptions)
+
+Options.
+
+---
+
+
+
 ### IngressV1Beta1Backend <a name="cdk8s-plus-20.IngressV1Beta1Backend"></a>
 
 The backend for an ingress path.
@@ -6605,14 +6794,6 @@ Provides read/write access to the underlying pod metadata of the resource.
 ### Probe <a name="cdk8s-plus-20.Probe"></a>
 
 Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
-
-#### Initializers <a name="cdk8s-plus-20.Probe.Initializer"></a>
-
-```typescript
-import { Probe } from 'cdk8s-plus-20'
-
-new Probe()
-```
 
 
 #### Static Functions <a name="Static Functions"></a>

--- a/src/_action.ts
+++ b/src/_action.ts
@@ -1,0 +1,29 @@
+import { Container } from './container';
+import * as k8s from './imports/k8s';
+
+/**
+ * Utility class to implement the conversion between our API and the k8s action
+ * structure. Used both for probes and handlers.
+ *
+ * @internal
+ */
+export class Action {
+
+  public static fromTcpSocket(container: Container, options: { port?: number; host?: string } = {}): k8s.TcpSocketAction {
+    return {
+      port: k8s.IntOrString.fromNumber(options.port ?? container.port ?? 80),
+      host: options.host,
+    };
+  }
+
+  public static fromCommand(command: string[]): k8s.ExecAction {
+    return { command };
+  }
+
+  public static fromHttpGet(container: Container, path: string, options: { port?: number } = { }): k8s.HttpGetAction {
+    return {
+      path,
+      port: k8s.IntOrString.fromNumber(options.port ?? container.port ?? 80),
+    };
+  }
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,5 +1,6 @@
 import { Size } from 'cdk8s';
 import { IConfigMap } from './config-map';
+import { Handler } from './handler';
 import * as k8s from './imports/k8s';
 import type { ResourceRequirements } from './imports/k8s';
 import { Probe } from './probe';
@@ -381,6 +382,37 @@ export enum ImagePullPolicy {
    */
   NEVER = 'Never',
 }
+
+/**
+ * Container lifecycle properties.
+ */
+export interface ContainerLifecycle {
+
+  /**
+   * This hook is executed immediately after a container is created. However,
+   * there is no guarantee that the hook will execute before the container ENTRYPOINT.
+   *
+   * @default - No post start handler.
+   */
+  readonly postStart?: Handler;
+
+  /**
+   * This hook is called immediately before a container is terminated due to an API request or management
+   * event such as a liveness/startup probe failure, preemption, resource contention and others.
+   * A call to the PreStop hook fails if the container is already in a terminated or completed state
+   * and the hook must complete before the TERM signal to stop the container can be sent.
+   * The Pod's termination grace period countdown begins before the PreStop hook is executed,
+   * so regardless of the outcome of the handler, the container will eventually terminate
+   * within the Pod's termination grace period. No parameters are passed to the handler.
+   *
+   * @see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+   *
+   * @default - No pre stop handler.
+   */
+  readonly preStop?: Handler;
+
+}
+
 /**
  * Properties for creating a container.
  */
@@ -480,6 +512,11 @@ export interface ContainerProps {
   readonly startup?: Probe;
 
   /**
+   * Describes actions that the management system should take in response to container lifecycle events.
+   */
+  readonly lifecycle?: ContainerLifecycle;
+
+  /**
    * Compute resources (CPU and memory requests and limits) required by the container
    * @see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
    */
@@ -551,6 +588,7 @@ export class Container {
   private readonly _readiness?: Probe;
   private readonly _liveness?: Probe;
   private readonly _startup?: Probe;
+  private readonly _lifecycle?: ContainerLifecycle;
 
   constructor(props: ContainerProps) {
     if (props instanceof Container) {
@@ -566,6 +604,7 @@ export class Container {
     this._readiness = props.readiness;
     this._liveness = props.liveness;
     this._startup = props.startup;
+    this._lifecycle = props.lifecycle;
     this.resources = props.resources;
     this.workingDir = props.workingDir;
     this.mounts = props.volumeMounts ?? [];
@@ -691,6 +730,10 @@ export class Container {
       readinessProbe: this._readiness?._toKube(this),
       livenessProbe: this._liveness?._toKube(this),
       startupProbe: this._startup?._toKube(this),
+      lifecycle: this._lifecycle ? {
+        postStart: this._lifecycle.postStart?._toKube(this),
+        preStop: this._lifecycle.preStop?._toKube(this),
+      } : undefined,
       resources: resourceRequirements,
       securityContext: this.securityContext._toKube(),
     };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,0 +1,89 @@
+import { Action } from './_action';
+import { Container } from './container';
+import * as k8s from './imports/k8s';
+
+/**
+ * Options for `Handler.fromTcpSocket`.
+ */
+export interface HandlerFromTcpSocketOptions {
+  /**
+   * The TCP port to connect to on the container.
+   *
+   * @default - defaults to `container.port`.
+   */
+  readonly port?: number;
+
+  /**
+   * The host name to connect to on the container.
+   *
+   * @default - defaults to the pod IP
+   */
+  readonly host?: string;
+
+}
+
+/**
+ * Options for `Handler.fromHttpGet`.
+ */
+export interface HandlerFromHttpGetOptions {
+
+  /**
+   * The TCP port to use when sending the GET request.
+   *
+   * @default - defaults to `container.port`.
+   */
+  readonly port?: number;
+
+}
+
+/**
+ * Defines a specific action that should be taken.
+ */
+export class Handler {
+
+  /**
+   * Defines a handler based on an HTTP GET request to the IP address of the container.
+   *
+   * @param path The URL path to hit
+   * @param options Options
+   */
+  public static fromHttpGet(path: string, options: HandlerFromHttpGetOptions = {}): Handler {
+    return new Handler(undefined, undefined, { path, ...options });
+  }
+
+  /**
+   * Defines a handler based on a command which is executed within the container.
+   *
+   * @param command The command to execute
+   */
+  public static fromCommand(command: string[]): Handler {
+    return new Handler(undefined, { command }, undefined);
+  }
+
+  /**
+   * Defines a handler based opening a connection to a TCP socket on the container.
+   *
+   * @param options Options
+   */
+  public static fromTcpSocket(options: HandlerFromTcpSocketOptions = {}): Handler {
+    return new Handler(options, undefined, undefined);
+  }
+
+  private constructor(
+    private readonly tcpSocketOptions?: HandlerFromTcpSocketOptions,
+    private readonly commandOptions?: { command: string[] },
+    private readonly httpGetOptions?: { path: string } & HandlerFromHttpGetOptions) {}
+
+  /**
+   * @internal
+   */
+  public _toKube(container: Container): k8s.Handler {
+
+    const exec = this.commandOptions ? Action.fromCommand(this.commandOptions.command) : undefined;
+    const httpGet = this.httpGetOptions ? Action.fromHttpGet(container, this.httpGetOptions.path, this.httpGetOptions) : undefined;
+    const tcpSocket = this.tcpSocketOptions ? Action.fromTcpSocket(container, this.tcpSocketOptions) : undefined;
+
+    return { exec, httpGet, tcpSocket };
+  }
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export * from './statefulset';
 export * from './volume';
 export * from './ingress-v1beta1';
 export * from './probe';
+export * from './handler';

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -1,7 +1,7 @@
 import * as cdk8s from 'cdk8s';
 import { Size } from 'cdk8s';
 import * as kplus from '../src';
-import { Container, Cpu } from '../src';
+import { Container, Cpu, Handler } from '../src';
 import * as k8s from '../src/imports/k8s';
 
 describe('EnvValue', () => {
@@ -395,3 +395,32 @@ test('custom security context', () => {
   expect(container.securityContext.group).toEqual(2000);
 
 });
+
+test('can configure a postStart lifecycle hook', () => {
+
+  const container = new Container({
+    image: 'image',
+    lifecycle: {
+      postStart: Handler.fromCommand(['hello']),
+    },
+  });
+
+  const spec = container._toKube();
+  expect(spec.lifecycle!.postStart).toEqual({ exec: { command: ['hello'] } });
+
+});
+
+test('can configure a preStop lifecycle hook', () => {
+
+  const container = new Container({
+    image: 'image',
+    lifecycle: {
+      preStop: Handler.fromCommand(['hello']),
+    },
+  });
+
+  const spec = container._toKube();
+  expect(spec.lifecycle!.preStop).toEqual({ exec: { command: ['hello'] } });
+
+});
+

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -1,0 +1,20 @@
+import { Container, Handler } from '../src';
+import { IntOrString } from '../src/imports/k8s';
+
+test('fromCommand', () => {
+  const container = new Container({ image: 'image' });
+  const handler = Handler.fromCommand(['hello']);
+  expect(handler._toKube(container).exec).toEqual({ command: ['hello'] });
+});
+
+test('fromHttpGet', () => {
+  const container = new Container({ image: 'image' });
+  const handler = Handler.fromHttpGet('/path');
+  expect(handler._toKube(container).httpGet).toEqual({ path: '/path', port: IntOrString.fromNumber(80) });
+});
+
+test('fromTcpSocket', () => {
+  const container = new Container({ image: 'image' });
+  const handler = Handler.fromTcpSocket({ port: 8888 });
+  expect(handler._toKube(container).tcpSocket).toEqual({ port: IntOrString.fromNumber(8888) });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [feat: container lifecycle hooks (#484)](https://github.com/cdk8s-team/cdk8s-plus/pull/484)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)