### PR TITLE
feat(config-map): immutable maps (#520)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -558,6 +558,7 @@ ConfigMap.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .binaryData(java.util.Map<java.lang.String, java.lang.String>)
 //  .data(java.util.Map<java.lang.String, java.lang.String>)
+//  .immutable(java.lang.Boolean)
     .build();
 ```
 
@@ -608,6 +609,17 @@ stored in Data must not overlap with the keys in the BinaryData field, this
 is enforced during validation process.
 
 You can also add data using `configMap.addData()`.
+
+---
+
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.parameter.immutable"></a>
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
 
 ---
 
@@ -1140,6 +1152,18 @@ public IServiceAccount getServiceAccount();
 - *Type:* [`org.cdk8s.plus20.IServiceAccount`](#org.cdk8s.plus20.IServiceAccount)
 
 The service account used to run this pod.
+
+---
+
+##### `immutable`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+
+Whether or not this config map is immutable.
 
 ---
 
@@ -5309,6 +5333,7 @@ ConfigMapProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .binaryData(java.util.Map<java.lang.String, java.lang.String>)
 //  .data(java.util.Map<java.lang.String, java.lang.String>)
+//  .immutable(java.lang.Boolean)
     .build();
 ```
 
@@ -5362,7 +5387,22 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="org.cdk8s.plus20.ConfigMapVolumeOptions"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+### ConfigMapVolumeOptions <a name="org.cdk8s.plus22.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -612,7 +612,7 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus20.ConfigMapProps.parameter.immutable"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* false
@@ -760,6 +760,18 @@ public java.util.Map<java.lang.String, java.lang.String> getData();
 The data associated with this config map.
 
 Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
+
+---
+
+##### `immutable`<sup>Required</sup> <a name="org.cdk8s.plus20.ConfigMap.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+
+Whether or not this config map is immutable.
 
 ---
 
@@ -1152,18 +1164,6 @@ public IServiceAccount getServiceAccount();
 - *Type:* [`org.cdk8s.plus20.IServiceAccount`](#org.cdk8s.plus20.IServiceAccount)
 
 The service account used to run this pod.
-
----
-
-##### `immutable`<sup>Required</sup> <a name="org.cdk8s.plus22.ConfigMap.property.immutable"></a>
-
-```java
-public java.lang.Boolean getImmutable();
-```
-
-- *Type:* `java.lang.Boolean`
-
-Whether or not this config map is immutable.
 
 ---
 
@@ -5387,7 +5387,7 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.ConfigMapProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus20.ConfigMapProps.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -5402,7 +5402,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-### ConfigMapVolumeOptions <a name="org.cdk8s.plus22.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="org.cdk8s.plus20.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -565,7 +565,8 @@ cdk8s_plus_20.ConfigMap(
   id: str,
   metadata: ApiObjectMetadata = None,
   binary_data: typing.Mapping[str] = None,
-  data: typing.Mapping[str] = None
+  data: typing.Mapping[str] = None,
+  immutable: bool = None
 )
 ```
 
@@ -616,6 +617,17 @@ stored in Data must not overlap with the keys in the BinaryData field, this
 is enforced during validation process.
 
 You can also add data using `configMap.addData()`.
+
+---
+
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.parameter.immutable"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
 
 ---
 
@@ -779,6 +791,18 @@ data: typing.Mapping[str]
 The data associated with this config map.
 
 Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
+
+---
+
+##### `immutable`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+
+Whether or not this config map is immutable.
 
 ---
 
@@ -7515,7 +7539,8 @@ import cdk8s_plus_20
 cdk8s_plus_20.ConfigMapProps(
   metadata: ApiObjectMetadata = None,
   binary_data: typing.Mapping[str] = None,
-  data: typing.Mapping[str] = None
+  data: typing.Mapping[str] = None,
+  immutable: bool = None
 )
 ```
 
@@ -7569,7 +7594,22 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="cdk8s_plus_20.ConfigMapVolumeOptions"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+### ConfigMapVolumeOptions <a name="cdk8s_plus_22.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -620,7 +620,7 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_20.ConfigMapProps.parameter.immutable"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -794,7 +794,7 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 
 ---
 
-##### `immutable`<sup>Required</sup> <a name="cdk8s_plus_22.ConfigMap.property.immutable"></a>
+##### `immutable`<sup>Required</sup> <a name="cdk8s_plus_20.ConfigMap.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -7594,7 +7594,7 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.ConfigMapProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_20.ConfigMapProps.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -7609,7 +7609,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-### ConfigMapVolumeOptions <a name="cdk8s_plus_22.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="cdk8s_plus_20.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -400,6 +400,18 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 
 ---
 
+##### `immutable`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+
+Whether or not this config map is immutable.
+
+---
+
 
 ### DaemonSet <a name="cdk8s-plus-20.DaemonSet"></a>
 
@@ -3657,7 +3669,22 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-### ConfigMapVolumeOptions <a name="cdk8s-plus-20.ConfigMapVolumeOptions"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapProps.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+### ConfigMapVolumeOptions <a name="cdk8s-plus-22.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -400,7 +400,7 @@ Returns an copy. To add data records, use `addData()` or `addBinaryData()`.
 
 ---
 
-##### `immutable`<sup>Required</sup> <a name="cdk8s-plus-22.ConfigMap.property.immutable"></a>
+##### `immutable`<sup>Required</sup> <a name="cdk8s-plus-20.ConfigMap.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -3669,7 +3669,7 @@ You can also add data using `configMap.addData()`.
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.ConfigMapProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-20.ConfigMapProps.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -3684,7 +3684,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-### ConfigMapVolumeOptions <a name="cdk8s-plus-22.ConfigMapVolumeOptions"></a>
+### ConfigMapVolumeOptions <a name="cdk8s-plus-20.ConfigMapVolumeOptions"></a>
 
 Options for the ConfigMap-based volume.
 

--- a/src/config-map.ts
+++ b/src/config-map.ts
@@ -34,6 +34,15 @@ export interface ConfigMapProps extends ResourceProps {
    * You can also add data using `configMap.addData()`.
    */
   readonly data?: { [key: string]: string };
+
+  /**
+   * If set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified).
+   * If not set to true, the field can be modified at any time.
+   *
+   * @default false
+   */
+  readonly immutable?: boolean;
+
 }
 
 /**
@@ -63,15 +72,22 @@ export class ConfigMap extends Resource implements IConfigMap {
   private readonly _binaryData: { [key: string]: string } = { };
   private readonly _data: { [key: string]: string } = { };
 
+  /**
+   * Whether or not this config map is immutable.
+   */
+  public readonly immutable: boolean;
+
   public constructor(scope: Construct, id: string, props: ConfigMapProps = { }) {
     super(scope, id);
 
+    this.immutable = props.immutable ?? false;
     this.apiObject = new k8s.KubeConfigMap(this, 'Resource', {
       metadata: props.metadata,
 
       // we need lazy here because we filter empty
       data: cdk8s.Lazy.any({ produce: () => this.synthesizeData() }),
       binaryData: cdk8s.Lazy.any({ produce: () => this.synthesizeBinaryData() }),
+      immutable: this.immutable,
     });
 
     for (const [k, v] of Object.entries(props.data ?? { })) {
@@ -81,6 +97,7 @@ export class ConfigMap extends Resource implements IConfigMap {
     for (const [k, v] of Object.entries(props.binaryData ?? { })) {
       this.addBinaryData(k, v);
     }
+
   }
 
   /**

--- a/test/__snapshots__/config-map.test.ts.snap
+++ b/test/__snapshots__/config-map.test.ts.snap
@@ -7,6 +7,7 @@ Array [
     "data": Object {
       "file1.txt": "Hello, world!",
     },
+    "immutable": false,
     "kind": "ConfigMap",
     "metadata": Object {
       "name": "test-my-config-map-c8eaefa4",
@@ -23,6 +24,7 @@ Array [
       "prefix.file1.txt": "Hello, world!",
       "prefix.file2.html": "<html>Hey</html>",
     },
+    "immutable": false,
     "kind": "ConfigMap",
     "metadata": Object {
       "name": "test-my-config-map-c8eaefa4",
@@ -39,6 +41,7 @@ Array [
       "file1.txt": "Hello, world!",
       "file2.html": "<html>Hey</html>",
     },
+    "immutable": false,
     "kind": "ConfigMap",
     "metadata": Object {
       "name": "test-my-config-map-c8eaefa4",
@@ -54,6 +57,7 @@ Array [
     "data": Object {
       "file1.txt": "Hello, world!",
     },
+    "immutable": false,
     "kind": "ConfigMap",
     "metadata": Object {
       "name": "test-my-config-map-c8eaefa4",
@@ -70,6 +74,7 @@ Array [
       "file1.txt": "Hello, world!",
       "hey-there": "<html>Hey</html>",
     },
+    "immutable": false,
     "kind": "ConfigMap",
     "metadata": Object {
       "name": "test-my-config-map-c8eaefa4",

--- a/test/config-map.test.ts
+++ b/test/config-map.test.ts
@@ -27,6 +27,7 @@ test('minimal', () => {
       metadata: {
         name: 'test-my-config-map-c8eaefa4',
       },
+      immutable: false,
     },
   ]);
 });
@@ -55,6 +56,7 @@ test('with data', () => {
       metadata: {
         name: 'test-my-config-map-c8eaefa4',
       },
+      immutable: false,
     },
   ]);
 });
@@ -83,6 +85,7 @@ test('with binaryData', () => {
       metadata: {
         name: 'test-my-config-map-c8eaefa4',
       },
+      immutable: false,
     },
   ]);
 });
@@ -117,6 +120,7 @@ test('with binaryData and data', () => {
       metadata: {
         name: 'test-my-config-map-c8eaefa4',
       },
+      immutable: false,
     },
   ]);
 });
@@ -176,6 +180,7 @@ test('addData()/addBinaryDataq() can be used to add data', () => {
       metadata: {
         name: 'test-my-config-map-c8eaefa4',
       },
+      immutable: false,
     },
   ]);
 });
@@ -279,6 +284,7 @@ test('metadata is synthesized', () => {
 Array [
   Object {
     "apiVersion": "v1",
+    "immutable": false,
     "kind": "ConfigMap",
     "metadata": Object {
       "name": "my-name",
@@ -286,4 +292,18 @@ Array [
   },
 ]
 `);
+});
+
+test('can configure an immutable config map', () => {
+
+  const chart = Testing.chart();
+  const cm = new ConfigMap(chart, 'my-config-map', {
+    immutable: true,
+  });
+
+  const spec = Testing.synth(chart)[0];
+
+  expect(cm.immutable).toBeTruthy();
+  expect(spec.immutable).toBeTruthy();
+
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [feat(config-map): immutable maps (#520)](https://github.com/cdk8s-team/cdk8s-plus/pull/520)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)