### PR TITLE
feat(pv): directly mount to container (#491)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -2052,7 +2052,7 @@ TTL before the job is deleted after it is finished.
 
 ### PersistentVolume <a name="org.cdk8s.plus21.PersistentVolume"></a>
 
-- *Implements:* [`org.cdk8s.plus21.IPersistentVolume`](#org.cdk8s.plus21.IPersistentVolume)
+- *Implements:* [`org.cdk8s.plus21.IPersistentVolume`](#org.cdk8s.plus21.IPersistentVolume), [`org.cdk8s.plus21.IStorage`](#org.cdk8s.plus21.IStorage)
 
 A PersistentVolume (PV) is a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using Storage Classes.
 
@@ -2178,6 +2178,12 @@ Defines what type of volume is required by the claim.
 ---
 
 #### Methods <a name="Methods"></a>
+
+##### `asVolume` <a name="org.cdk8s.plus21.PersistentVolume.asVolume"></a>
+
+```java
+public asVolume()
+```
 
 ##### `bind` <a name="org.cdk8s.plus21.PersistentVolume.bind"></a>
 
@@ -9375,8 +9381,8 @@ The variable value.
 ##### `mount` <a name="org.cdk8s.plus21.Container.mount"></a>
 
 ```java
-public mount(java.lang.String path, Volume volume)
-public mount(java.lang.String path, Volume volume, MountOptions options)
+public mount(java.lang.String path, IStorage storage)
+public mount(java.lang.String path, IStorage storage, MountOptions options)
 ```
 
 ###### `path`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.path"></a>
@@ -9387,11 +9393,11 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.volume"></a>
+###### `storage`<sup>Required</sup> <a name="org.cdk8s.plus21.Container.parameter.storage"></a>
 
-- *Type:* [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume)
+- *Type:* [`org.cdk8s.plus21.IStorage`](#org.cdk8s.plus21.IStorage)
 
-The volume to mount.
+The storage to mount.
 
 ---
 
@@ -10620,6 +10626,8 @@ Options.
 
 ### Volume <a name="org.cdk8s.plus21.Volume"></a>
 
+- *Implements:* [`org.cdk8s.plus21.IStorage`](#org.cdk8s.plus21.IStorage)
+
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
 Docker also has a concept of volumes, though it is somewhat looser and less
@@ -10651,6 +10659,13 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
+#### Methods <a name="Methods"></a>
+
+##### `asVolume` <a name="org.cdk8s.plus21.Volume.asVolume"></a>
+
+```java
+public asVolume()
+```
 
 #### Static Functions <a name="Static Functions"></a>
 
@@ -10699,27 +10714,6 @@ Volume.fromEmptyDir(java.lang.String name, EmptyDirVolumeOptions options)
 - *Type:* [`org.cdk8s.plus21.EmptyDirVolumeOptions`](#org.cdk8s.plus21.EmptyDirVolumeOptions)
 
 Additional options.
-
----
-
-##### `fromPersistentVolume` <a name="org.cdk8s.plus21.Volume.fromPersistentVolume"></a>
-
-```java
-import org.cdk8s.plus21.Volume;
-
-Volume.fromPersistentVolume(PersistentVolume pv)
-Volume.fromPersistentVolume(PersistentVolume pv, PersistentVolumeClaimVolumeOptions options)
-```
-
-###### `pv`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.pv"></a>
-
-- *Type:* [`org.cdk8s.plus21.PersistentVolume`](#org.cdk8s.plus21.PersistentVolume)
-
----
-
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Volume.parameter.options"></a>
-
-- *Type:* [`org.cdk8s.plus21.PersistentVolumeClaimVolumeOptions`](#org.cdk8s.plus21.PersistentVolumeClaimVolumeOptions)
 
 ---
 
@@ -11154,6 +11148,21 @@ public java.lang.String getName();
 The Kubernetes name of this resource.
 
 ---
+
+### IStorage <a name="org.cdk8s.plus21.IStorage"></a>
+
+- *Implemented By:* [`org.cdk8s.plus21.AwsElasticBlockStorePersistentVolume`](#org.cdk8s.plus21.AwsElasticBlockStorePersistentVolume), [`org.cdk8s.plus21.AzureDiskPersistentVolume`](#org.cdk8s.plus21.AzureDiskPersistentVolume), [`org.cdk8s.plus21.GCEPersistentDiskPersistentVolume`](#org.cdk8s.plus21.GCEPersistentDiskPersistentVolume), [`org.cdk8s.plus21.PersistentVolume`](#org.cdk8s.plus21.PersistentVolume), [`org.cdk8s.plus21.Volume`](#org.cdk8s.plus21.Volume), [`org.cdk8s.plus21.IStorage`](#org.cdk8s.plus21.IStorage)
+
+Represents a piece of storage in the cluster.
+
+#### Methods <a name="Methods"></a>
+
+##### `asVolume` <a name="org.cdk8s.plus21.IStorage.asVolume"></a>
+
+```java
+public asVolume()
+```
+
 
 ## Enums <a name="Enums"></a>
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -2987,7 +2987,7 @@ TTL before the job is deleted after it is finished.
 
 ### PersistentVolume <a name="cdk8s_plus_21.PersistentVolume"></a>
 
-- *Implements:* [`cdk8s_plus_21.IPersistentVolume`](#cdk8s_plus_21.IPersistentVolume)
+- *Implements:* [`cdk8s_plus_21.IPersistentVolume`](#cdk8s_plus_21.IPersistentVolume), [`cdk8s_plus_21.IStorage`](#cdk8s_plus_21.IStorage)
 
 A PersistentVolume (PV) is a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using Storage Classes.
 
@@ -3115,6 +3115,12 @@ Defines what type of volume is required by the claim.
 ---
 
 #### Methods <a name="Methods"></a>
+
+##### `as_volume` <a name="cdk8s_plus_21.PersistentVolume.as_volume"></a>
+
+```python
+def as_volume()
+```
 
 ##### `bind` <a name="cdk8s_plus_21.PersistentVolume.bind"></a>
 
@@ -11211,7 +11217,7 @@ The variable value.
 ```python
 def mount(
   path: str,
-  volume: Volume,
+  storage: IStorage,
   propagation: MountPropagation = None,
   read_only: bool = None,
   sub_path: str = None,
@@ -11227,11 +11233,11 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.volume"></a>
+###### `storage`<sup>Required</sup> <a name="cdk8s_plus_21.Container.parameter.storage"></a>
 
-- *Type:* [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume)
+- *Type:* [`cdk8s_plus_21.IStorage`](#cdk8s_plus_21.IStorage)
 
-The volume to mount.
+The storage to mount.
 
 ---
 
@@ -13144,6 +13150,8 @@ The TCP port to connect to on the container.
 
 ### Volume <a name="cdk8s_plus_21.Volume"></a>
 
+- *Implements:* [`cdk8s_plus_21.IStorage`](#cdk8s_plus_21.IStorage)
+
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
 Docker also has a concept of volumes, though it is somewhat looser and less
@@ -13175,6 +13183,13 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
+#### Methods <a name="Methods"></a>
+
+##### `as_volume` <a name="cdk8s_plus_21.Volume.as_volume"></a>
+
+```python
+def as_volume()
+```
 
 #### Static Functions <a name="Static Functions"></a>
 
@@ -13293,42 +13308,6 @@ The size
 limit is also applicable for memory medium. The maximum usage on memory
 medium EmptyDir would be the minimum value between the SizeLimit specified
 here and the sum of memory limits of all containers in a pod.
-
----
-
-##### `from_persistent_volume` <a name="cdk8s_plus_21.Volume.from_persistent_volume"></a>
-
-```python
-import cdk8s_plus_21
-
-cdk8s_plus_21.Volume.from_persistent_volume(
-  pv: PersistentVolume,
-  name: str = None,
-  read_only: bool = None
-)
-```
-
-###### `pv`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.pv"></a>
-
-- *Type:* [`cdk8s_plus_21.PersistentVolume`](#cdk8s_plus_21.PersistentVolume)
-
----
-
-###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.PersistentVolumeClaimVolumeOptions.parameter.name"></a>
-
-- *Type:* `str`
-- *Default:* Derived from the PVC name.
-
-The volume name.
-
----
-
-###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.PersistentVolumeClaimVolumeOptions.parameter.read_only"></a>
-
-- *Type:* `bool`
-- *Default:* false
-
-Will force the ReadOnly setting in VolumeMounts.
 
 ---
 
@@ -14178,6 +14157,21 @@ name: str
 The Kubernetes name of this resource.
 
 ---
+
+### IStorage <a name="cdk8s_plus_21.IStorage"></a>
+
+- *Implemented By:* [`cdk8s_plus_21.AwsElasticBlockStorePersistentVolume`](#cdk8s_plus_21.AwsElasticBlockStorePersistentVolume), [`cdk8s_plus_21.AzureDiskPersistentVolume`](#cdk8s_plus_21.AzureDiskPersistentVolume), [`cdk8s_plus_21.GCEPersistentDiskPersistentVolume`](#cdk8s_plus_21.GCEPersistentDiskPersistentVolume), [`cdk8s_plus_21.PersistentVolume`](#cdk8s_plus_21.PersistentVolume), [`cdk8s_plus_21.Volume`](#cdk8s_plus_21.Volume), [`cdk8s_plus_21.IStorage`](#cdk8s_plus_21.IStorage)
+
+Represents a piece of storage in the cluster.
+
+#### Methods <a name="Methods"></a>
+
+##### `as_volume` <a name="cdk8s_plus_21.IStorage.as_volume"></a>
+
+```python
+def as_volume()
+```
+
 
 ## Enums <a name="Enums"></a>
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1206,7 +1206,7 @@ TTL before the job is deleted after it is finished.
 
 ### PersistentVolume <a name="cdk8s-plus-21.PersistentVolume"></a>
 
-- *Implements:* [`cdk8s-plus-21.IPersistentVolume`](#cdk8s-plus-21.IPersistentVolume)
+- *Implements:* [`cdk8s-plus-21.IPersistentVolume`](#cdk8s-plus-21.IPersistentVolume), [`cdk8s-plus-21.IStorage`](#cdk8s-plus-21.IStorage)
 
 A PersistentVolume (PV) is a piece of storage in the cluster that has been provisioned by an administrator or dynamically provisioned using Storage Classes.
 
@@ -1243,6 +1243,12 @@ new PersistentVolume(scope: Construct, id: string, props?: PersistentVolumeProps
 ---
 
 #### Methods <a name="Methods"></a>
+
+##### `asVolume` <a name="cdk8s-plus-21.PersistentVolume.asVolume"></a>
+
+```typescript
+public asVolume()
+```
 
 ##### `bind` <a name="cdk8s-plus-21.PersistentVolume.bind"></a>
 
@@ -7408,7 +7414,7 @@ The variable value.
 ##### `mount` <a name="cdk8s-plus-21.Container.mount"></a>
 
 ```typescript
-public mount(path: string, volume: Volume, options?: MountOptions)
+public mount(path: string, storage: IStorage, options?: MountOptions)
 ```
 
 ###### `path`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.path"></a>
@@ -7419,11 +7425,11 @@ The desired path in the container.
 
 ---
 
-###### `volume`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.volume"></a>
+###### `storage`<sup>Required</sup> <a name="cdk8s-plus-21.Container.parameter.storage"></a>
 
-- *Type:* [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume)
+- *Type:* [`cdk8s-plus-21.IStorage`](#cdk8s-plus-21.IStorage)
 
-The volume to mount.
+The storage to mount.
 
 ---
 
@@ -8325,6 +8331,8 @@ Options.
 
 ### Volume <a name="cdk8s-plus-21.Volume"></a>
 
+- *Implements:* [`cdk8s-plus-21.IStorage`](#cdk8s-plus-21.IStorage)
+
 Volume represents a named volume in a pod that may be accessed by any container in the pod.
 
 Docker also has a concept of volumes, though it is somewhat looser and less
@@ -8356,6 +8364,13 @@ image and volumes. The Docker image is at the root of the filesystem
 hierarchy, and any volumes are mounted at the specified paths within the
 image. Volumes can not mount onto other volumes
 
+#### Methods <a name="Methods"></a>
+
+##### `asVolume` <a name="cdk8s-plus-21.Volume.asVolume"></a>
+
+```typescript
+public asVolume()
+```
 
 #### Static Functions <a name="Static Functions"></a>
 
@@ -8402,26 +8417,6 @@ Volume.fromEmptyDir(name: string, options?: EmptyDirVolumeOptions)
 - *Type:* [`cdk8s-plus-21.EmptyDirVolumeOptions`](#cdk8s-plus-21.EmptyDirVolumeOptions)
 
 Additional options.
-
----
-
-##### `fromPersistentVolume` <a name="cdk8s-plus-21.Volume.fromPersistentVolume"></a>
-
-```typescript
-import { Volume } from 'cdk8s-plus-21'
-
-Volume.fromPersistentVolume(pv: PersistentVolume, options?: PersistentVolumeClaimVolumeOptions)
-```
-
-###### `pv`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.pv"></a>
-
-- *Type:* [`cdk8s-plus-21.PersistentVolume`](#cdk8s-plus-21.PersistentVolume)
-
----
-
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Volume.parameter.options"></a>
-
-- *Type:* [`cdk8s-plus-21.PersistentVolumeClaimVolumeOptions`](#cdk8s-plus-21.PersistentVolumeClaimVolumeOptions)
 
 ---
 
@@ -8854,6 +8849,21 @@ public readonly name: string;
 The Kubernetes name of this resource.
 
 ---
+
+### IStorage <a name="cdk8s-plus-21.IStorage"></a>
+
+- *Implemented By:* [`cdk8s-plus-21.AwsElasticBlockStorePersistentVolume`](#cdk8s-plus-21.AwsElasticBlockStorePersistentVolume), [`cdk8s-plus-21.AzureDiskPersistentVolume`](#cdk8s-plus-21.AzureDiskPersistentVolume), [`cdk8s-plus-21.GCEPersistentDiskPersistentVolume`](#cdk8s-plus-21.GCEPersistentDiskPersistentVolume), [`cdk8s-plus-21.PersistentVolume`](#cdk8s-plus-21.PersistentVolume), [`cdk8s-plus-21.Volume`](#cdk8s-plus-21.Volume), [`cdk8s-plus-21.IStorage`](#cdk8s-plus-21.IStorage)
+
+Represents a piece of storage in the cluster.
+
+#### Methods <a name="Methods"></a>
+
+##### `asVolume` <a name="cdk8s-plus-21.IStorage.asVolume"></a>
+
+```typescript
+public asVolume()
+```
+
 
 ## Enums <a name="Enums"></a>
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -5,7 +5,7 @@ import * as k8s from './imports/k8s';
 import type { ResourceRequirements } from './imports/k8s';
 import { Probe } from './probe';
 import { SecretValue } from './secret';
-import { Volume } from './volume';
+import { IStorage, Volume } from './volume';
 
 /**
  * Properties for `ContainerSecurityContext`
@@ -656,10 +656,10 @@ export class Container {
    * Every pod that is configured to use this container will autmoatically have access to the volume.
    *
    * @param path - The desired path in the container.
-   * @param volume - The volume to mount.
+   * @param storage - The storage to mount.
    */
-  public mount(path: string, volume: Volume, options: MountOptions = { }) {
-    this.mounts.push({ path, volume, ...options });
+  public mount(path: string, storage: IStorage, options: MountOptions = { }) {
+    this.mounts.push({ path, volume: storage.asVolume(), ...options });
   }
 
   /**

--- a/src/pv.ts
+++ b/src/pv.ts
@@ -4,6 +4,7 @@ import { Construct } from 'constructs';
 import { IResource, Resource, ResourceProps } from './base';
 import * as k8s from './imports/k8s';
 import { IPersistentVolumeClaim, PersistentVolumeClaim, PersistentVolumeMode, PersistentVolumeAccessMode } from './pvc';
+import { IStorage, Volume } from './volume';
 
 /**
  * Contract of a `PersistentVolumeClaim`.
@@ -84,7 +85,7 @@ export interface PersistentVolumeProps extends ResourceProps {
  * implementation of the storage, be that NFS, iSCSI, or a
  * cloud-provider-specific storage system.
  */
-export class PersistentVolume extends Resource implements IPersistentVolume {
+export class PersistentVolume extends Resource implements IPersistentVolume, IStorage {
 
   /**
    * Imports a pv from the cluster as a reference.
@@ -204,6 +205,11 @@ export class PersistentVolume extends Resource implements IPersistentVolume {
       throw new Error(`Cannot bind volume '${this.name}' to claim '${pvc.name}' since it is already bound to claim '${this._claim.name}'`);
     }
     this._claim = pvc;
+  }
+
+  public asVolume(): Volume {
+    const claim = this.reserve();
+    return Volume.fromPersistentVolumeClaim(claim);
   }
 
   /**

--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Container can mount container to a pv 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "containers": Array [
+        Object {
+          "env": Array [],
+          "image": "image",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "ports": Array [],
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+          "volumeMounts": Array [
+            Object {
+              "mountPath": "/path/to/mount",
+              "name": "pvc-pvc-test-pv-c8b2a2c6",
+            },
+          ],
+        },
+      ],
+      "hostAliases": Array [],
+      "initContainers": Array [],
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+        "sysctls": Array [],
+      },
+      "volumes": Array [
+        Object {
+          "name": "pvc-pvc-test-pv-c8b2a2c6",
+          "persistentVolumeClaim": Object {
+            "claimName": "pvc-test-pv-c8b2a2c6",
+            "readOnly": false,
+          },
+        },
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "PersistentVolume",
+    "metadata": Object {
+      "name": "test-pv-c8b2a2c6",
+    },
+    "spec": Object {
+      "awsElasticBlockStore": Object {
+        "fsType": "ext4",
+        "readOnly": false,
+        "volumeID": "vol",
+      },
+      "claimRef": Object {
+        "name": "pvc-test-pv-c8b2a2c6",
+      },
+      "persistentVolumeReclaimPolicy": "Retain",
+      "volumeMode": "Filesystem",
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "PersistentVolumeClaim",
+    "metadata": Object {
+      "name": "pvc-test-pv-c8b2a2c6",
+    },
+    "spec": Object {
+      "volumeMode": "Filesystem",
+      "volumeName": "test-pv-c8b2a2c6",
+    },
+  },
+]
+`;

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -1,5 +1,5 @@
 import * as cdk8s from 'cdk8s';
-import { Size } from 'cdk8s';
+import { Size, Testing } from 'cdk8s';
 import * as kplus from '../src';
 import { Container, Cpu, Handler } from '../src';
 import * as k8s from '../src/imports/k8s';
@@ -237,6 +237,20 @@ describe('Container', () => {
     };
 
     expect(container._toKube().volumeMounts).toEqual([expected]);
+  });
+
+  test('can mount container to a pv', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod');
+
+    const volume = new kplus.AwsElasticBlockStorePersistentVolume(chart, 'PV', { volumeId: 'vol' });
+
+    const container = pod.addContainer({ image: 'image' });
+    container.mount('/path/to/mount', volume);
+
+    const resources = Testing.synth(chart);
+    expect(resources).toMatchSnapshot();
   });
 
   test('mount options', () => {

--- a/test/volume.test.ts
+++ b/test/volume.test.ts
@@ -1,6 +1,5 @@
 import { Testing, Size } from 'cdk8s';
 import { Volume, ConfigMap, EmptyDirMedium, Secret, PersistentVolumeClaim } from '../src';
-import { AzureDiskPersistentVolume } from '../src/pv';
 
 describe('fromSecret', () => {
   test('minimal definition', () => {
@@ -305,44 +304,6 @@ describe('fromPersistentVolumeClaim', () => {
       name: volume.name,
       persistentVolumeClaim: {
         claimName: pvc.name,
-        readOnly: true,
-      },
-    });
-  });
-
-});
-
-describe('fromPersistentVolume', () => {
-
-  test('defaults', () => {
-
-    const chart = Testing.chart();
-
-    const pv = new AzureDiskPersistentVolume(chart, 'pv', { diskName: 'name', diskUri: 'uri' });
-    const volume = Volume.fromPersistentVolume(pv);
-
-    expect(volume.name).toEqual(pv.name);
-    expect(volume._toKube()).toEqual({
-      name: volume.name,
-      persistentVolumeClaim: {
-        claimName: `pvc-${pv.name}`,
-        readOnly: false,
-      },
-    });
-  });
-
-  test('custom', () => {
-
-    const chart = Testing.chart();
-
-    const pv = new AzureDiskPersistentVolume(chart, 'pv', { diskName: 'name', diskUri: 'uri' });
-    const volume = Volume.fromPersistentVolume(pv, { name: 'custom', readOnly: true });
-
-    expect(volume.name).toEqual('custom');
-    expect(volume._toKube()).toEqual({
-      name: volume.name,
-      persistentVolumeClaim: {
-        claimName: `pvc-${pv.name}`,
         readOnly: true,
       },
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [feat(pv): directly mount to container (#491)](https://github.com/cdk8s-team/cdk8s-plus/pull/491)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)