### PR TITLE
feat(secret): immutable secrets (#522)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -524,7 +524,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.BasicAuthSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.parameter.immutable"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* false
@@ -535,7 +535,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `password`<sup>Required</sup> <a name="org.cdk8s.plus22.BasicAuthSecretProps.parameter.password"></a>
+##### `password`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.parameter.password"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1662,7 +1662,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.DockerConfigSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.parameter.immutable"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* false
@@ -1673,7 +1673,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="org.cdk8s.plus22.DockerConfigSecretProps.parameter.data"></a>
+##### `data`<sup>Required</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.parameter.data"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.Object`>
 
@@ -3399,7 +3399,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.immutable"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* false
@@ -3410,7 +3410,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.stringData"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.String`>
 
@@ -3493,7 +3493,7 @@ The name of the secret to reference.
 
 #### Properties <a name="Properties"></a>
 
-##### `immutable`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.property.immutable"></a>
+##### `immutable`<sup>Required</sup> <a name="org.cdk8s.plus21.Secret.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -3932,7 +3932,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountTokenSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.parameter.immutable"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* false
@@ -3943,7 +3943,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccountTokenSecretProps.parameter.serviceAccount"></a>
+##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.parameter.serviceAccount"></a>
 
 - *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
@@ -3993,7 +3993,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.SshAuthSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.parameter.immutable"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* false
@@ -4004,7 +4004,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus22.SshAuthSecretProps.parameter.sshPrivateKey"></a>
+##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.parameter.sshPrivateKey"></a>
 
 - *Type:* `java.lang.String`
 
@@ -4493,7 +4493,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.TlsSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.TlsSecretProps.parameter.immutable"></a>
 
 - *Type:* `java.lang.Boolean`
 - *Default:* false
@@ -4504,7 +4504,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus22.TlsSecretProps.parameter.tlsCert"></a>
+##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecretProps.parameter.tlsCert"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5287,7 +5287,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.BasicAuthSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -5302,7 +5302,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `password`<sup>Required</sup> <a name="org.cdk8s.plus22.BasicAuthSecretProps.property.password"></a>
+##### `password`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.property.password"></a>
 
 ```java
 public java.lang.String getPassword();
@@ -5421,14 +5421,14 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### CommonSecretProps <a name="org.cdk8s.plus22.CommonSecretProps"></a>
+### CommonSecretProps <a name="org.cdk8s.plus21.CommonSecretProps"></a>
 
 Common properties for `Secret`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.CommonSecretProps;
+import org.cdk8s.plus21.CommonSecretProps;
 
 CommonSecretProps.builder()
 //  .metadata(ApiObjectMetadata)
@@ -5436,7 +5436,7 @@ CommonSecretProps.builder()
     .build();
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommonSecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommonSecretProps.property.metadata"></a>
 
 ```java
 public ApiObjectMetadata getMetadata();
@@ -5448,7 +5448,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommonSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.CommonSecretProps.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -5463,7 +5463,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-### ConfigMapProps <a name="org.cdk8s.plus22.ConfigMapProps"></a>
+### ConfigMapProps <a name="org.cdk8s.plus21.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
@@ -6514,7 +6514,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.DockerConfigSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -6529,7 +6529,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="org.cdk8s.plus22.DockerConfigSecretProps.property.data"></a>
+##### `data`<sup>Required</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.property.data"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.Object> getData();
@@ -9153,7 +9153,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -9168,7 +9168,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.stringData"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getStringData();
@@ -9393,7 +9393,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountTokenSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -9408,7 +9408,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
@@ -9783,7 +9783,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.SshAuthSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -9798,7 +9798,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus22.SshAuthSecretProps.property.sshPrivateKey"></a>
+##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.property.sshPrivateKey"></a>
 
 ```java
 public java.lang.String getSshPrivateKey();
@@ -10242,7 +10242,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.TlsSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus21.TlsSecretProps.property.immutable"></a>
 
 ```java
 public java.lang.Boolean getImmutable();
@@ -10257,7 +10257,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus22.TlsSecretProps.property.tlsCert"></a>
+##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecretProps.property.tlsCert"></a>
 
 ```java
 public java.lang.String getTlsCert();

--- a/docs/java.md
+++ b/docs/java.md
@@ -498,6 +498,7 @@ import org.cdk8s.plus21.BasicAuthSecret;
 
 BasicAuthSecret.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .password(java.lang.String)
     .username(java.lang.String)
     .build();
@@ -523,7 +524,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `password`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.parameter.password"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.BasicAuthSecretProps.parameter.immutable"></a>
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `password`<sup>Required</sup> <a name="org.cdk8s.plus22.BasicAuthSecretProps.parameter.password"></a>
 
 - *Type:* `java.lang.String`
 
@@ -1625,6 +1637,7 @@ import org.cdk8s.plus21.DockerConfigSecret;
 
 DockerConfigSecret.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .data(java.util.Map<java.lang.String, java.lang.Object>)
     .build();
 ```
@@ -1649,7 +1662,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `data`<sup>Required</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.parameter.data"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.DockerConfigSecretProps.parameter.immutable"></a>
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `data`<sup>Required</sup> <a name="org.cdk8s.plus22.DockerConfigSecretProps.parameter.data"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.Object`>
 
@@ -3349,6 +3373,7 @@ import org.cdk8s.plus21.Secret;
 
 Secret.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
 //  .stringData(java.util.Map<java.lang.String, java.lang.String>)
 //  .type(java.lang.String)
     .build();
@@ -3374,7 +3399,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.parameter.stringData"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.immutable"></a>
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.parameter.stringData"></a>
 
 - *Type:* java.util.Map<java.lang.String, `java.lang.String`>
 
@@ -3455,6 +3491,19 @@ The name of the secret to reference.
 
 ---
 
+#### Properties <a name="Properties"></a>
+
+##### `immutable`<sup>Required</sup> <a name="org.cdk8s.plus22.Secret.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+
+Whether or not the secret is immutable.
+
+---
 
 
 ### Service <a name="org.cdk8s.plus21.Service"></a>
@@ -3858,6 +3907,7 @@ import org.cdk8s.plus21.ServiceAccountTokenSecret;
 
 ServiceAccountTokenSecret.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .serviceAccount(IServiceAccount)
     .build();
 ```
@@ -3882,7 +3932,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.parameter.serviceAccount"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountTokenSecretProps.parameter.immutable"></a>
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccountTokenSecretProps.parameter.serviceAccount"></a>
 
 - *Type:* [`org.cdk8s.plus21.IServiceAccount`](#org.cdk8s.plus21.IServiceAccount)
 
@@ -3907,6 +3968,7 @@ import org.cdk8s.plus21.SshAuthSecret;
 
 SshAuthSecret.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .sshPrivateKey(java.lang.String)
     .build();
 ```
@@ -3931,7 +3993,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.parameter.sshPrivateKey"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.SshAuthSecretProps.parameter.immutable"></a>
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus22.SshAuthSecretProps.parameter.sshPrivateKey"></a>
 
 - *Type:* `java.lang.String`
 
@@ -4394,6 +4467,7 @@ import org.cdk8s.plus21.TlsSecret;
 
 TlsSecret.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .tlsCert(java.lang.String)
     .tlsKey(java.lang.String)
     .build();
@@ -4419,7 +4493,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecretProps.parameter.tlsCert"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.TlsSecretProps.parameter.immutable"></a>
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus22.TlsSecretProps.parameter.tlsCert"></a>
 
 - *Type:* `java.lang.String`
 
@@ -5184,6 +5269,7 @@ import org.cdk8s.plus21.BasicAuthSecretProps;
 
 BasicAuthSecretProps.builder()
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .password(java.lang.String)
     .username(java.lang.String)
     .build();
@@ -5201,7 +5287,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `password`<sup>Required</sup> <a name="org.cdk8s.plus21.BasicAuthSecretProps.property.password"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.BasicAuthSecretProps.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `password`<sup>Required</sup> <a name="org.cdk8s.plus22.BasicAuthSecretProps.property.password"></a>
 
 ```java
 public java.lang.String getPassword();
@@ -5320,7 +5421,49 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="org.cdk8s.plus21.ConfigMapProps"></a>
+### CommonSecretProps <a name="org.cdk8s.plus22.CommonSecretProps"></a>
+
+Common properties for `Secret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus22.CommonSecretProps;
+
+CommonSecretProps.builder()
+//  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
+    .build();
+```
+
+##### `metadata`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommonSecretProps.property.metadata"></a>
+
+```java
+public ApiObjectMetadata getMetadata();
+```
+
+- *Type:* [`org.cdk8s.ApiObjectMetadata`](#org.cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.CommonSecretProps.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+### ConfigMapProps <a name="org.cdk8s.plus22.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
@@ -6354,6 +6497,7 @@ import org.cdk8s.plus21.DockerConfigSecretProps;
 
 DockerConfigSecretProps.builder()
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .data(java.util.Map<java.lang.String, java.lang.Object>)
     .build();
 ```
@@ -6370,7 +6514,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `data`<sup>Required</sup> <a name="org.cdk8s.plus21.DockerConfigSecretProps.property.data"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.DockerConfigSecretProps.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `data`<sup>Required</sup> <a name="org.cdk8s.plus22.DockerConfigSecretProps.property.data"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.Object> getData();
@@ -8976,6 +9135,7 @@ import org.cdk8s.plus21.SecretProps;
 
 SecretProps.builder()
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
 //  .stringData(java.util.Map<java.lang.String, java.lang.String>)
 //  .type(java.lang.String)
     .build();
@@ -8993,7 +9153,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus21.SecretProps.property.stringData"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `stringData`<sup>Optional</sup> <a name="org.cdk8s.plus22.SecretProps.property.stringData"></a>
 
 ```java
 public java.util.Map<java.lang.String, java.lang.String> getStringData();
@@ -9201,6 +9376,7 @@ import org.cdk8s.plus21.ServiceAccountTokenSecretProps;
 
 ServiceAccountTokenSecretProps.builder()
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .serviceAccount(IServiceAccount)
     .build();
 ```
@@ -9217,7 +9393,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus21.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.ServiceAccountTokenSecretProps.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `serviceAccount`<sup>Required</sup> <a name="org.cdk8s.plus22.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
 
 ```java
 public IServiceAccount getServiceAccount();
@@ -9575,6 +9766,7 @@ import org.cdk8s.plus21.SshAuthSecretProps;
 
 SshAuthSecretProps.builder()
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .sshPrivateKey(java.lang.String)
     .build();
 ```
@@ -9591,7 +9783,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus21.SshAuthSecretProps.property.sshPrivateKey"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.SshAuthSecretProps.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `sshPrivateKey`<sup>Required</sup> <a name="org.cdk8s.plus22.SshAuthSecretProps.property.sshPrivateKey"></a>
 
 ```java
 public java.lang.String getSshPrivateKey();
@@ -10017,6 +10224,7 @@ import org.cdk8s.plus21.TlsSecretProps;
 
 TlsSecretProps.builder()
 //  .metadata(ApiObjectMetadata)
+//  .immutable(java.lang.Boolean)
     .tlsCert(java.lang.String)
     .tlsKey(java.lang.String)
     .build();
@@ -10034,7 +10242,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus21.TlsSecretProps.property.tlsCert"></a>
+##### `immutable`<sup>Optional</sup> <a name="org.cdk8s.plus22.TlsSecretProps.property.immutable"></a>
+
+```java
+public java.lang.Boolean getImmutable();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `tlsCert`<sup>Required</sup> <a name="org.cdk8s.plus22.TlsSecretProps.property.tlsCert"></a>
 
 ```java
 public java.lang.String getTlsCert();

--- a/docs/python.md
+++ b/docs/python.md
@@ -504,6 +504,7 @@ cdk8s_plus_21.BasicAuthSecret(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   password: str,
   username: str
 )
@@ -529,7 +530,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `password`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.parameter.password"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.BasicAuthSecretProps.parameter.immutable"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `password`<sup>Required</sup> <a name="cdk8s_plus_22.BasicAuthSecretProps.parameter.password"></a>
 
 - *Type:* `str`
 
@@ -1612,17 +1624,8 @@ cdk8s_plus_21.Deployment(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
-  containers: typing.List[ContainerProps] = None,
-  docker_registry_auth: DockerConfigSecret = None,
-  host_aliases: typing.List[HostAlias] = None,
-  init_containers: typing.List[ContainerProps] = None,
-  restart_policy: RestartPolicy = None,
-  security_context: PodSecurityContextProps = None,
-  service_account: IServiceAccount = None,
-  volumes: typing.List[Volume] = None,
-  pod_metadata: ApiObjectMetadata = None,
-  default_selector: bool = None,
-  replicas: typing.Union[int, float] = None
+  immutable: bool = None,
+  data: typing.Mapping[typing.Any]
 )
 ```
 
@@ -1646,7 +1649,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.containers"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.DockerConfigSecretProps.parameter.immutable"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `data`<sup>Required</sup> <a name="cdk8s_plus_22.DockerConfigSecretProps.parameter.data"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
@@ -5049,6 +5063,7 @@ cdk8s_plus_21.Secret(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   string_data: typing.Mapping[str] = None,
   type: str = None
 )
@@ -5074,7 +5089,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.string_data"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.immutable"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.string_data"></a>
 
 - *Type:* typing.Mapping[`str`]
 
@@ -5162,6 +5188,19 @@ The name of the secret to reference.
 
 ---
 
+#### Properties <a name="Properties"></a>
+
+##### `immutable`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+
+Whether or not the secret is immutable.
+
+---
 
 
 ### Service <a name="cdk8s_plus_21.Service"></a>
@@ -5685,6 +5724,7 @@ cdk8s_plus_21.ServiceAccountTokenSecret(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   service_account: IServiceAccount
 )
 ```
@@ -5709,7 +5749,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.parameter.service_account"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountTokenSecretProps.parameter.immutable"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccountTokenSecretProps.parameter.service_account"></a>
 
 - *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
@@ -5736,6 +5787,7 @@ cdk8s_plus_21.SshAuthSecret(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   ssh_private_key: str
 )
 ```
@@ -5760,7 +5812,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.parameter.ssh_private_key"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.SshAuthSecretProps.parameter.immutable"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_22.SshAuthSecretProps.parameter.ssh_private_key"></a>
 
 - *Type:* `str`
 
@@ -6601,6 +6664,7 @@ cdk8s_plus_21.TlsSecret(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   tls_cert: str,
   tls_key: str
 )
@@ -6626,7 +6690,18 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecretProps.parameter.tls_cert"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.TlsSecretProps.parameter.immutable"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_22.TlsSecretProps.parameter.tls_cert"></a>
 
 - *Type:* `str`
 
@@ -7391,6 +7466,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.BasicAuthSecretProps(
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   password: str,
   username: str
 )
@@ -7408,7 +7484,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `password`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.property.password"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.BasicAuthSecretProps.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `password`<sup>Required</sup> <a name="cdk8s_plus_22.BasicAuthSecretProps.property.password"></a>
 
 ```python
 password: str
@@ -7527,7 +7618,49 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="cdk8s_plus_21.ConfigMapProps"></a>
+### CommonSecretProps <a name="cdk8s_plus_22.CommonSecretProps"></a>
+
+Common properties for `Secret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.CommonSecretProps(
+  metadata: ApiObjectMetadata = None,
+  immutable: bool = None
+)
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.CommonSecretProps.property.metadata"></a>
+
+```python
+metadata: ApiObjectMetadata
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.CommonSecretProps.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+### ConfigMapProps <a name="cdk8s_plus_22.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
@@ -8561,6 +8694,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.DockerConfigSecretProps(
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   data: typing.Mapping[typing.Any]
 )
 ```
@@ -8577,7 +8711,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `data`<sup>Required</sup> <a name="cdk8s_plus_21.DockerConfigSecretProps.property.data"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.DockerConfigSecretProps.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `data`<sup>Required</sup> <a name="cdk8s_plus_22.DockerConfigSecretProps.property.data"></a>
 
 ```python
 data: typing.Mapping[typing.Any]
@@ -11183,6 +11332,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.SecretProps(
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   string_data: typing.Mapping[str] = None,
   type: str = None
 )
@@ -11200,7 +11350,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.string_data"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.string_data"></a>
 
 ```python
 string_data: typing.Mapping[str]
@@ -11408,6 +11573,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.ServiceAccountTokenSecretProps(
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   service_account: IServiceAccount
 )
 ```
@@ -11424,7 +11590,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.property.service_account"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountTokenSecretProps.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccountTokenSecretProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
@@ -11782,6 +11963,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.SshAuthSecretProps(
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   ssh_private_key: str
 )
 ```
@@ -11798,7 +11980,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.property.ssh_private_key"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.SshAuthSecretProps.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_22.SshAuthSecretProps.property.ssh_private_key"></a>
 
 ```python
 ssh_private_key: str
@@ -12224,6 +12421,7 @@ import cdk8s_plus_21
 
 cdk8s_plus_21.TlsSecretProps(
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   tls_cert: str,
   tls_key: str
 )
@@ -12241,7 +12439,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecretProps.property.tls_cert"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.TlsSecretProps.property.immutable"></a>
+
+```python
+immutable: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_22.TlsSecretProps.property.tls_cert"></a>
 
 ```python
 tls_cert: str

--- a/docs/python.md
+++ b/docs/python.md
@@ -530,7 +530,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.BasicAuthSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.parameter.immutable"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -541,7 +541,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `password`<sup>Required</sup> <a name="cdk8s_plus_22.BasicAuthSecretProps.parameter.password"></a>
+##### `password`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.parameter.password"></a>
 
 - *Type:* `str`
 
@@ -1624,8 +1624,17 @@ cdk8s_plus_21.Deployment(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
-  immutable: bool = None,
-  data: typing.Mapping[typing.Any]
+  containers: typing.List[ContainerProps] = None,
+  docker_registry_auth: DockerConfigSecret = None,
+  host_aliases: typing.List[HostAlias] = None,
+  init_containers: typing.List[ContainerProps] = None,
+  restart_policy: RestartPolicy = None,
+  security_context: PodSecurityContextProps = None,
+  service_account: IServiceAccount = None,
+  volumes: typing.List[Volume] = None,
+  pod_metadata: ApiObjectMetadata = None,
+  default_selector: bool = None,
+  replicas: typing.Union[int, float] = None
 )
 ```
 
@@ -1649,18 +1658,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.DockerConfigSecretProps.parameter.immutable"></a>
-
-- *Type:* `bool`
-- *Default:* false
-
-If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
-
-If not set to true, the field can be modified at any time.
-
----
-
-##### `data`<sup>Required</sup> <a name="cdk8s_plus_22.DockerConfigSecretProps.parameter.data"></a>
+##### `containers`<sup>Optional</sup> <a name="cdk8s_plus_21.DeploymentProps.parameter.containers"></a>
 
 - *Type:* typing.List[[`cdk8s_plus_21.ContainerProps`](#cdk8s_plus_21.ContainerProps)]
 - *Default:* No containers. Note that a pod spec must include at least one container.
@@ -2527,6 +2525,7 @@ cdk8s_plus_21.DockerConfigSecret(
   scope: Construct,
   id: str,
   metadata: ApiObjectMetadata = None,
+  immutable: bool = None,
   data: typing.Mapping[typing.Any]
 )
 ```
@@ -2548,6 +2547,17 @@ cdk8s_plus_21.DockerConfigSecret(
 - *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
 
 Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.DockerConfigSecretProps.parameter.immutable"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
 
 ---
 
@@ -5089,7 +5099,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.immutable"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -5100,7 +5110,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.parameter.string_data"></a>
+##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.parameter.string_data"></a>
 
 - *Type:* typing.Mapping[`str`]
 
@@ -5190,7 +5200,7 @@ The name of the secret to reference.
 
 #### Properties <a name="Properties"></a>
 
-##### `immutable`<sup>Required</sup> <a name="cdk8s_plus_22.Secret.property.immutable"></a>
+##### `immutable`<sup>Required</sup> <a name="cdk8s_plus_21.Secret.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -5749,7 +5759,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountTokenSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.parameter.immutable"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -5760,7 +5770,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccountTokenSecretProps.parameter.service_account"></a>
+##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.parameter.service_account"></a>
 
 - *Type:* [`cdk8s_plus_21.IServiceAccount`](#cdk8s_plus_21.IServiceAccount)
 
@@ -5812,7 +5822,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.SshAuthSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.parameter.immutable"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -5823,7 +5833,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_22.SshAuthSecretProps.parameter.ssh_private_key"></a>
+##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.parameter.ssh_private_key"></a>
 
 - *Type:* `str`
 
@@ -6690,7 +6700,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.TlsSecretProps.parameter.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.TlsSecretProps.parameter.immutable"></a>
 
 - *Type:* `bool`
 - *Default:* false
@@ -6701,7 +6711,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_22.TlsSecretProps.parameter.tls_cert"></a>
+##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecretProps.parameter.tls_cert"></a>
 
 - *Type:* `str`
 
@@ -7484,7 +7494,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.BasicAuthSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -7499,7 +7509,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `password`<sup>Required</sup> <a name="cdk8s_plus_22.BasicAuthSecretProps.property.password"></a>
+##### `password`<sup>Required</sup> <a name="cdk8s_plus_21.BasicAuthSecretProps.property.password"></a>
 
 ```python
 password: str
@@ -7618,22 +7628,22 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### CommonSecretProps <a name="cdk8s_plus_22.CommonSecretProps"></a>
+### CommonSecretProps <a name="cdk8s_plus_21.CommonSecretProps"></a>
 
 Common properties for `Secret`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_21
 
-cdk8s_plus_22.CommonSecretProps(
+cdk8s_plus_21.CommonSecretProps(
   metadata: ApiObjectMetadata = None,
   immutable: bool = None
 )
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_22.CommonSecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s_plus_21.CommonSecretProps.property.metadata"></a>
 
 ```python
 metadata: ApiObjectMetadata
@@ -7645,7 +7655,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.CommonSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.CommonSecretProps.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -7660,7 +7670,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-### ConfigMapProps <a name="cdk8s_plus_22.ConfigMapProps"></a>
+### ConfigMapProps <a name="cdk8s_plus_21.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
@@ -8711,7 +8721,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.DockerConfigSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.DockerConfigSecretProps.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -8726,7 +8736,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="cdk8s_plus_22.DockerConfigSecretProps.property.data"></a>
+##### `data`<sup>Required</sup> <a name="cdk8s_plus_21.DockerConfigSecretProps.property.data"></a>
 
 ```python
 data: typing.Mapping[typing.Any]
@@ -11350,7 +11360,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -11365,7 +11375,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_22.SecretProps.property.string_data"></a>
+##### `string_data`<sup>Optional</sup> <a name="cdk8s_plus_21.SecretProps.property.string_data"></a>
 
 ```python
 string_data: typing.Mapping[str]
@@ -11590,7 +11600,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.ServiceAccountTokenSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -11605,7 +11615,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_22.ServiceAccountTokenSecretProps.property.service_account"></a>
+##### `service_account`<sup>Required</sup> <a name="cdk8s_plus_21.ServiceAccountTokenSecretProps.property.service_account"></a>
 
 ```python
 service_account: IServiceAccount
@@ -11980,7 +11990,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.SshAuthSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -11995,7 +12005,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_22.SshAuthSecretProps.property.ssh_private_key"></a>
+##### `ssh_private_key`<sup>Required</sup> <a name="cdk8s_plus_21.SshAuthSecretProps.property.ssh_private_key"></a>
 
 ```python
 ssh_private_key: str
@@ -12439,7 +12449,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_22.TlsSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s_plus_21.TlsSecretProps.property.immutable"></a>
 
 ```python
 immutable: bool
@@ -12454,7 +12464,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_22.TlsSecretProps.property.tls_cert"></a>
+##### `tls_cert`<sup>Required</sup> <a name="cdk8s_plus_21.TlsSecretProps.property.tls_cert"></a>
 
 ```python
 tls_cert: str

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2115,6 +2115,19 @@ The name of the secret to reference.
 
 ---
 
+#### Properties <a name="Properties"></a>
+
+##### `immutable`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+
+Whether or not the secret is immutable.
+
+---
 
 
 ### Service <a name="cdk8s-plus-21.Service"></a>
@@ -3494,7 +3507,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `password`<sup>Required</sup> <a name="cdk8s-plus-21.BasicAuthSecretProps.property.password"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.BasicAuthSecretProps.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `password`<sup>Required</sup> <a name="cdk8s-plus-22.BasicAuthSecretProps.property.password"></a>
 
 ```typescript
 public readonly password: string;
@@ -3607,7 +3635,46 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### ConfigMapProps <a name="cdk8s-plus-21.ConfigMapProps"></a>
+### CommonSecretProps <a name="cdk8s-plus-22.CommonSecretProps"></a>
+
+Common properties for `Secret`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { CommonSecretProps } from 'cdk8s-plus-22'
+
+const commonSecretProps: CommonSecretProps = { ... }
+```
+
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.CommonSecretProps.property.metadata"></a>
+
+```typescript
+public readonly metadata: ApiObjectMetadata;
+```
+
+- *Type:* [`cdk8s.ApiObjectMetadata`](#cdk8s.ApiObjectMetadata)
+
+Metadata that all persisted resources must have, which includes all objects users must create.
+
+---
+
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.CommonSecretProps.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+### ConfigMapProps <a name="cdk8s-plus-22.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
@@ -4590,7 +4657,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `data`<sup>Required</sup> <a name="cdk8s-plus-21.DockerConfigSecretProps.property.data"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.DockerConfigSecretProps.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `data`<sup>Required</sup> <a name="cdk8s-plus-22.DockerConfigSecretProps.property.data"></a>
 
 ```typescript
 public readonly data: {[ key: string ]: any};
@@ -7043,7 +7125,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.stringData"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `stringData`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.stringData"></a>
 
 ```typescript
 public readonly stringData: {[ key: string ]: string};
@@ -7253,7 +7350,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `serviceAccount`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceAccountTokenSecretProps.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `serviceAccount`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
@@ -7603,7 +7715,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `sshPrivateKey`<sup>Required</sup> <a name="cdk8s-plus-21.SshAuthSecretProps.property.sshPrivateKey"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.SshAuthSecretProps.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `sshPrivateKey`<sup>Required</sup> <a name="cdk8s-plus-22.SshAuthSecretProps.property.sshPrivateKey"></a>
 
 ```typescript
 public readonly sshPrivateKey: string;
@@ -8016,7 +8143,22 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `tlsCert`<sup>Required</sup> <a name="cdk8s-plus-21.TlsSecretProps.property.tlsCert"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.TlsSecretProps.property.immutable"></a>
+
+```typescript
+public readonly immutable: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified).
+
+If not set to true, the field can be modified at any time.
+
+---
+
+##### `tlsCert`<sup>Required</sup> <a name="cdk8s-plus-22.TlsSecretProps.property.tlsCert"></a>
 
 ```typescript
 public readonly tlsCert: string;

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2117,7 +2117,7 @@ The name of the secret to reference.
 
 #### Properties <a name="Properties"></a>
 
-##### `immutable`<sup>Required</sup> <a name="cdk8s-plus-22.Secret.property.immutable"></a>
+##### `immutable`<sup>Required</sup> <a name="cdk8s-plus-21.Secret.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -3507,7 +3507,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.BasicAuthSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-21.BasicAuthSecretProps.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -3522,7 +3522,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `password`<sup>Required</sup> <a name="cdk8s-plus-22.BasicAuthSecretProps.property.password"></a>
+##### `password`<sup>Required</sup> <a name="cdk8s-plus-21.BasicAuthSecretProps.property.password"></a>
 
 ```typescript
 public readonly password: string;
@@ -3635,19 +3635,19 @@ Defaults to 1 second. Minimum value is 1.
 
 ---
 
-### CommonSecretProps <a name="cdk8s-plus-22.CommonSecretProps"></a>
+### CommonSecretProps <a name="cdk8s-plus-21.CommonSecretProps"></a>
 
 Common properties for `Secret`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { CommonSecretProps } from 'cdk8s-plus-22'
+import { CommonSecretProps } from 'cdk8s-plus-21'
 
 const commonSecretProps: CommonSecretProps = { ... }
 ```
 
-##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-22.CommonSecretProps.property.metadata"></a>
+##### `metadata`<sup>Optional</sup> <a name="cdk8s-plus-21.CommonSecretProps.property.metadata"></a>
 
 ```typescript
 public readonly metadata: ApiObjectMetadata;
@@ -3659,7 +3659,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.CommonSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-21.CommonSecretProps.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -3674,7 +3674,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-### ConfigMapProps <a name="cdk8s-plus-22.ConfigMapProps"></a>
+### ConfigMapProps <a name="cdk8s-plus-21.ConfigMapProps"></a>
 
 Properties for initialization of `ConfigMap`.
 
@@ -4657,7 +4657,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.DockerConfigSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-21.DockerConfigSecretProps.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -4672,7 +4672,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `data`<sup>Required</sup> <a name="cdk8s-plus-22.DockerConfigSecretProps.property.data"></a>
+##### `data`<sup>Required</sup> <a name="cdk8s-plus-21.DockerConfigSecretProps.property.data"></a>
 
 ```typescript
 public readonly data: {[ key: string ]: any};
@@ -7125,7 +7125,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -7140,7 +7140,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `stringData`<sup>Optional</sup> <a name="cdk8s-plus-22.SecretProps.property.stringData"></a>
+##### `stringData`<sup>Optional</sup> <a name="cdk8s-plus-21.SecretProps.property.stringData"></a>
 
 ```typescript
 public readonly stringData: {[ key: string ]: string};
@@ -7350,7 +7350,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.ServiceAccountTokenSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-21.ServiceAccountTokenSecretProps.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -7365,7 +7365,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `serviceAccount`<sup>Required</sup> <a name="cdk8s-plus-22.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
+##### `serviceAccount`<sup>Required</sup> <a name="cdk8s-plus-21.ServiceAccountTokenSecretProps.property.serviceAccount"></a>
 
 ```typescript
 public readonly serviceAccount: IServiceAccount;
@@ -7715,7 +7715,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.SshAuthSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-21.SshAuthSecretProps.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -7730,7 +7730,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `sshPrivateKey`<sup>Required</sup> <a name="cdk8s-plus-22.SshAuthSecretProps.property.sshPrivateKey"></a>
+##### `sshPrivateKey`<sup>Required</sup> <a name="cdk8s-plus-21.SshAuthSecretProps.property.sshPrivateKey"></a>
 
 ```typescript
 public readonly sshPrivateKey: string;
@@ -8143,7 +8143,7 @@ Metadata that all persisted resources must have, which includes all objects user
 
 ---
 
-##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-22.TlsSecretProps.property.immutable"></a>
+##### `immutable`<sup>Optional</sup> <a name="cdk8s-plus-21.TlsSecretProps.property.immutable"></a>
 
 ```typescript
 public readonly immutable: boolean;
@@ -8158,7 +8158,7 @@ If not set to true, the field can be modified at any time.
 
 ---
 
-##### `tlsCert`<sup>Required</sup> <a name="cdk8s-plus-22.TlsSecretProps.property.tlsCert"></a>
+##### `tlsCert`<sup>Required</sup> <a name="cdk8s-plus-21.TlsSecretProps.property.tlsCert"></a>
 
 ```typescript
 public readonly tlsCert: string;

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -28,20 +28,21 @@ test('Can create a new secret', () => {
   });
 
   expect(Testing.synth(chart)).toMatchInlineSnapshot(`
-    Array [
-      Object {
-        "apiVersion": "v1",
-        "kind": "Secret",
-        "metadata": Object {
-          "name": "test-secret-c837fa76",
-        },
-        "stringData": Object {
-          "key": "value",
-        },
-        "type": "kubernetes.io/tls",
-      },
-    ]
-  `);
+Array [
+  Object {
+    "apiVersion": "v1",
+    "immutable": false,
+    "kind": "Secret",
+    "metadata": Object {
+      "name": "test-secret-c837fa76",
+    },
+    "stringData": Object {
+      "key": "value",
+    },
+    "type": "kubernetes.io/tls",
+  },
+]
+`);
 });
 
 test('Can add data to new secrets', () => {
@@ -54,6 +55,7 @@ test('Can add data to new secrets', () => {
 Array [
   Object {
     "apiVersion": "v1",
+    "immutable": false,
     "kind": "Secret",
     "metadata": Object {
       "name": "test-secret-c837fa76",
@@ -78,6 +80,7 @@ test('Can create a basic auth secret', () => {
 Array [
   Object {
     "apiVersion": "v1",
+    "immutable": false,
     "kind": "Secret",
     "metadata": Object {
       "name": "test-basicauthsecret-c82606a8",
@@ -103,6 +106,7 @@ test('Can create an ssh auth secret', () => {
 Array [
   Object {
     "apiVersion": "v1",
+    "immutable": false,
     "kind": "Secret",
     "metadata": Object {
       "name": "test-sshauthsecret-c8356ec6",
@@ -138,6 +142,7 @@ Array [
   },
   Object {
     "apiVersion": "v1",
+    "immutable": false,
     "kind": "Secret",
     "metadata": Object {
       "annotations": Object {
@@ -166,6 +171,7 @@ test('Can create a TLS secret', () => {
 Array [
   Object {
     "apiVersion": "v1",
+    "immutable": false,
     "kind": "Secret",
     "metadata": Object {
       "name": "test-tlssecret-c8c8af35",
@@ -200,6 +206,7 @@ test('Can create a Docker config secret', () => {
 Array [
   Object {
     "apiVersion": "v1",
+    "immutable": false,
     "kind": "Secret",
     "metadata": Object {
       "name": "test-dockerconfigsecret-c8b65039",
@@ -211,4 +218,114 @@ Array [
   },
 ]
 `);
+});
+
+test('default immutability', () => {
+
+  const chart = Testing.chart();
+
+  const secret = new kplus.Secret(chart, 'Secret');
+
+  const spec = Testing.synth(chart)[0];
+
+  expect(secret.immutable).toBeFalsy();
+  expect(spec.immutable).toBeFalsy();
+
+});
+
+test('can configure an immutable generic secret', () => {
+
+  const chart = Testing.chart();
+
+  const secret = new kplus.Secret(chart, 'Secret', {
+    immutable: true,
+  });
+
+  const spec = Testing.synth(chart)[0];
+
+  expect(secret.immutable).toBeTruthy();
+  expect(spec.immutable).toBeTruthy();
+
+});
+
+test('can configure an immutable basic auth secret', () => {
+
+  const chart = Testing.chart();
+
+  const secret = new kplus.BasicAuthSecret(chart, 'Secret', {
+    username: 'user',
+    password: 'pass',
+    immutable: true,
+  });
+
+  const spec = Testing.synth(chart)[0];
+
+  expect(secret.immutable).toBeTruthy();
+  expect(spec.immutable).toBeTruthy();
+
+});
+
+test('can configure an immutable ssh auth secret', () => {
+
+  const chart = Testing.chart();
+
+  const secret = new kplus.SshAuthSecret(chart, 'Secret', {
+    sshPrivateKey: 'private',
+    immutable: true,
+  });
+
+  const spec = Testing.synth(chart)[0];
+
+  expect(secret.immutable).toBeTruthy();
+  expect(spec.immutable).toBeTruthy();
+
+});
+
+test('can configure an immutable service account token secret', () => {
+
+  const chart = Testing.chart();
+
+  const secret = new kplus.ServiceAccountTokenSecret(chart, 'Secret', {
+    serviceAccount: kplus.ServiceAccount.fromServiceAccountName('sa'),
+    immutable: true,
+  });
+
+  const spec = Testing.synth(chart)[0];
+
+  expect(secret.immutable).toBeTruthy();
+  expect(spec.immutable).toBeTruthy();
+
+});
+
+test('can configure an immutable tls secret', () => {
+
+  const chart = Testing.chart();
+
+  const secret = new kplus.TlsSecret(chart, 'Secret', {
+    tlsCert: 'cert',
+    tlsKey: 'key',
+    immutable: true,
+  });
+
+  const spec = Testing.synth(chart)[0];
+
+  expect(secret.immutable).toBeTruthy();
+  expect(spec.immutable).toBeTruthy();
+
+});
+
+test('can configure an immutable docker config secret', () => {
+
+  const chart = Testing.chart();
+
+  const secret = new kplus.DockerConfigSecret(chart, 'Secret', {
+    data: {},
+    immutable: true,
+  });
+
+  const spec = Testing.synth(chart)[0];
+
+  expect(secret.immutable).toBeTruthy();
+  expect(spec.immutable).toBeTruthy();
+
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [feat(secret): immutable secrets (#522)](https://github.com/cdk8s-team/cdk8s-plus/pull/522)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)