### PR TITLE
feat(volume): azure, gce and aws volumes (#499)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -4330,6 +4330,85 @@ Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
 
 ---
 
+### AwsElasticBlockStoreVolumeOptions <a name="org.cdk8s.plus21.AwsElasticBlockStoreVolumeOptions"></a>
+
+Options of `Volume.fromAwsElasticBlockStore`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.AwsElasticBlockStoreVolumeOptions;
+
+AwsElasticBlockStoreVolumeOptions.builder()
+//  .fsType(java.lang.String)
+//  .name(java.lang.String)
+//  .partition(java.lang.Number)
+//  .readOnly(java.lang.Boolean)
+    .build();
+```
+
+##### `fsType`<sup>Optional</sup> <a name="org.cdk8s.plus21.AwsElasticBlockStoreVolumeOptions.property.fsType"></a>
+
+```java
+public java.lang.String getFsType();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* 'ext4'
+
+Filesystem type of the volume that you want to mount.
+
+Tip: Ensure that the filesystem type is supported by the host operating system.
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.AwsElasticBlockStoreVolumeOptions.property.name"></a>
+
+```java
+public java.lang.String getName();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `partition`<sup>Optional</sup> <a name="org.cdk8s.plus21.AwsElasticBlockStoreVolumeOptions.property.partition"></a>
+
+```java
+public java.lang.Number getPartition();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* No partition.
+
+The partition in the volume that you want to mount.
+
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+---
+
+##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.AwsElasticBlockStoreVolumeOptions.property.readOnly"></a>
+
+```java
+public java.lang.Boolean getReadOnly();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
 ### AzureDiskPersistentVolumeProps <a name="org.cdk8s.plus21.AzureDiskPersistentVolumeProps"></a>
 
 Properties for `AzureDiskPersistentVolume`.
@@ -4541,6 +4620,91 @@ Kind of disk.
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.AzureDiskPersistentVolumeProps.property.readOnly"></a>
+
+```java
+public java.lang.Boolean getReadOnly();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+Force the ReadOnly setting in VolumeMounts.
+
+---
+
+### AzureDiskVolumeOptions <a name="org.cdk8s.plus21.AzureDiskVolumeOptions"></a>
+
+Options of `Volume.fromAzureDisk`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.AzureDiskVolumeOptions;
+
+AzureDiskVolumeOptions.builder()
+//  .cachingMode(AzureDiskPersistentVolumeCachingMode)
+//  .fsType(java.lang.String)
+//  .kind(AzureDiskPersistentVolumeKind)
+//  .name(java.lang.String)
+//  .readOnly(java.lang.Boolean)
+    .build();
+```
+
+##### `cachingMode`<sup>Optional</sup> <a name="org.cdk8s.plus21.AzureDiskVolumeOptions.property.cachingMode"></a>
+
+```java
+public AzureDiskPersistentVolumeCachingMode getCachingMode();
+```
+
+- *Type:* [`org.cdk8s.plus21.AzureDiskPersistentVolumeCachingMode`](#org.cdk8s.plus21.AzureDiskPersistentVolumeCachingMode)
+- *Default:* AzureDiskPersistentVolumeCachingMode.NONE.
+
+Host Caching mode.
+
+---
+
+##### `fsType`<sup>Optional</sup> <a name="org.cdk8s.plus21.AzureDiskVolumeOptions.property.fsType"></a>
+
+```java
+public java.lang.String getFsType();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* 'ext4'
+
+Filesystem type to mount.
+
+Must be a filesystem type supported by the host operating system.
+
+---
+
+##### `kind`<sup>Optional</sup> <a name="org.cdk8s.plus21.AzureDiskVolumeOptions.property.kind"></a>
+
+```java
+public AzureDiskPersistentVolumeKind getKind();
+```
+
+- *Type:* [`org.cdk8s.plus21.AzureDiskPersistentVolumeKind`](#org.cdk8s.plus21.AzureDiskPersistentVolumeKind)
+- *Default:* AzureDiskPersistentVolumeKind.SHARED
+
+Kind of disk.
+
+---
+
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.AzureDiskVolumeOptions.property.name"></a>
+
+```java
+public java.lang.String getName();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.AzureDiskVolumeOptions.property.readOnly"></a>
 
 ```java
 public java.lang.Boolean getReadOnly();
@@ -6142,6 +6306,85 @@ Similarly, the volume partition for /dev/sda is "0" (or you can leave the proper
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.GCEPersistentDiskPersistentVolumeProps.property.readOnly"></a>
+
+```java
+public java.lang.Boolean getReadOnly();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+### GCEPersistentDiskVolumeOptions <a name="org.cdk8s.plus21.GCEPersistentDiskVolumeOptions"></a>
+
+Options of `Volume.fromGcePersistentDisk`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus21.GCEPersistentDiskVolumeOptions;
+
+GCEPersistentDiskVolumeOptions.builder()
+//  .fsType(java.lang.String)
+//  .name(java.lang.String)
+//  .partition(java.lang.Number)
+//  .readOnly(java.lang.Boolean)
+    .build();
+```
+
+##### `fsType`<sup>Optional</sup> <a name="org.cdk8s.plus21.GCEPersistentDiskVolumeOptions.property.fsType"></a>
+
+```java
+public java.lang.String getFsType();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* 'ext4'
+
+Filesystem type of the volume that you want to mount.
+
+Tip: Ensure that the filesystem type is supported by the host operating system.
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+##### `name`<sup>Optional</sup> <a name="org.cdk8s.plus21.GCEPersistentDiskVolumeOptions.property.name"></a>
+
+```java
+public java.lang.String getName();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `partition`<sup>Optional</sup> <a name="org.cdk8s.plus21.GCEPersistentDiskVolumeOptions.property.partition"></a>
+
+```java
+public java.lang.Number getPartition();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* No partition.
+
+The partition in the volume that you want to mount.
+
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+---
+
+##### `readOnly`<sup>Optional</sup> <a name="org.cdk8s.plus21.GCEPersistentDiskVolumeOptions.property.readOnly"></a>
 
 ```java
 public java.lang.Boolean getReadOnly();
@@ -10669,6 +10912,54 @@ public asVolume()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `fromAwsElasticBlockStore` <a name="org.cdk8s.plus21.Volume.fromAwsElasticBlockStore"></a>
+
+```java
+import org.cdk8s.plus21.Volume;
+
+Volume.fromAwsElasticBlockStore(java.lang.String volumeId)
+Volume.fromAwsElasticBlockStore(java.lang.String volumeId, AwsElasticBlockStoreVolumeOptions options)
+```
+
+###### `volumeId`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.volumeId"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Volume.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus21.AwsElasticBlockStoreVolumeOptions`](#org.cdk8s.plus21.AwsElasticBlockStoreVolumeOptions)
+
+---
+
+##### `fromAzureDisk` <a name="org.cdk8s.plus21.Volume.fromAzureDisk"></a>
+
+```java
+import org.cdk8s.plus21.Volume;
+
+Volume.fromAzureDisk(java.lang.String diskName, java.lang.String diskUri)
+Volume.fromAzureDisk(java.lang.String diskName, java.lang.String diskUri, AzureDiskVolumeOptions options)
+```
+
+###### `diskName`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.diskName"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+###### `diskUri`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.diskUri"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Volume.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus21.AzureDiskVolumeOptions`](#org.cdk8s.plus21.AzureDiskVolumeOptions)
+
+---
+
 ##### `fromConfigMap` <a name="org.cdk8s.plus21.Volume.fromConfigMap"></a>
 
 ```java
@@ -10714,6 +11005,27 @@ Volume.fromEmptyDir(java.lang.String name, EmptyDirVolumeOptions options)
 - *Type:* [`org.cdk8s.plus21.EmptyDirVolumeOptions`](#org.cdk8s.plus21.EmptyDirVolumeOptions)
 
 Additional options.
+
+---
+
+##### `fromGcePersistentDisk` <a name="org.cdk8s.plus21.Volume.fromGcePersistentDisk"></a>
+
+```java
+import org.cdk8s.plus21.Volume;
+
+Volume.fromGcePersistentDisk(java.lang.String pdName)
+Volume.fromGcePersistentDisk(java.lang.String pdName, GCEPersistentDiskVolumeOptions options)
+```
+
+###### `pdName`<sup>Required</sup> <a name="org.cdk8s.plus21.Volume.parameter.pdName"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus21.Volume.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus21.GCEPersistentDiskVolumeOptions`](#org.cdk8s.plus21.GCEPersistentDiskVolumeOptions)
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -6161,6 +6161,85 @@ Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
 
 ---
 
+### AwsElasticBlockStoreVolumeOptions <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions"></a>
+
+Options of `Volume.fromAwsElasticBlockStore`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions(
+  fs_type: str = None,
+  name: str = None,
+  partition: typing.Union[int, float] = None,
+  read_only: bool = None
+)
+```
+
+##### `fs_type`<sup>Optional</sup> <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions.property.fs_type"></a>
+
+```python
+fs_type: str
+```
+
+- *Type:* `str`
+- *Default:* 'ext4'
+
+Filesystem type of the volume that you want to mount.
+
+Tip: Ensure that the filesystem type is supported by the host operating system.
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions.property.name"></a>
+
+```python
+name: str
+```
+
+- *Type:* `str`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `partition`<sup>Optional</sup> <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions.property.partition"></a>
+
+```python
+partition: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No partition.
+
+The partition in the volume that you want to mount.
+
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+---
+
+##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions.property.read_only"></a>
+
+```python
+read_only: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
 ### AzureDiskPersistentVolumeProps <a name="cdk8s_plus_21.AzureDiskPersistentVolumeProps"></a>
 
 Properties for `AzureDiskPersistentVolume`.
@@ -6372,6 +6451,91 @@ Kind of disk.
 ---
 
 ##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskPersistentVolumeProps.property.read_only"></a>
+
+```python
+read_only: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+Force the ReadOnly setting in VolumeMounts.
+
+---
+
+### AzureDiskVolumeOptions <a name="cdk8s_plus_21.AzureDiskVolumeOptions"></a>
+
+Options of `Volume.fromAzureDisk`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.AzureDiskVolumeOptions(
+  caching_mode: AzureDiskPersistentVolumeCachingMode = None,
+  fs_type: str = None,
+  kind: AzureDiskPersistentVolumeKind = None,
+  name: str = None,
+  read_only: bool = None
+)
+```
+
+##### `caching_mode`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.property.caching_mode"></a>
+
+```python
+caching_mode: AzureDiskPersistentVolumeCachingMode
+```
+
+- *Type:* [`cdk8s_plus_21.AzureDiskPersistentVolumeCachingMode`](#cdk8s_plus_21.AzureDiskPersistentVolumeCachingMode)
+- *Default:* AzureDiskPersistentVolumeCachingMode.NONE.
+
+Host Caching mode.
+
+---
+
+##### `fs_type`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.property.fs_type"></a>
+
+```python
+fs_type: str
+```
+
+- *Type:* `str`
+- *Default:* 'ext4'
+
+Filesystem type to mount.
+
+Must be a filesystem type supported by the host operating system.
+
+---
+
+##### `kind`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.property.kind"></a>
+
+```python
+kind: AzureDiskPersistentVolumeKind
+```
+
+- *Type:* [`cdk8s_plus_21.AzureDiskPersistentVolumeKind`](#cdk8s_plus_21.AzureDiskPersistentVolumeKind)
+- *Default:* AzureDiskPersistentVolumeKind.SHARED
+
+Kind of disk.
+
+---
+
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.property.name"></a>
+
+```python
+name: str
+```
+
+- *Type:* `str`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.property.read_only"></a>
 
 ```python
 read_only: bool
@@ -7973,6 +8137,85 @@ Similarly, the volume partition for /dev/sda is "0" (or you can leave the proper
 ---
 
 ##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskPersistentVolumeProps.property.read_only"></a>
+
+```python
+read_only: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+### GCEPersistentDiskVolumeOptions <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions"></a>
+
+Options of `Volume.fromGcePersistentDisk`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.GCEPersistentDiskVolumeOptions(
+  fs_type: str = None,
+  name: str = None,
+  partition: typing.Union[int, float] = None,
+  read_only: bool = None
+)
+```
+
+##### `fs_type`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions.property.fs_type"></a>
+
+```python
+fs_type: str
+```
+
+- *Type:* `str`
+- *Default:* 'ext4'
+
+Filesystem type of the volume that you want to mount.
+
+Tip: Ensure that the filesystem type is supported by the host operating system.
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+##### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions.property.name"></a>
+
+```python
+name: str
+```
+
+- *Type:* `str`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `partition`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions.property.partition"></a>
+
+```python
+partition: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No partition.
+
+The partition in the volume that you want to mount.
+
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+---
+
+##### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions.property.read_only"></a>
 
 ```python
 read_only: bool
@@ -13193,6 +13436,147 @@ def as_volume()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `from_aws_elastic_block_store` <a name="cdk8s_plus_21.Volume.from_aws_elastic_block_store"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.Volume.from_aws_elastic_block_store(
+  volume_id: str,
+  fs_type: str = None,
+  name: str = None,
+  partition: typing.Union[int, float] = None,
+  read_only: bool = None
+)
+```
+
+###### `volume_id`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.volume_id"></a>
+
+- *Type:* `str`
+
+---
+
+###### `fs_type`<sup>Optional</sup> <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions.parameter.fs_type"></a>
+
+- *Type:* `str`
+- *Default:* 'ext4'
+
+Filesystem type of the volume that you want to mount.
+
+Tip: Ensure that the filesystem type is supported by the host operating system.
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+###### `partition`<sup>Optional</sup> <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions.parameter.partition"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No partition.
+
+The partition in the volume that you want to mount.
+
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+---
+
+###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.AwsElasticBlockStoreVolumeOptions.parameter.read_only"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+##### `from_azure_disk` <a name="cdk8s_plus_21.Volume.from_azure_disk"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.Volume.from_azure_disk(
+  disk_name: str,
+  disk_uri: str,
+  caching_mode: AzureDiskPersistentVolumeCachingMode = None,
+  fs_type: str = None,
+  kind: AzureDiskPersistentVolumeKind = None,
+  name: str = None,
+  read_only: bool = None
+)
+```
+
+###### `disk_name`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.disk_name"></a>
+
+- *Type:* `str`
+
+---
+
+###### `disk_uri`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.disk_uri"></a>
+
+- *Type:* `str`
+
+---
+
+###### `caching_mode`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.parameter.caching_mode"></a>
+
+- *Type:* [`cdk8s_plus_21.AzureDiskPersistentVolumeCachingMode`](#cdk8s_plus_21.AzureDiskPersistentVolumeCachingMode)
+- *Default:* AzureDiskPersistentVolumeCachingMode.NONE.
+
+Host Caching mode.
+
+---
+
+###### `fs_type`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.parameter.fs_type"></a>
+
+- *Type:* `str`
+- *Default:* 'ext4'
+
+Filesystem type to mount.
+
+Must be a filesystem type supported by the host operating system.
+
+---
+
+###### `kind`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.parameter.kind"></a>
+
+- *Type:* [`cdk8s_plus_21.AzureDiskPersistentVolumeKind`](#cdk8s_plus_21.AzureDiskPersistentVolumeKind)
+- *Default:* AzureDiskPersistentVolumeKind.SHARED
+
+Kind of disk.
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.AzureDiskVolumeOptions.parameter.read_only"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+Force the ReadOnly setting in VolumeMounts.
+
+---
+
 ##### `from_config_map` <a name="cdk8s_plus_21.Volume.from_config_map"></a>
 
 ```python
@@ -13308,6 +13692,72 @@ The size
 limit is also applicable for memory medium. The maximum usage on memory
 medium EmptyDir would be the minimum value between the SizeLimit specified
 here and the sum of memory limits of all containers in a pod.
+
+---
+
+##### `from_gce_persistent_disk` <a name="cdk8s_plus_21.Volume.from_gce_persistent_disk"></a>
+
+```python
+import cdk8s_plus_21
+
+cdk8s_plus_21.Volume.from_gce_persistent_disk(
+  pd_name: str,
+  fs_type: str = None,
+  name: str = None,
+  partition: typing.Union[int, float] = None,
+  read_only: bool = None
+)
+```
+
+###### `pd_name`<sup>Required</sup> <a name="cdk8s_plus_21.Volume.parameter.pd_name"></a>
+
+- *Type:* `str`
+
+---
+
+###### `fs_type`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions.parameter.fs_type"></a>
+
+- *Type:* `str`
+- *Default:* 'ext4'
+
+Filesystem type of the volume that you want to mount.
+
+Tip: Ensure that the filesystem type is supported by the host operating system.
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+###### `name`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions.parameter.name"></a>
+
+- *Type:* `str`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+###### `partition`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions.parameter.partition"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* No partition.
+
+The partition in the volume that you want to mount.
+
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+---
+
+###### `read_only`<sup>Optional</sup> <a name="cdk8s_plus_21.GCEPersistentDiskVolumeOptions.parameter.read_only"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2853,6 +2853,80 @@ Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
 
 ---
 
+### AwsElasticBlockStoreVolumeOptions <a name="cdk8s-plus-21.AwsElasticBlockStoreVolumeOptions"></a>
+
+Options of `Volume.fromAwsElasticBlockStore`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { AwsElasticBlockStoreVolumeOptions } from 'cdk8s-plus-21'
+
+const awsElasticBlockStoreVolumeOptions: AwsElasticBlockStoreVolumeOptions = { ... }
+```
+
+##### `fsType`<sup>Optional</sup> <a name="cdk8s-plus-21.AwsElasticBlockStoreVolumeOptions.property.fsType"></a>
+
+```typescript
+public readonly fsType: string;
+```
+
+- *Type:* `string`
+- *Default:* 'ext4'
+
+Filesystem type of the volume that you want to mount.
+
+Tip: Ensure that the filesystem type is supported by the host operating system.
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.AwsElasticBlockStoreVolumeOptions.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* `string`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `partition`<sup>Optional</sup> <a name="cdk8s-plus-21.AwsElasticBlockStoreVolumeOptions.property.partition"></a>
+
+```typescript
+public readonly partition: number;
+```
+
+- *Type:* `number`
+- *Default:* No partition.
+
+The partition in the volume that you want to mount.
+
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+---
+
+##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.AwsElasticBlockStoreVolumeOptions.property.readOnly"></a>
+
+```typescript
+public readonly readOnly: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
 ### AzureDiskPersistentVolumeProps <a name="cdk8s-plus-21.AzureDiskPersistentVolumeProps"></a>
 
 Properties for `AzureDiskPersistentVolume`.
@@ -3049,6 +3123,85 @@ Kind of disk.
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.AzureDiskPersistentVolumeProps.property.readOnly"></a>
+
+```typescript
+public readonly readOnly: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+Force the ReadOnly setting in VolumeMounts.
+
+---
+
+### AzureDiskVolumeOptions <a name="cdk8s-plus-21.AzureDiskVolumeOptions"></a>
+
+Options of `Volume.fromAzureDisk`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { AzureDiskVolumeOptions } from 'cdk8s-plus-21'
+
+const azureDiskVolumeOptions: AzureDiskVolumeOptions = { ... }
+```
+
+##### `cachingMode`<sup>Optional</sup> <a name="cdk8s-plus-21.AzureDiskVolumeOptions.property.cachingMode"></a>
+
+```typescript
+public readonly cachingMode: AzureDiskPersistentVolumeCachingMode;
+```
+
+- *Type:* [`cdk8s-plus-21.AzureDiskPersistentVolumeCachingMode`](#cdk8s-plus-21.AzureDiskPersistentVolumeCachingMode)
+- *Default:* AzureDiskPersistentVolumeCachingMode.NONE.
+
+Host Caching mode.
+
+---
+
+##### `fsType`<sup>Optional</sup> <a name="cdk8s-plus-21.AzureDiskVolumeOptions.property.fsType"></a>
+
+```typescript
+public readonly fsType: string;
+```
+
+- *Type:* `string`
+- *Default:* 'ext4'
+
+Filesystem type to mount.
+
+Must be a filesystem type supported by the host operating system.
+
+---
+
+##### `kind`<sup>Optional</sup> <a name="cdk8s-plus-21.AzureDiskVolumeOptions.property.kind"></a>
+
+```typescript
+public readonly kind: AzureDiskPersistentVolumeKind;
+```
+
+- *Type:* [`cdk8s-plus-21.AzureDiskPersistentVolumeKind`](#cdk8s-plus-21.AzureDiskPersistentVolumeKind)
+- *Default:* AzureDiskPersistentVolumeKind.SHARED
+
+Kind of disk.
+
+---
+
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.AzureDiskVolumeOptions.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* `string`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.AzureDiskVolumeOptions.property.readOnly"></a>
 
 ```typescript
 public readonly readOnly: boolean;
@@ -4545,6 +4698,80 @@ Similarly, the volume partition for /dev/sda is "0" (or you can leave the proper
 ---
 
 ##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.GCEPersistentDiskPersistentVolumeProps.property.readOnly"></a>
+
+```typescript
+public readonly readOnly: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+### GCEPersistentDiskVolumeOptions <a name="cdk8s-plus-21.GCEPersistentDiskVolumeOptions"></a>
+
+Options of `Volume.fromGcePersistentDisk`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { GCEPersistentDiskVolumeOptions } from 'cdk8s-plus-21'
+
+const gCEPersistentDiskVolumeOptions: GCEPersistentDiskVolumeOptions = { ... }
+```
+
+##### `fsType`<sup>Optional</sup> <a name="cdk8s-plus-21.GCEPersistentDiskVolumeOptions.property.fsType"></a>
+
+```typescript
+public readonly fsType: string;
+```
+
+- *Type:* `string`
+- *Default:* 'ext4'
+
+Filesystem type of the volume that you want to mount.
+
+Tip: Ensure that the filesystem type is supported by the host operating system.
+
+> https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+---
+
+##### `name`<sup>Optional</sup> <a name="cdk8s-plus-21.GCEPersistentDiskVolumeOptions.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* `string`
+- *Default:* auto-generated
+
+The volume name.
+
+---
+
+##### `partition`<sup>Optional</sup> <a name="cdk8s-plus-21.GCEPersistentDiskVolumeOptions.property.partition"></a>
+
+```typescript
+public readonly partition: number;
+```
+
+- *Type:* `number`
+- *Default:* No partition.
+
+The partition in the volume that you want to mount.
+
+If omitted, the default is to mount by volume name.
+Examples: For volume /dev/sda1, you specify the partition as "1".
+Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+---
+
+##### `readOnly`<sup>Optional</sup> <a name="cdk8s-plus-21.GCEPersistentDiskVolumeOptions.property.readOnly"></a>
 
 ```typescript
 public readonly readOnly: boolean;
@@ -8374,6 +8601,52 @@ public asVolume()
 
 #### Static Functions <a name="Static Functions"></a>
 
+##### `fromAwsElasticBlockStore` <a name="cdk8s-plus-21.Volume.fromAwsElasticBlockStore"></a>
+
+```typescript
+import { Volume } from 'cdk8s-plus-21'
+
+Volume.fromAwsElasticBlockStore(volumeId: string, options?: AwsElasticBlockStoreVolumeOptions)
+```
+
+###### `volumeId`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.volumeId"></a>
+
+- *Type:* `string`
+
+---
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Volume.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-21.AwsElasticBlockStoreVolumeOptions`](#cdk8s-plus-21.AwsElasticBlockStoreVolumeOptions)
+
+---
+
+##### `fromAzureDisk` <a name="cdk8s-plus-21.Volume.fromAzureDisk"></a>
+
+```typescript
+import { Volume } from 'cdk8s-plus-21'
+
+Volume.fromAzureDisk(diskName: string, diskUri: string, options?: AzureDiskVolumeOptions)
+```
+
+###### `diskName`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.diskName"></a>
+
+- *Type:* `string`
+
+---
+
+###### `diskUri`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.diskUri"></a>
+
+- *Type:* `string`
+
+---
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Volume.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-21.AzureDiskVolumeOptions`](#cdk8s-plus-21.AzureDiskVolumeOptions)
+
+---
+
 ##### `fromConfigMap` <a name="cdk8s-plus-21.Volume.fromConfigMap"></a>
 
 ```typescript
@@ -8417,6 +8690,26 @@ Volume.fromEmptyDir(name: string, options?: EmptyDirVolumeOptions)
 - *Type:* [`cdk8s-plus-21.EmptyDirVolumeOptions`](#cdk8s-plus-21.EmptyDirVolumeOptions)
 
 Additional options.
+
+---
+
+##### `fromGcePersistentDisk` <a name="cdk8s-plus-21.Volume.fromGcePersistentDisk"></a>
+
+```typescript
+import { Volume } from 'cdk8s-plus-21'
+
+Volume.fromGcePersistentDisk(pdName: string, options?: GCEPersistentDiskVolumeOptions)
+```
+
+###### `pdName`<sup>Required</sup> <a name="cdk8s-plus-21.Volume.parameter.pdName"></a>
+
+- *Type:* `string`
+
+---
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-21.Volume.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-21.GCEPersistentDiskVolumeOptions`](#cdk8s-plus-21.GCEPersistentDiskVolumeOptions)
 
 ---
 

--- a/src/pv.ts
+++ b/src/pv.ts
@@ -4,7 +4,7 @@ import { Construct } from 'constructs';
 import { IResource, Resource, ResourceProps } from './base';
 import * as k8s from './imports/k8s';
 import { IPersistentVolumeClaim, PersistentVolumeClaim, PersistentVolumeMode, PersistentVolumeAccessMode } from './pvc';
-import { IStorage, Volume } from './volume';
+import { IStorage, Volume, AzureDiskPersistentVolumeCachingMode, AzureDiskPersistentVolumeKind } from './volume';
 
 /**
  * Contract of a `PersistentVolumeClaim`.
@@ -467,48 +467,6 @@ export class AzureDiskPersistentVolume extends PersistentVolume {
       },
     };
   }
-}
-
-/**
- * Azure Disk kinds.
- */
-export enum AzureDiskPersistentVolumeKind {
-
-  /**
-   * Multiple blob disks per storage account.
-   */
-  SHARED = 'Shared',
-
-  /**
-   * Single blob disk per storage account.
-   */
-  DEDICATED = 'Dedicated',
-
-  /**
-   * Azure managed data disk.
-   */
-  MANAGED = 'Managed',
-}
-
-/**
- * Azure disk caching modes.
- */
-export enum AzureDiskPersistentVolumeCachingMode {
-
-  /**
-   * None.
-   */
-  NONE = 'None',
-
-  /**
-   * ReadOnly.
-   */
-  READ_ONLY = 'ReadOnly',
-
-  /**
-   * ReadWrite.
-   */
-  READ_WRITE = 'ReadWrite'
 }
 
 /**

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -49,6 +49,68 @@ export interface IStorage {
  * image. Volumes can not mount onto other volumes
  */
 export class Volume implements IStorage {
+
+  /**
+   * Mounts an Amazon Web Services (AWS) EBS volume into your pod.
+   * Unlike emptyDir, which is erased when a pod is removed, the contents of an EBS volume are
+   * persisted and the volume is unmounted. This means that an EBS volume can be pre-populated with data,
+   * and that data can be shared between pods.
+   *
+   * There are some restrictions when using an awsElasticBlockStore volume:
+   *
+   * - the nodes on which pods are running must be AWS EC2 instances.
+   * - those instances need to be in the same region and availability zone as the EBS volume.
+   * - EBS only supports a single EC2 instance mounting a volume.
+   */
+  public static fromAwsElasticBlockStore(volumeId: string, options: AwsElasticBlockStoreVolumeOptions = {}): Volume {
+    return new Volume(options.name ?? `ebs-${volumeId}`, {
+      awsElasticBlockStore: {
+        volumeId,
+        fsType: options.fsType ?? 'ext4',
+        partition: options.partition,
+        readOnly: options.readOnly ?? false,
+      },
+    });
+  }
+
+  /**
+   * Mounts a Microsoft Azure Data Disk into a pod.
+   */
+  public static fromAzureDisk(diskName: string, diskUri: string, options: AzureDiskVolumeOptions = {}): Volume {
+    return new Volume(options.name ?? `azuredisk-${diskName}`, {
+      azureDisk: {
+        diskName,
+        diskUri,
+        cachingMode: options.cachingMode ?? AzureDiskPersistentVolumeCachingMode.NONE,
+        fsType: options.fsType ?? 'ext4',
+        kind: options.kind ?? AzureDiskPersistentVolumeKind.SHARED,
+        readOnly: options.readOnly ?? false,
+      },
+    });
+  }
+
+  /**
+   * Mounts a Google Compute Engine (GCE) persistent disk (PD) into your Pod.
+   * Unlike emptyDir, which is erased when a pod is removed, the contents of a PD are
+   * preserved and the volume is merely unmounted. This means that a PD can be pre-populated
+   * with data, and that data can be shared between pods.
+   *
+   * There are some restrictions when using a gcePersistentDisk:
+   *
+   * - the nodes on which Pods are running must be GCE VMs
+   * - those VMs need to be in the same GCE project and zone as the persistent disk
+   */
+  public static fromGcePersistentDisk(pdName: string, options: GCEPersistentDiskVolumeOptions = {}): Volume {
+    return new Volume(options.name ?? `gcedisk-${pdName}`, {
+      gcePersistentDisk: {
+        pdName,
+        fsType: options.fsType ?? 'ext4',
+        partition: options.partition,
+        readOnly: options.readOnly ?? false,
+      },
+    });
+  }
+
   /**
    * Populate the volume from a ConfigMap.
    *
@@ -174,6 +236,123 @@ export class Volume implements IStorage {
       ...this.config,
     };
   }
+}
+
+/**
+ * Options of `Volume.fromGcePersistentDisk`.
+ */
+export interface GCEPersistentDiskVolumeOptions {
+  /**
+   * The volume name.
+   *
+   * @default - auto-generated
+   */
+  readonly name?: string;
+
+  /**
+   * Filesystem type of the volume that you want to mount.
+   * Tip: Ensure that the filesystem type is supported by the host operating system.
+   *
+   * @see https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+   * @default 'ext4'
+   */
+  readonly fsType?: string;
+
+  /**
+   * The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+   * Examples: For volume /dev/sda1, you specify the partition as "1".
+   * Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+   *
+   * @default - No partition.
+   */
+  readonly partition?: number;
+
+  /**
+   * Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+   *
+   * @see https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+   * @default false
+   */
+  readonly readOnly?: boolean;
+
+}
+
+/**
+ * Options of `Volume.fromAzureDisk`.
+ */
+export interface AzureDiskVolumeOptions {
+  /**
+   * The volume name.
+   *
+   * @default - auto-generated
+   */
+  readonly name?: string;
+
+  /**
+   * Host Caching mode.
+   *
+   * @default - AzureDiskPersistentVolumeCachingMode.NONE.
+   */
+  readonly cachingMode?: AzureDiskPersistentVolumeCachingMode;
+
+  /**
+   * Filesystem type to mount. Must be a filesystem type supported by the host operating system.
+   *
+   * @default 'ext4'
+   */
+  readonly fsType?: string;
+
+  /**
+   * Kind of disk.
+   *
+   * @default AzureDiskPersistentVolumeKind.SHARED
+   */
+  readonly kind?: AzureDiskPersistentVolumeKind;
+
+  /**
+   * Force the ReadOnly setting in VolumeMounts.
+   *
+   * @default false
+   */
+  readonly readOnly?: boolean;
+}
+
+/**
+ * Options of `Volume.fromAwsElasticBlockStore`.
+ */
+export interface AwsElasticBlockStoreVolumeOptions {
+  /**
+   * The volume name.
+   *
+   * @default - auto-generated
+   */
+  readonly name?: string;
+
+  /**
+   * Filesystem type of the volume that you want to mount.
+   * Tip: Ensure that the filesystem type is supported by the host operating system.
+   *
+   * @see https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+   * @default 'ext4'
+   */
+  readonly fsType?: string;
+
+  /**
+   * The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+   * Examples: For volume /dev/sda1, you specify the partition as "1".
+   * Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+   *
+   * @default - No partition.
+   */
+  readonly partition?: number;
+
+  /**
+   * Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+   *
+   * @see https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+   * @default false
+   */
+  readonly readOnly?: boolean;
 }
 
 /**
@@ -346,4 +525,46 @@ export interface SecretVolumeOptions {
    */
   readonly items?: { [key: string]: PathMapping };
 
+}
+
+/**
+ * Azure Disk kinds.
+ */
+export enum AzureDiskPersistentVolumeKind {
+
+  /**
+   * Multiple blob disks per storage account.
+   */
+  SHARED = 'Shared',
+
+  /**
+   * Single blob disk per storage account.
+   */
+  DEDICATED = 'Dedicated',
+
+  /**
+   * Azure managed data disk.
+   */
+  MANAGED = 'Managed',
+}
+
+/**
+ * Azure disk caching modes.
+ */
+export enum AzureDiskPersistentVolumeCachingMode {
+
+  /**
+   * None.
+   */
+  NONE = 'None',
+
+  /**
+   * ReadOnly.
+   */
+  READ_ONLY = 'ReadOnly',
+
+  /**
+   * ReadWrite.
+   */
+  READ_WRITE = 'ReadWrite'
 }

--- a/test/volume.test.ts
+++ b/test/volume.test.ts
@@ -1,5 +1,5 @@
 import { Testing, Size } from 'cdk8s';
-import { Volume, ConfigMap, EmptyDirMedium, Secret, PersistentVolumeClaim } from '../src';
+import { Volume, ConfigMap, EmptyDirMedium, Secret, PersistentVolumeClaim, AzureDiskPersistentVolumeCachingMode, AzureDiskPersistentVolumeKind } from '../src';
 
 describe('fromSecret', () => {
   test('minimal definition', () => {
@@ -307,6 +307,132 @@ describe('fromPersistentVolumeClaim', () => {
         readOnly: true,
       },
     });
+  });
+
+});
+
+describe('fromAwsElasticBlockStore', () => {
+
+  test('defaults', () => {
+
+    const volume = Volume.fromAwsElasticBlockStore('vol');
+    const spec = volume._toKube();
+    expect(spec).toEqual({
+      name: 'ebs-vol',
+      awsElasticBlockStore: {
+        fsType: 'ext4',
+        readOnly: false,
+        volumeId: 'vol',
+      },
+    });
+
+  });
+
+  test('custom', () => {
+
+    const volume = Volume.fromAwsElasticBlockStore('vol', {
+      fsType: 'fs',
+      name: 'name',
+      partition: 1,
+      readOnly: true,
+    });
+    const spec = volume._toKube();
+    expect(spec).toEqual({
+      name: 'name',
+      awsElasticBlockStore: {
+        fsType: 'fs',
+        readOnly: true,
+        volumeId: 'vol',
+        partition: 1,
+      },
+    });
+
+  });
+
+});
+
+describe('fromGcePersistentDisk', () => {
+
+  test('defaults', () => {
+
+    const volume = Volume.fromGcePersistentDisk('pd');
+    const spec = volume._toKube();
+    expect(spec).toEqual({
+      name: 'gcedisk-pd',
+      gcePersistentDisk: {
+        fsType: 'ext4',
+        pdName: 'pd',
+        readOnly: false,
+      },
+    });
+
+  });
+
+  test('custom', () => {
+
+    const volume = Volume.fromGcePersistentDisk('pd', {
+      fsType: 'fs',
+      name: 'name',
+      partition: 1,
+      readOnly: true,
+    });
+    const spec = volume._toKube();
+    expect(spec).toEqual({
+      name: 'name',
+      gcePersistentDisk: {
+        fsType: 'fs',
+        pdName: 'pd',
+        readOnly: true,
+        partition: 1,
+      },
+    });
+
+  });
+
+});
+
+describe('fromAzureDisk', () => {
+
+  test('defaults', () => {
+
+    const volume = Volume.fromAzureDisk('disk', 'uri');
+    const spec = volume._toKube();
+    expect(spec).toEqual({
+      name: 'azuredisk-disk',
+      azureDisk: {
+        cachingMode: 'None',
+        diskName: 'disk',
+        diskUri: 'uri',
+        fsType: 'ext4',
+        readOnly: false,
+        kind: 'Shared',
+      },
+    });
+
+  });
+
+  test('custom', () => {
+
+    const volume = Volume.fromAzureDisk('disk', 'uri', {
+      cachingMode: AzureDiskPersistentVolumeCachingMode.READ_ONLY,
+      fsType: 'fs',
+      kind: AzureDiskPersistentVolumeKind.DEDICATED,
+      name: 'name',
+      readOnly: true,
+    });
+    const spec = volume._toKube();
+    expect(spec).toEqual({
+      name: 'name',
+      azureDisk: {
+        cachingMode: 'ReadOnly',
+        diskName: 'disk',
+        diskUri: 'uri',
+        fsType: 'fs',
+        readOnly: true,
+        kind: 'Dedicated',
+      },
+    });
+
   });
 
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [feat(volume): azure, gce and aws volumes (#499)](https://github.com/cdk8s-team/cdk8s-plus/pull/499)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)