### PR TITLE
feat(pod): docker registry auth (#516)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -1170,6 +1170,7 @@ import org.cdk8s.plus20.Deployment;
 Deployment.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -1216,7 +1217,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.parameter.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.dockerRegistryAuth"></a>
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -2068,6 +2078,7 @@ import org.cdk8s.plus20.Job;
 Job.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -2115,7 +2126,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.parameter.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.dockerRegistryAuth"></a>
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -2923,6 +2943,7 @@ import org.cdk8s.plus20.Pod;
 Pod.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -2966,7 +2987,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.parameter.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.dockerRegistryAuth"></a>
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -3916,6 +3946,7 @@ import org.cdk8s.plus20.StatefulSet;
 StatefulSet.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -3964,7 +3995,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.parameter.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.dockerRegistryAuth"></a>
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -6037,6 +6077,7 @@ import org.cdk8s.plus20.DeploymentProps;
 DeploymentProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -6079,7 +6120,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.dockerRegistryAuth"></a>
+
+```java
+public DockerConfigSecret getDockerRegistryAuth();
+```
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -7406,6 +7460,7 @@ import org.cdk8s.plus20.JobProps;
 JobProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -7449,7 +7504,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.dockerRegistryAuth"></a>
+
+```java
+public DockerConfigSecret getDockerRegistryAuth();
+```
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -8085,6 +8153,7 @@ import org.cdk8s.plus20.PodProps;
 PodProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -8124,7 +8193,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.dockerRegistryAuth"></a>
+
+```java
+public DockerConfigSecret getDockerRegistryAuth();
+```
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -8345,6 +8427,7 @@ import org.cdk8s.plus20.PodSpecProps;
 
 PodSpecProps.builder()
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -8372,7 +8455,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.dockerRegistryAuth"></a>
+
+```java
+public DockerConfigSecret getDockerRegistryAuth();
+```
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -8490,6 +8586,7 @@ import org.cdk8s.plus20.PodTemplateProps;
 
 PodTemplateProps.builder()
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -8518,7 +8615,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.dockerRegistryAuth"></a>
+
+```java
+public DockerConfigSecret getDockerRegistryAuth();
+```
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -9441,6 +9551,7 @@ import org.cdk8s.plus20.StatefulSetProps;
 StatefulSetProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -9485,7 +9596,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.dockerRegistryAuth"></a>
+
+```java
+public DockerConfigSecret getDockerRegistryAuth();
+```
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -10982,6 +11106,7 @@ import org.cdk8s.plus20.PodSpec;
 
 PodSpec.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -11005,7 +11130,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.parameter.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.dockerRegistryAuth"></a>
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -11205,7 +11339,17 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpec.property.restartPolicy"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpec.property.dockerRegistryAuth"></a>
+
+```java
+public DockerConfigSecret getDockerRegistryAuth();
+```
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+
+---
+
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpec.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
@@ -11243,6 +11387,7 @@ import org.cdk8s.plus20.PodTemplate;
 
 PodTemplate.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -11267,7 +11412,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.parameter.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.dockerRegistryAuth"></a>
+
+- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -780,6 +780,7 @@ import org.cdk8s.plus20.DaemonSet;
 DaemonSet.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -823,6 +824,15 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.DaemonSetProps.parameter.dockerRegistryAuth"></a>
+
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
 
 ---
 
@@ -1217,16 +1227,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.parameter.dockerRegistryAuth"></a>
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -2126,16 +2136,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.parameter.dockerRegistryAuth"></a>
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.parameter.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -2987,16 +2997,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.parameter.dockerRegistryAuth"></a>
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.parameter.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -3995,16 +4005,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.parameter.dockerRegistryAuth"></a>
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -5877,6 +5887,7 @@ import org.cdk8s.plus20.DaemonSetProps;
 DaemonSetProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
 //  .restartPolicy(RestartPolicy)
@@ -5916,6 +5927,19 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.DaemonSetProps.property.dockerRegistryAuth"></a>
+
+```java
+public DockerConfigSecret getDockerRegistryAuth();
+```
+
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
 
 ---
 
@@ -6120,20 +6144,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.property.dockerRegistryAuth"></a>
 
 ```java
 public DockerConfigSecret getDockerRegistryAuth();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -7504,20 +7528,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.property.dockerRegistryAuth"></a>
 
 ```java
 public DockerConfigSecret getDockerRegistryAuth();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.JobProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -8193,20 +8217,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.property.dockerRegistryAuth"></a>
 
 ```java
 public DockerConfigSecret getDockerRegistryAuth();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -8455,20 +8479,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.property.dockerRegistryAuth"></a>
 
 ```java
 public DockerConfigSecret getDockerRegistryAuth();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -8615,20 +8639,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.property.dockerRegistryAuth"></a>
 
 ```java
 public DockerConfigSecret getDockerRegistryAuth();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -9596,20 +9620,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.property.dockerRegistryAuth"></a>
 
 ```java
 public DockerConfigSecret getDockerRegistryAuth();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.property.hostAliases"></a>
 
 ```java
 public java.util.List<HostAlias> getHostAliases();
@@ -11130,16 +11154,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.parameter.dockerRegistryAuth"></a>
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpecProps.parameter.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 
@@ -11339,17 +11363,17 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpec.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpec.property.dockerRegistryAuth"></a>
 
 ```java
 public DockerConfigSecret getDockerRegistryAuth();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpec.property.restartPolicy"></a>
 
 ```java
 public RestartPolicy getRestartPolicy();
@@ -11412,16 +11436,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.parameter.dockerRegistryAuth"></a>
 
-- *Type:* [`org.cdk8s.plus22.DockerConfigSecret`](#org.cdk8s.plus22.DockerConfigSecret)
+- *Type:* [`org.cdk8s.plus20.DockerConfigSecret`](#org.cdk8s.plus20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus22.PodTemplateProps.parameter.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.parameter.hostAliases"></a>
 
 - *Type:* java.util.List<[`org.cdk8s.plus20.HostAlias`](#org.cdk8s.plus20.HostAlias)>
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -860,16 +860,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.DaemonSetProps.parameter.docker_registry_auth"></a>
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.DaemonSetProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -1589,6 +1589,7 @@ cdk8s_plus_20.Deployment(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -1632,6 +1633,15 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.parameter.docker_registry_auth"></a>
+
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
 
 ---
 
@@ -3066,16 +3076,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.parameter.docker_registry_auth"></a>
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -4312,16 +4322,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.parameter.docker_registry_auth"></a>
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -5826,16 +5836,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.parameter.docker_registry_auth"></a>
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -8084,6 +8094,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.DaemonSetProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -8123,6 +8134,19 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.DaemonSetProps.property.docker_registry_auth"></a>
+
+```python
+docker_registry_auth: DockerConfigSecret
+```
+
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
 
 ---
 
@@ -8327,20 +8351,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.property.docker_registry_auth"></a>
 
 ```python
 docker_registry_auth: DockerConfigSecret
 ```
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -9711,20 +9735,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.property.docker_registry_auth"></a>
 
 ```python
 docker_registry_auth: DockerConfigSecret
 ```
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -10400,20 +10424,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.property.docker_registry_auth"></a>
 
 ```python
 docker_registry_auth: DockerConfigSecret
 ```
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -10662,20 +10686,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.property.docker_registry_auth"></a>
 
 ```python
 docker_registry_auth: DockerConfigSecret
 ```
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -10822,20 +10846,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.property.docker_registry_auth"></a>
 
 ```python
 docker_registry_auth: DockerConfigSecret
 ```
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -11803,20 +11827,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.property.docker_registry_auth"></a>
 
 ```python
 docker_registry_auth: DockerConfigSecret
 ```
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -13465,16 +13489,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.parameter.docker_registry_auth"></a>
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -14045,17 +14069,17 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpec.property.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpec.property.docker_registry_auth"></a>
 
 ```python
 docker_registry_auth: DockerConfigSecret
 ```
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpec.property.restart_policy"></a>
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpec.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
@@ -14118,16 +14142,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.docker_registry_auth"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.parameter.docker_registry_auth"></a>
 
-- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Type:* [`cdk8s_plus_20.DockerConfigSecret`](#cdk8s_plus_20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.host_aliases"></a>
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -813,6 +813,7 @@ cdk8s_plus_20.DaemonSet(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -859,7 +860,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.DaemonSetProps.parameter.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.docker_registry_auth"></a>
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -3008,6 +3018,7 @@ cdk8s_plus_20.Job(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -3055,7 +3066,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.parameter.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.docker_registry_auth"></a>
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -4248,6 +4268,7 @@ cdk8s_plus_20.Pod(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -4291,7 +4312,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.parameter.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.docker_registry_auth"></a>
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -5747,6 +5777,7 @@ cdk8s_plus_20.StatefulSet(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -5795,7 +5826,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.parameter.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.docker_registry_auth"></a>
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -8244,6 +8284,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.DeploymentProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -8286,7 +8327,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.property.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.docker_registry_auth"></a>
+
+```python
+docker_registry_auth: DockerConfigSecret
+```
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -9613,6 +9667,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.JobProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -9656,7 +9711,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.property.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.docker_registry_auth"></a>
+
+```python
+docker_registry_auth: DockerConfigSecret
+```
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.JobProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -10292,6 +10360,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.PodProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -10331,7 +10400,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.property.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.docker_registry_auth"></a>
+
+```python
+docker_registry_auth: DockerConfigSecret
+```
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -10552,6 +10634,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodSpecProps(
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -10579,7 +10662,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.property.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.docker_registry_auth"></a>
+
+```python
+docker_registry_auth: DockerConfigSecret
+```
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -10697,6 +10793,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodTemplateProps(
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -10725,7 +10822,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.property.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.docker_registry_auth"></a>
+
+```python
+docker_registry_auth: DockerConfigSecret
+```
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -11648,6 +11758,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.StatefulSetProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -11692,7 +11803,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.property.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.docker_registry_auth"></a>
+
+```python
+docker_registry_auth: DockerConfigSecret
+```
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.host_aliases"></a>
 
 ```python
 host_aliases: typing.List[HostAlias]
@@ -13317,6 +13441,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodSpec(
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -13340,7 +13465,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.parameter.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.docker_registry_auth"></a>
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpecProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 
@@ -13911,7 +14045,17 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpec.property.restart_policy"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpec.property.docker_registry_auth"></a>
+
+```python
+docker_registry_auth: DockerConfigSecret
+```
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+
+---
+
+##### `restart_policy`<sup>Optional</sup> <a name="cdk8s_plus_22.PodSpec.property.restart_policy"></a>
 
 ```python
 restart_policy: RestartPolicy
@@ -13949,6 +14093,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodTemplate(
   containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
   restart_policy: RestartPolicy = None,
@@ -13973,7 +14118,16 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.parameter.host_aliases"></a>
+##### `docker_registry_auth`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.docker_registry_auth"></a>
+
+- *Type:* [`cdk8s_plus_22.DockerConfigSecret`](#cdk8s_plus_22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `host_aliases`<sup>Optional</sup> <a name="cdk8s_plus_22.PodTemplateProps.parameter.host_aliases"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_20.HostAlias`](#cdk8s_plus_20.HostAlias)]
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -4367,7 +4367,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.dockerRegistryAuth"></a>
+
+```typescript
+public readonly dockerRegistryAuth: DockerConfigSecret;
+```
+
+- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -5646,7 +5659,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.JobProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.dockerRegistryAuth"></a>
+
+```typescript
+public readonly dockerRegistryAuth: DockerConfigSecret;
+```
+
+- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -6282,7 +6308,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.PodProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.dockerRegistryAuth"></a>
+
+```typescript
+public readonly dockerRegistryAuth: DockerConfigSecret;
+```
+
+- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -6515,7 +6554,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpecProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.dockerRegistryAuth"></a>
+
+```typescript
+public readonly dockerRegistryAuth: DockerConfigSecret;
+```
+
+- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -6652,7 +6704,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.PodTemplateProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.dockerRegistryAuth"></a>
+
+```typescript
+public readonly dockerRegistryAuth: DockerConfigSecret;
+```
+
+- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -7552,7 +7617,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.StatefulSetProps.property.hostAliases"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.dockerRegistryAuth"></a>
+
+```typescript
+public readonly dockerRegistryAuth: DockerConfigSecret;
+```
+
+- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -8853,7 +8931,17 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpec.property.restartPolicy"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.property.dockerRegistryAuth"></a>
+
+```typescript
+public readonly dockerRegistryAuth: DockerConfigSecret;
+```
+
+- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+
+---
+
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -4179,6 +4179,19 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.DaemonSetProps.property.dockerRegistryAuth"></a>
+
+```typescript
+public readonly dockerRegistryAuth: DockerConfigSecret;
+```
+
+- *Type:* [`cdk8s-plus-20.DockerConfigSecret`](#cdk8s-plus-20.DockerConfigSecret)
+- *Default:* No auth. Images are assumed to be publicly available.
+
+A secret containing docker credentials for authenticating to a registry.
+
+---
+
 ##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.DaemonSetProps.property.hostAliases"></a>
 
 ```typescript
@@ -4367,20 +4380,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentProps.property.dockerRegistryAuth"></a>
 
 ```typescript
 public readonly dockerRegistryAuth: DockerConfigSecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Type:* [`cdk8s-plus-20.DockerConfigSecret`](#cdk8s-plus-20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -5659,20 +5672,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.JobProps.property.dockerRegistryAuth"></a>
 
 ```typescript
 public readonly dockerRegistryAuth: DockerConfigSecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Type:* [`cdk8s-plus-20.DockerConfigSecret`](#cdk8s-plus-20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.JobProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.JobProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -6308,20 +6321,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.PodProps.property.dockerRegistryAuth"></a>
 
 ```typescript
 public readonly dockerRegistryAuth: DockerConfigSecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Type:* [`cdk8s-plus-20.DockerConfigSecret`](#cdk8s-plus-20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.PodProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.PodProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -6554,20 +6567,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpecProps.property.dockerRegistryAuth"></a>
 
 ```typescript
 public readonly dockerRegistryAuth: DockerConfigSecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Type:* [`cdk8s-plus-20.DockerConfigSecret`](#cdk8s-plus-20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpecProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpecProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -6704,20 +6717,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.PodTemplateProps.property.dockerRegistryAuth"></a>
 
 ```typescript
 public readonly dockerRegistryAuth: DockerConfigSecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Type:* [`cdk8s-plus-20.DockerConfigSecret`](#cdk8s-plus-20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.PodTemplateProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.PodTemplateProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -7617,20 +7630,20 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.StatefulSetProps.property.dockerRegistryAuth"></a>
 
 ```typescript
 public readonly dockerRegistryAuth: DockerConfigSecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Type:* [`cdk8s-plus-20.DockerConfigSecret`](#cdk8s-plus-20.DockerConfigSecret)
 - *Default:* No auth. Images are assumed to be publicly available.
 
 A secret containing docker credentials for authenticating to a registry.
 
 ---
 
-##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.hostAliases"></a>
+##### `hostAliases`<sup>Optional</sup> <a name="cdk8s-plus-20.StatefulSetProps.property.hostAliases"></a>
 
 ```typescript
 public readonly hostAliases: HostAlias[];
@@ -8931,17 +8944,17 @@ Use `addVolume` to add volumes.
 
 ---
 
-##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.property.dockerRegistryAuth"></a>
+##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpec.property.dockerRegistryAuth"></a>
 
 ```typescript
 public readonly dockerRegistryAuth: DockerConfigSecret;
 ```
 
-- *Type:* [`cdk8s-plus-22.DockerConfigSecret`](#cdk8s-plus-22.DockerConfigSecret)
+- *Type:* [`cdk8s-plus-20.DockerConfigSecret`](#cdk8s-plus-20.DockerConfigSecret)
 
 ---
 
-##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-22.PodSpec.property.restartPolicy"></a>
+##### `restartPolicy`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpec.property.restartPolicy"></a>
 
 ```typescript
 public readonly restartPolicy: RestartPolicy;

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -3,6 +3,7 @@ import { Construct } from 'constructs';
 import { ResourceProps, Resource } from './base';
 import { Container, ContainerProps } from './container';
 import * as k8s from './imports/k8s';
+import { DockerConfigSecret } from './secret';
 import { IServiceAccount } from './service-account';
 import { Volume } from './volume';
 
@@ -94,6 +95,7 @@ export class PodSpec implements IPodSpec {
   public readonly restartPolicy?: RestartPolicy;
   public readonly serviceAccount?: IServiceAccount;
   public readonly securityContext: PodSecurityContext;
+  public readonly dockerRegistryAuth?: DockerConfigSecret;
 
   private readonly _containers: Container[] = [];
   private readonly _initContainers: Container[] = [];
@@ -104,6 +106,7 @@ export class PodSpec implements IPodSpec {
     this.restartPolicy = props.restartPolicy;
     this.serviceAccount = props.serviceAccount;
     this.securityContext = new PodSecurityContext(props.securityContext);
+    this.dockerRegistryAuth = props.dockerRegistryAuth;
 
     if (props.containers) {
       props.containers.forEach(c => this.addContainer(c));
@@ -234,6 +237,7 @@ export class PodSpec implements IPodSpec {
       initContainers: initContainers,
       hostAliases: this.hostAliases,
       volumes: Array.from(volumes.values()).map(v => v._toKube()),
+      imagePullSecrets: this.dockerRegistryAuth ? [{ name: this.dockerRegistryAuth.name }] : undefined,
     };
 
   }
@@ -434,6 +438,13 @@ export interface PodSpecProps {
    * @schema io.k8s.api.core.v1.HostAlias
    */
   readonly hostAliases?: HostAlias[];
+
+  /**
+   * A secret containing docker credentials for authenticating to a registry.
+   *
+   * @default - No auth. Images are assumed to be publicly available.
+   */
+  readonly dockerRegistryAuth?: DockerConfigSecret;
 
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [feat(pod): docker registry auth (#516)](https://github.com/cdk8s-team/cdk8s-plus/pull/516)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)