### PR TITLE
feat(deployment): upgrade strategy (#521)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -1383,9 +1383,9 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.parameter.strategy"></a>
 
-- *Type:* [`org.cdk8s.plus22.DeploymentStrategy`](#org.cdk8s.plus22.DeploymentStrategy)
+- *Type:* [`org.cdk8s.plus20.DeploymentStrategy`](#org.cdk8s.plus20.DeploymentStrategy)
 - *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
 
 Specifies the strategy used to replace old Pods by new ones.
@@ -1595,19 +1595,19 @@ public PodSecurityContext getSecurityContext();
 
 ---
 
-##### `strategy`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.strategy"></a>
+##### `strategy`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.property.strategy"></a>
 
 ```java
 public DeploymentStrategy getStrategy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DeploymentStrategy`](#org.cdk8s.plus22.DeploymentStrategy)
+- *Type:* [`org.cdk8s.plus20.DeploymentStrategy`](#org.cdk8s.plus20.DeploymentStrategy)
 
 The upgrade strategy of this deployment.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
@@ -6509,27 +6509,27 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.property.strategy"></a>
 
 ```java
 public DeploymentStrategy getStrategy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.DeploymentStrategy`](#org.cdk8s.plus22.DeploymentStrategy)
+- *Type:* [`org.cdk8s.plus20.DeploymentStrategy`](#org.cdk8s.plus20.DeploymentStrategy)
 - *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
 
 Specifies the strategy used to replace old Pods by new ones.
 
 ---
 
-### DeploymentStrategyRollingUpdateOptions <a name="org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions"></a>
+### DeploymentStrategyRollingUpdateOptions <a name="org.cdk8s.plus20.DeploymentStrategyRollingUpdateOptions"></a>
 
 Options for `DeploymentStrategy.rollingUpdate`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions;
+import org.cdk8s.plus20.DeploymentStrategyRollingUpdateOptions;
 
 DeploymentStrategyRollingUpdateOptions.builder()
 //  .maxSurge(PercentOrAbsolute)
@@ -6537,13 +6537,13 @@ DeploymentStrategyRollingUpdateOptions.builder()
     .build();
 ```
 
-##### `maxSurge`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions.property.maxSurge"></a>
+##### `maxSurge`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentStrategyRollingUpdateOptions.property.maxSurge"></a>
 
 ```java
 public PercentOrAbsolute getMaxSurge();
 ```
 
-- *Type:* [`org.cdk8s.plus22.PercentOrAbsolute`](#org.cdk8s.plus22.PercentOrAbsolute)
+- *Type:* [`org.cdk8s.plus20.PercentOrAbsolute`](#org.cdk8s.plus20.PercentOrAbsolute)
 - *Default:* '25%'
 
 The maximum number of pods that can be scheduled above the desired number of pods.
@@ -6559,13 +6559,13 @@ total number of pods running at any time during the update is at most 130% of de
 
 ---
 
-##### `maxUnavailable`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions.property.maxUnavailable"></a>
+##### `maxUnavailable`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentStrategyRollingUpdateOptions.property.maxUnavailable"></a>
 
 ```java
 public PercentOrAbsolute getMaxUnavailable();
 ```
 
-- *Type:* [`org.cdk8s.plus22.PercentOrAbsolute`](#org.cdk8s.plus22.PercentOrAbsolute)
+- *Type:* [`org.cdk8s.plus20.PercentOrAbsolute`](#org.cdk8s.plus20.PercentOrAbsolute)
 - *Default:* '25%'
 
 The maximum number of pods that can be unavailable during the update.
@@ -6581,7 +6581,7 @@ number of pods available at all times during the update is at least 70% of desir
 
 ---
 
-### DockerConfigSecretProps <a name="org.cdk8s.plus22.DockerConfigSecretProps"></a>
+### DockerConfigSecretProps <a name="org.cdk8s.plus20.DockerConfigSecretProps"></a>
 
 Options for `DockerConfigSecret`.
 
@@ -11051,39 +11051,39 @@ public java.lang.String getAmount();
 ---
 
 
-### DeploymentStrategy <a name="org.cdk8s.plus22.DeploymentStrategy"></a>
+### DeploymentStrategy <a name="org.cdk8s.plus20.DeploymentStrategy"></a>
 
 Deployment strategies.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `recreate` <a name="org.cdk8s.plus22.DeploymentStrategy.recreate"></a>
+##### `recreate` <a name="org.cdk8s.plus20.DeploymentStrategy.recreate"></a>
 
 ```java
-import org.cdk8s.plus22.DeploymentStrategy;
+import org.cdk8s.plus20.DeploymentStrategy;
 
 DeploymentStrategy.recreate()
 ```
 
-##### `rollingUpdate` <a name="org.cdk8s.plus22.DeploymentStrategy.rollingUpdate"></a>
+##### `rollingUpdate` <a name="org.cdk8s.plus20.DeploymentStrategy.rollingUpdate"></a>
 
 ```java
-import org.cdk8s.plus22.DeploymentStrategy;
+import org.cdk8s.plus20.DeploymentStrategy;
 
 DeploymentStrategy.rollingUpdate()
 DeploymentStrategy.rollingUpdate(DeploymentStrategyRollingUpdateOptions options)
 ```
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentStrategy.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentStrategy.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions`](#org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions)
+- *Type:* [`org.cdk8s.plus20.DeploymentStrategyRollingUpdateOptions`](#org.cdk8s.plus20.DeploymentStrategyRollingUpdateOptions)
 
 ---
 
 
 
-### EnvValue <a name="org.cdk8s.plus22.EnvValue"></a>
+### EnvValue <a name="org.cdk8s.plus20.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
@@ -11361,13 +11361,13 @@ The service object.
 
 
 
-### PercentOrAbsolute <a name="org.cdk8s.plus22.PercentOrAbsolute"></a>
+### PercentOrAbsolute <a name="org.cdk8s.plus20.PercentOrAbsolute"></a>
 
 Union like class repsenting either a ration in percents or an absolute number.
 
 #### Methods <a name="Methods"></a>
 
-##### `isZero` <a name="org.cdk8s.plus22.PercentOrAbsolute.isZero"></a>
+##### `isZero` <a name="org.cdk8s.plus20.PercentOrAbsolute.isZero"></a>
 
 ```java
 public isZero()
@@ -11375,29 +11375,29 @@ public isZero()
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `absolute` <a name="org.cdk8s.plus22.PercentOrAbsolute.absolute"></a>
+##### `absolute` <a name="org.cdk8s.plus20.PercentOrAbsolute.absolute"></a>
 
 ```java
-import org.cdk8s.plus22.PercentOrAbsolute;
+import org.cdk8s.plus20.PercentOrAbsolute;
 
 PercentOrAbsolute.absolute(java.lang.Number num)
 ```
 
-###### `num`<sup>Required</sup> <a name="org.cdk8s.plus22.PercentOrAbsolute.parameter.num"></a>
+###### `num`<sup>Required</sup> <a name="org.cdk8s.plus20.PercentOrAbsolute.parameter.num"></a>
 
 - *Type:* `java.lang.Number`
 
 ---
 
-##### `percent` <a name="org.cdk8s.plus22.PercentOrAbsolute.percent"></a>
+##### `percent` <a name="org.cdk8s.plus20.PercentOrAbsolute.percent"></a>
 
 ```java
-import org.cdk8s.plus22.PercentOrAbsolute;
+import org.cdk8s.plus20.PercentOrAbsolute;
 
 PercentOrAbsolute.percent(java.lang.Number percent)
 ```
 
-###### `percent`<sup>Required</sup> <a name="org.cdk8s.plus22.PercentOrAbsolute.parameter.percent"></a>
+###### `percent`<sup>Required</sup> <a name="org.cdk8s.plus20.PercentOrAbsolute.parameter.percent"></a>
 
 - *Type:* `java.lang.Number`
 
@@ -11405,7 +11405,7 @@ PercentOrAbsolute.percent(java.lang.Number percent)
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.PercentOrAbsolute.property.value"></a>
+##### `value`<sup>Required</sup> <a name="org.cdk8s.plus20.PercentOrAbsolute.property.value"></a>
 
 ```java
 public java.lang.Object getValue();
@@ -11416,7 +11416,7 @@ public java.lang.Object getValue();
 ---
 
 
-### PodSecurityContext <a name="org.cdk8s.plus22.PodSecurityContext"></a>
+### PodSecurityContext <a name="org.cdk8s.plus20.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -1226,6 +1226,7 @@ Deployment.Builder.create(Construct scope, java.lang.String id)
 //  .podMetadata(ApiObjectMetadata)
 //  .defaultSelector(java.lang.Boolean)
 //  .replicas(java.lang.Number)
+//  .strategy(DeploymentStrategy)
     .build();
 ```
 
@@ -1379,6 +1380,15 @@ If this is set to `false` you must define your selector through
 - *Default:* 1
 
 Number of desired pods.
+
+---
+
+##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.parameter.strategy"></a>
+
+- *Type:* [`org.cdk8s.plus22.DeploymentStrategy`](#org.cdk8s.plus22.DeploymentStrategy)
+- *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
+
+Specifies the strategy used to replace old Pods by new ones.
 
 ---
 
@@ -1585,7 +1595,19 @@ public PodSecurityContext getSecurityContext();
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.property.volumes"></a>
+##### `strategy`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.strategy"></a>
+
+```java
+public DeploymentStrategy getStrategy();
+```
+
+- *Type:* [`org.cdk8s.plus22.DeploymentStrategy`](#org.cdk8s.plus22.DeploymentStrategy)
+
+The upgrade strategy of this deployment.
+
+---
+
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.Deployment.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
@@ -6294,6 +6316,7 @@ DeploymentProps.builder()
 //  .podMetadata(ApiObjectMetadata)
 //  .defaultSelector(java.lang.Boolean)
 //  .replicas(java.lang.Number)
+//  .strategy(DeploymentStrategy)
     .build();
 ```
 
@@ -6486,7 +6509,79 @@ Number of desired pods.
 
 ---
 
-### DockerConfigSecretProps <a name="org.cdk8s.plus20.DockerConfigSecretProps"></a>
+##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentProps.property.strategy"></a>
+
+```java
+public DeploymentStrategy getStrategy();
+```
+
+- *Type:* [`org.cdk8s.plus22.DeploymentStrategy`](#org.cdk8s.plus22.DeploymentStrategy)
+- *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
+
+Specifies the strategy used to replace old Pods by new ones.
+
+---
+
+### DeploymentStrategyRollingUpdateOptions <a name="org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions"></a>
+
+Options for `DeploymentStrategy.rollingUpdate`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions;
+
+DeploymentStrategyRollingUpdateOptions.builder()
+//  .maxSurge(PercentOrAbsolute)
+//  .maxUnavailable(PercentOrAbsolute)
+    .build();
+```
+
+##### `maxSurge`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions.property.maxSurge"></a>
+
+```java
+public PercentOrAbsolute getMaxSurge();
+```
+
+- *Type:* [`org.cdk8s.plus22.PercentOrAbsolute`](#org.cdk8s.plus22.PercentOrAbsolute)
+- *Default:* '25%'
+
+The maximum number of pods that can be scheduled above the desired number of pods.
+
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding up.
+This can not be 0 if `maxUnavailable` is 0.
+
+Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update
+starts, such that the total number of old and new pods do not exceed 130% of desired pods.
+Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that
+total number of pods running at any time during the update is at most 130% of desired pods.
+
+---
+
+##### `maxUnavailable`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions.property.maxUnavailable"></a>
+
+```java
+public PercentOrAbsolute getMaxUnavailable();
+```
+
+- *Type:* [`org.cdk8s.plus22.PercentOrAbsolute`](#org.cdk8s.plus22.PercentOrAbsolute)
+- *Default:* '25%'
+
+The maximum number of pods that can be unavailable during the update.
+
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding down.
+This can not be 0 if `maxSurge` is 0.
+
+Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired
+pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can
+be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total
+number of pods available at all times during the update is at least 70% of desired pods.
+
+---
+
+### DockerConfigSecretProps <a name="org.cdk8s.plus22.DockerConfigSecretProps"></a>
 
 Options for `DockerConfigSecret`.
 
@@ -10956,7 +11051,39 @@ public java.lang.String getAmount();
 ---
 
 
-### EnvValue <a name="org.cdk8s.plus20.EnvValue"></a>
+### DeploymentStrategy <a name="org.cdk8s.plus22.DeploymentStrategy"></a>
+
+Deployment strategies.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `recreate` <a name="org.cdk8s.plus22.DeploymentStrategy.recreate"></a>
+
+```java
+import org.cdk8s.plus22.DeploymentStrategy;
+
+DeploymentStrategy.recreate()
+```
+
+##### `rollingUpdate` <a name="org.cdk8s.plus22.DeploymentStrategy.rollingUpdate"></a>
+
+```java
+import org.cdk8s.plus22.DeploymentStrategy;
+
+DeploymentStrategy.rollingUpdate()
+DeploymentStrategy.rollingUpdate(DeploymentStrategyRollingUpdateOptions options)
+```
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.DeploymentStrategy.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions`](#org.cdk8s.plus22.DeploymentStrategyRollingUpdateOptions)
+
+---
+
+
+
+### EnvValue <a name="org.cdk8s.plus22.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
@@ -11234,7 +11361,62 @@ The service object.
 
 
 
-### PodSecurityContext <a name="org.cdk8s.plus20.PodSecurityContext"></a>
+### PercentOrAbsolute <a name="org.cdk8s.plus22.PercentOrAbsolute"></a>
+
+Union like class repsenting either a ration in percents or an absolute number.
+
+#### Methods <a name="Methods"></a>
+
+##### `isZero` <a name="org.cdk8s.plus22.PercentOrAbsolute.isZero"></a>
+
+```java
+public isZero()
+```
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `absolute` <a name="org.cdk8s.plus22.PercentOrAbsolute.absolute"></a>
+
+```java
+import org.cdk8s.plus22.PercentOrAbsolute;
+
+PercentOrAbsolute.absolute(java.lang.Number num)
+```
+
+###### `num`<sup>Required</sup> <a name="org.cdk8s.plus22.PercentOrAbsolute.parameter.num"></a>
+
+- *Type:* `java.lang.Number`
+
+---
+
+##### `percent` <a name="org.cdk8s.plus22.PercentOrAbsolute.percent"></a>
+
+```java
+import org.cdk8s.plus22.PercentOrAbsolute;
+
+PercentOrAbsolute.percent(java.lang.Number percent)
+```
+
+###### `percent`<sup>Required</sup> <a name="org.cdk8s.plus22.PercentOrAbsolute.parameter.percent"></a>
+
+- *Type:* `java.lang.Number`
+
+---
+
+#### Properties <a name="Properties"></a>
+
+##### `value`<sup>Required</sup> <a name="org.cdk8s.plus22.PercentOrAbsolute.property.value"></a>
+
+```java
+public java.lang.Object getValue();
+```
+
+- *Type:* `java.lang.Object`
+
+---
+
+
+### PodSecurityContext <a name="org.cdk8s.plus22.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -858,7 +858,8 @@ cdk8s_plus_20.DaemonSet(
   volumes: typing.List[Volume] = None,
   pod_metadata: ApiObjectMetadata = None,
   default_selector: bool = None,
-  min_ready_seconds: typing.Union[int, float] = None
+  replicas: typing.Union[int, float] = None,
+  strategy: DeploymentStrategy = None
 )
 ```
 
@@ -1012,6 +1013,15 @@ If this is set to `false` you must define your selector through
 - *Default:* 0
 
 Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available.
+
+---
+
+##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.strategy"></a>
+
+- *Type:* [`cdk8s_plus_22.DeploymentStrategy`](#cdk8s_plus_22.DeploymentStrategy)
+- *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
+
+Specifies the strategy used to replace old Pods by new ones.
 
 ---
 
@@ -1548,7 +1558,19 @@ security_context: PodSecurityContext
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_20.DaemonSet.property.volumes"></a>
+##### `strategy`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.strategy"></a>
+
+```python
+strategy: DeploymentStrategy
+```
+
+- *Type:* [`cdk8s_plus_22.DeploymentStrategy`](#cdk8s_plus_22.DeploymentStrategy)
+
+The upgrade strategy of this deployment.
+
+---
+
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
@@ -8500,7 +8522,8 @@ cdk8s_plus_20.DeploymentProps(
   volumes: typing.List[Volume] = None,
   pod_metadata: ApiObjectMetadata = None,
   default_selector: bool = None,
-  replicas: typing.Union[int, float] = None
+  replicas: typing.Union[int, float] = None,
+  strategy: DeploymentStrategy = None
 )
 ```
 
@@ -8693,7 +8716,79 @@ Number of desired pods.
 
 ---
 
-### DockerConfigSecretProps <a name="cdk8s_plus_20.DockerConfigSecretProps"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.strategy"></a>
+
+```python
+strategy: DeploymentStrategy
+```
+
+- *Type:* [`cdk8s_plus_22.DeploymentStrategy`](#cdk8s_plus_22.DeploymentStrategy)
+- *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
+
+Specifies the strategy used to replace old Pods by new ones.
+
+---
+
+### DeploymentStrategyRollingUpdateOptions <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions"></a>
+
+Options for `DeploymentStrategy.rollingUpdate`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions(
+  max_surge: PercentOrAbsolute = None,
+  max_unavailable: PercentOrAbsolute = None
+)
+```
+
+##### `max_surge`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions.property.max_surge"></a>
+
+```python
+max_surge: PercentOrAbsolute
+```
+
+- *Type:* [`cdk8s_plus_22.PercentOrAbsolute`](#cdk8s_plus_22.PercentOrAbsolute)
+- *Default:* '25%'
+
+The maximum number of pods that can be scheduled above the desired number of pods.
+
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding up.
+This can not be 0 if `maxUnavailable` is 0.
+
+Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update
+starts, such that the total number of old and new pods do not exceed 130% of desired pods.
+Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that
+total number of pods running at any time during the update is at most 130% of desired pods.
+
+---
+
+##### `max_unavailable`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions.property.max_unavailable"></a>
+
+```python
+max_unavailable: PercentOrAbsolute
+```
+
+- *Type:* [`cdk8s_plus_22.PercentOrAbsolute`](#cdk8s_plus_22.PercentOrAbsolute)
+- *Default:* '25%'
+
+The maximum number of pods that can be unavailable during the update.
+
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding down.
+This can not be 0 if `maxSurge` is 0.
+
+Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired
+pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can
+be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total
+number of pods available at all times during the update is at least 70% of desired pods.
+
+---
+
+### DockerConfigSecretProps <a name="cdk8s_plus_22.DockerConfigSecretProps"></a>
 
 Options for `DockerConfigSecret`.
 
@@ -13219,7 +13314,71 @@ amount: str
 ---
 
 
-### EnvValue <a name="cdk8s_plus_20.EnvValue"></a>
+### DeploymentStrategy <a name="cdk8s_plus_22.DeploymentStrategy"></a>
+
+Deployment strategies.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `recreate` <a name="cdk8s_plus_22.DeploymentStrategy.recreate"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.DeploymentStrategy.recreate()
+```
+
+##### `rolling_update` <a name="cdk8s_plus_22.DeploymentStrategy.rolling_update"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.DeploymentStrategy.rolling_update(
+  max_surge: PercentOrAbsolute = None,
+  max_unavailable: PercentOrAbsolute = None
+)
+```
+
+###### `max_surge`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions.parameter.max_surge"></a>
+
+- *Type:* [`cdk8s_plus_22.PercentOrAbsolute`](#cdk8s_plus_22.PercentOrAbsolute)
+- *Default:* '25%'
+
+The maximum number of pods that can be scheduled above the desired number of pods.
+
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding up.
+This can not be 0 if `maxUnavailable` is 0.
+
+Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update
+starts, such that the total number of old and new pods do not exceed 130% of desired pods.
+Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that
+total number of pods running at any time during the update is at most 130% of desired pods.
+
+---
+
+###### `max_unavailable`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions.parameter.max_unavailable"></a>
+
+- *Type:* [`cdk8s_plus_22.PercentOrAbsolute`](#cdk8s_plus_22.PercentOrAbsolute)
+- *Default:* '25%'
+
+The maximum number of pods that can be unavailable during the update.
+
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding down.
+This can not be 0 if `maxSurge` is 0.
+
+Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired
+pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can
+be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total
+number of pods available at all times during the update is at least 70% of desired pods.
+
+---
+
+
+
+### EnvValue <a name="cdk8s_plus_22.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
@@ -13569,7 +13728,66 @@ The port to use to access the service.
 
 
 
-### PodSecurityContext <a name="cdk8s_plus_20.PodSecurityContext"></a>
+### PercentOrAbsolute <a name="cdk8s_plus_22.PercentOrAbsolute"></a>
+
+Union like class repsenting either a ration in percents or an absolute number.
+
+#### Methods <a name="Methods"></a>
+
+##### `is_zero` <a name="cdk8s_plus_22.PercentOrAbsolute.is_zero"></a>
+
+```python
+def is_zero()
+```
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `absolute` <a name="cdk8s_plus_22.PercentOrAbsolute.absolute"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.PercentOrAbsolute.absolute(
+  num: typing.Union[int, float]
+)
+```
+
+###### `num`<sup>Required</sup> <a name="cdk8s_plus_22.PercentOrAbsolute.parameter.num"></a>
+
+- *Type:* `typing.Union[int, float]`
+
+---
+
+##### `percent` <a name="cdk8s_plus_22.PercentOrAbsolute.percent"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.PercentOrAbsolute.percent(
+  percent: typing.Union[int, float]
+)
+```
+
+###### `percent`<sup>Required</sup> <a name="cdk8s_plus_22.PercentOrAbsolute.parameter.percent"></a>
+
+- *Type:* `typing.Union[int, float]`
+
+---
+
+#### Properties <a name="Properties"></a>
+
+##### `value`<sup>Required</sup> <a name="cdk8s_plus_22.PercentOrAbsolute.property.value"></a>
+
+```python
+value: typing.Any
+```
+
+- *Type:* `typing.Any`
+
+---
+
+
+### PodSecurityContext <a name="cdk8s_plus_22.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -858,8 +858,7 @@ cdk8s_plus_20.DaemonSet(
   volumes: typing.List[Volume] = None,
   pod_metadata: ApiObjectMetadata = None,
   default_selector: bool = None,
-  replicas: typing.Union[int, float] = None,
-  strategy: DeploymentStrategy = None
+  min_ready_seconds: typing.Union[int, float] = None
 )
 ```
 
@@ -1013,15 +1012,6 @@ If this is set to `false` you must define your selector through
 - *Default:* 0
 
 Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available.
-
----
-
-##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.parameter.strategy"></a>
-
-- *Type:* [`cdk8s_plus_22.DeploymentStrategy`](#cdk8s_plus_22.DeploymentStrategy)
-- *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
-
-Specifies the strategy used to replace old Pods by new ones.
 
 ---
 
@@ -1558,19 +1548,7 @@ security_context: PodSecurityContext
 
 ---
 
-##### `strategy`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.strategy"></a>
-
-```python
-strategy: DeploymentStrategy
-```
-
-- *Type:* [`cdk8s_plus_22.DeploymentStrategy`](#cdk8s_plus_22.DeploymentStrategy)
-
-The upgrade strategy of this deployment.
-
----
-
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_20.DaemonSet.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
@@ -1656,7 +1634,8 @@ cdk8s_plus_20.Deployment(
   volumes: typing.List[Volume] = None,
   pod_metadata: ApiObjectMetadata = None,
   default_selector: bool = None,
-  replicas: typing.Union[int, float] = None
+  replicas: typing.Union[int, float] = None,
+  strategy: DeploymentStrategy = None
 )
 ```
 
@@ -1810,6 +1789,15 @@ If this is set to `false` you must define your selector through
 - *Default:* 1
 
 Number of desired pods.
+
+---
+
+##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.parameter.strategy"></a>
+
+- *Type:* [`cdk8s_plus_20.DeploymentStrategy`](#cdk8s_plus_20.DeploymentStrategy)
+- *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
+
+Specifies the strategy used to replace old Pods by new ones.
 
 ---
 
@@ -2490,6 +2478,18 @@ security_context: PodSecurityContext
 ```
 
 - *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+---
+
+##### `strategy`<sup>Required</sup> <a name="cdk8s_plus_20.Deployment.property.strategy"></a>
+
+```python
+strategy: DeploymentStrategy
+```
+
+- *Type:* [`cdk8s_plus_20.DeploymentStrategy`](#cdk8s_plus_20.DeploymentStrategy)
+
+The upgrade strategy of this deployment.
 
 ---
 
@@ -8716,41 +8716,41 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentProps.property.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.property.strategy"></a>
 
 ```python
 strategy: DeploymentStrategy
 ```
 
-- *Type:* [`cdk8s_plus_22.DeploymentStrategy`](#cdk8s_plus_22.DeploymentStrategy)
+- *Type:* [`cdk8s_plus_20.DeploymentStrategy`](#cdk8s_plus_20.DeploymentStrategy)
 - *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
 
 Specifies the strategy used to replace old Pods by new ones.
 
 ---
 
-### DeploymentStrategyRollingUpdateOptions <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions"></a>
+### DeploymentStrategyRollingUpdateOptions <a name="cdk8s_plus_20.DeploymentStrategyRollingUpdateOptions"></a>
 
 Options for `DeploymentStrategy.rollingUpdate`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_20
 
-cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions(
+cdk8s_plus_20.DeploymentStrategyRollingUpdateOptions(
   max_surge: PercentOrAbsolute = None,
   max_unavailable: PercentOrAbsolute = None
 )
 ```
 
-##### `max_surge`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions.property.max_surge"></a>
+##### `max_surge`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentStrategyRollingUpdateOptions.property.max_surge"></a>
 
 ```python
 max_surge: PercentOrAbsolute
 ```
 
-- *Type:* [`cdk8s_plus_22.PercentOrAbsolute`](#cdk8s_plus_22.PercentOrAbsolute)
+- *Type:* [`cdk8s_plus_20.PercentOrAbsolute`](#cdk8s_plus_20.PercentOrAbsolute)
 - *Default:* '25%'
 
 The maximum number of pods that can be scheduled above the desired number of pods.
@@ -8766,13 +8766,13 @@ total number of pods running at any time during the update is at most 130% of de
 
 ---
 
-##### `max_unavailable`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions.property.max_unavailable"></a>
+##### `max_unavailable`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentStrategyRollingUpdateOptions.property.max_unavailable"></a>
 
 ```python
 max_unavailable: PercentOrAbsolute
 ```
 
-- *Type:* [`cdk8s_plus_22.PercentOrAbsolute`](#cdk8s_plus_22.PercentOrAbsolute)
+- *Type:* [`cdk8s_plus_20.PercentOrAbsolute`](#cdk8s_plus_20.PercentOrAbsolute)
 - *Default:* '25%'
 
 The maximum number of pods that can be unavailable during the update.
@@ -8788,7 +8788,7 @@ number of pods available at all times during the update is at least 70% of desir
 
 ---
 
-### DockerConfigSecretProps <a name="cdk8s_plus_22.DockerConfigSecretProps"></a>
+### DockerConfigSecretProps <a name="cdk8s_plus_20.DockerConfigSecretProps"></a>
 
 Options for `DockerConfigSecret`.
 
@@ -13314,35 +13314,35 @@ amount: str
 ---
 
 
-### DeploymentStrategy <a name="cdk8s_plus_22.DeploymentStrategy"></a>
+### DeploymentStrategy <a name="cdk8s_plus_20.DeploymentStrategy"></a>
 
 Deployment strategies.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `recreate` <a name="cdk8s_plus_22.DeploymentStrategy.recreate"></a>
+##### `recreate` <a name="cdk8s_plus_20.DeploymentStrategy.recreate"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_20
 
-cdk8s_plus_22.DeploymentStrategy.recreate()
+cdk8s_plus_20.DeploymentStrategy.recreate()
 ```
 
-##### `rolling_update` <a name="cdk8s_plus_22.DeploymentStrategy.rolling_update"></a>
+##### `rolling_update` <a name="cdk8s_plus_20.DeploymentStrategy.rolling_update"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_20
 
-cdk8s_plus_22.DeploymentStrategy.rolling_update(
+cdk8s_plus_20.DeploymentStrategy.rolling_update(
   max_surge: PercentOrAbsolute = None,
   max_unavailable: PercentOrAbsolute = None
 )
 ```
 
-###### `max_surge`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions.parameter.max_surge"></a>
+###### `max_surge`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentStrategyRollingUpdateOptions.parameter.max_surge"></a>
 
-- *Type:* [`cdk8s_plus_22.PercentOrAbsolute`](#cdk8s_plus_22.PercentOrAbsolute)
+- *Type:* [`cdk8s_plus_20.PercentOrAbsolute`](#cdk8s_plus_20.PercentOrAbsolute)
 - *Default:* '25%'
 
 The maximum number of pods that can be scheduled above the desired number of pods.
@@ -13358,9 +13358,9 @@ total number of pods running at any time during the update is at most 130% of de
 
 ---
 
-###### `max_unavailable`<sup>Optional</sup> <a name="cdk8s_plus_22.DeploymentStrategyRollingUpdateOptions.parameter.max_unavailable"></a>
+###### `max_unavailable`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentStrategyRollingUpdateOptions.parameter.max_unavailable"></a>
 
-- *Type:* [`cdk8s_plus_22.PercentOrAbsolute`](#cdk8s_plus_22.PercentOrAbsolute)
+- *Type:* [`cdk8s_plus_20.PercentOrAbsolute`](#cdk8s_plus_20.PercentOrAbsolute)
 - *Default:* '25%'
 
 The maximum number of pods that can be unavailable during the update.
@@ -13378,7 +13378,7 @@ number of pods available at all times during the update is at least 70% of desir
 
 
 
-### EnvValue <a name="cdk8s_plus_22.EnvValue"></a>
+### EnvValue <a name="cdk8s_plus_20.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
@@ -13728,13 +13728,13 @@ The port to use to access the service.
 
 
 
-### PercentOrAbsolute <a name="cdk8s_plus_22.PercentOrAbsolute"></a>
+### PercentOrAbsolute <a name="cdk8s_plus_20.PercentOrAbsolute"></a>
 
 Union like class repsenting either a ration in percents or an absolute number.
 
 #### Methods <a name="Methods"></a>
 
-##### `is_zero` <a name="cdk8s_plus_22.PercentOrAbsolute.is_zero"></a>
+##### `is_zero` <a name="cdk8s_plus_20.PercentOrAbsolute.is_zero"></a>
 
 ```python
 def is_zero()
@@ -13742,33 +13742,33 @@ def is_zero()
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `absolute` <a name="cdk8s_plus_22.PercentOrAbsolute.absolute"></a>
+##### `absolute` <a name="cdk8s_plus_20.PercentOrAbsolute.absolute"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_20
 
-cdk8s_plus_22.PercentOrAbsolute.absolute(
+cdk8s_plus_20.PercentOrAbsolute.absolute(
   num: typing.Union[int, float]
 )
 ```
 
-###### `num`<sup>Required</sup> <a name="cdk8s_plus_22.PercentOrAbsolute.parameter.num"></a>
+###### `num`<sup>Required</sup> <a name="cdk8s_plus_20.PercentOrAbsolute.parameter.num"></a>
 
 - *Type:* `typing.Union[int, float]`
 
 ---
 
-##### `percent` <a name="cdk8s_plus_22.PercentOrAbsolute.percent"></a>
+##### `percent` <a name="cdk8s_plus_20.PercentOrAbsolute.percent"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_20
 
-cdk8s_plus_22.PercentOrAbsolute.percent(
+cdk8s_plus_20.PercentOrAbsolute.percent(
   percent: typing.Union[int, float]
 )
 ```
 
-###### `percent`<sup>Required</sup> <a name="cdk8s_plus_22.PercentOrAbsolute.parameter.percent"></a>
+###### `percent`<sup>Required</sup> <a name="cdk8s_plus_20.PercentOrAbsolute.parameter.percent"></a>
 
 - *Type:* `typing.Union[int, float]`
 
@@ -13776,7 +13776,7 @@ cdk8s_plus_22.PercentOrAbsolute.percent(
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Required</sup> <a name="cdk8s_plus_22.PercentOrAbsolute.property.value"></a>
+##### `value`<sup>Required</sup> <a name="cdk8s_plus_20.PercentOrAbsolute.property.value"></a>
 
 ```python
 value: typing.Any
@@ -13787,7 +13787,7 @@ value: typing.Any
 ---
 
 
-### PodSecurityContext <a name="cdk8s_plus_22.PodSecurityContext"></a>
+### PodSecurityContext <a name="cdk8s_plus_20.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -913,19 +913,19 @@ public readonly securityContext: PodSecurityContext;
 
 ---
 
-##### `strategy`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.strategy"></a>
+##### `strategy`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.property.strategy"></a>
 
 ```typescript
 public readonly strategy: DeploymentStrategy;
 ```
 
-- *Type:* [`cdk8s-plus-22.DeploymentStrategy`](#cdk8s-plus-22.DeploymentStrategy)
+- *Type:* [`cdk8s-plus-20.DeploymentStrategy`](#cdk8s-plus-20.DeploymentStrategy)
 
 The upgrade strategy of this deployment.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
@@ -4645,38 +4645,38 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentProps.property.strategy"></a>
 
 ```typescript
 public readonly strategy: DeploymentStrategy;
 ```
 
-- *Type:* [`cdk8s-plus-22.DeploymentStrategy`](#cdk8s-plus-22.DeploymentStrategy)
+- *Type:* [`cdk8s-plus-20.DeploymentStrategy`](#cdk8s-plus-20.DeploymentStrategy)
 - *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
 
 Specifies the strategy used to replace old Pods by new ones.
 
 ---
 
-### DeploymentStrategyRollingUpdateOptions <a name="cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions"></a>
+### DeploymentStrategyRollingUpdateOptions <a name="cdk8s-plus-20.DeploymentStrategyRollingUpdateOptions"></a>
 
 Options for `DeploymentStrategy.rollingUpdate`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { DeploymentStrategyRollingUpdateOptions } from 'cdk8s-plus-22'
+import { DeploymentStrategyRollingUpdateOptions } from 'cdk8s-plus-20'
 
 const deploymentStrategyRollingUpdateOptions: DeploymentStrategyRollingUpdateOptions = { ... }
 ```
 
-##### `maxSurge`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions.property.maxSurge"></a>
+##### `maxSurge`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentStrategyRollingUpdateOptions.property.maxSurge"></a>
 
 ```typescript
 public readonly maxSurge: PercentOrAbsolute;
 ```
 
-- *Type:* [`cdk8s-plus-22.PercentOrAbsolute`](#cdk8s-plus-22.PercentOrAbsolute)
+- *Type:* [`cdk8s-plus-20.PercentOrAbsolute`](#cdk8s-plus-20.PercentOrAbsolute)
 - *Default:* '25%'
 
 The maximum number of pods that can be scheduled above the desired number of pods.
@@ -4692,13 +4692,13 @@ total number of pods running at any time during the update is at most 130% of de
 
 ---
 
-##### `maxUnavailable`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions.property.maxUnavailable"></a>
+##### `maxUnavailable`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentStrategyRollingUpdateOptions.property.maxUnavailable"></a>
 
 ```typescript
 public readonly maxUnavailable: PercentOrAbsolute;
 ```
 
-- *Type:* [`cdk8s-plus-22.PercentOrAbsolute`](#cdk8s-plus-22.PercentOrAbsolute)
+- *Type:* [`cdk8s-plus-20.PercentOrAbsolute`](#cdk8s-plus-20.PercentOrAbsolute)
 - *Default:* '25%'
 
 The maximum number of pods that can be unavailable during the update.
@@ -4714,7 +4714,7 @@ number of pods available at all times during the update is at least 70% of desir
 
 ---
 
-### DockerConfigSecretProps <a name="cdk8s-plus-22.DockerConfigSecretProps"></a>
+### DockerConfigSecretProps <a name="cdk8s-plus-20.DockerConfigSecretProps"></a>
 
 Options for `DockerConfigSecret`.
 
@@ -8702,38 +8702,38 @@ public readonly amount: string;
 ---
 
 
-### DeploymentStrategy <a name="cdk8s-plus-22.DeploymentStrategy"></a>
+### DeploymentStrategy <a name="cdk8s-plus-20.DeploymentStrategy"></a>
 
 Deployment strategies.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `recreate` <a name="cdk8s-plus-22.DeploymentStrategy.recreate"></a>
+##### `recreate` <a name="cdk8s-plus-20.DeploymentStrategy.recreate"></a>
 
 ```typescript
-import { DeploymentStrategy } from 'cdk8s-plus-22'
+import { DeploymentStrategy } from 'cdk8s-plus-20'
 
 DeploymentStrategy.recreate()
 ```
 
-##### `rollingUpdate` <a name="cdk8s-plus-22.DeploymentStrategy.rollingUpdate"></a>
+##### `rollingUpdate` <a name="cdk8s-plus-20.DeploymentStrategy.rollingUpdate"></a>
 
 ```typescript
-import { DeploymentStrategy } from 'cdk8s-plus-22'
+import { DeploymentStrategy } from 'cdk8s-plus-20'
 
 DeploymentStrategy.rollingUpdate(options?: DeploymentStrategyRollingUpdateOptions)
 ```
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentStrategy.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentStrategy.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions`](#cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions)
+- *Type:* [`cdk8s-plus-20.DeploymentStrategyRollingUpdateOptions`](#cdk8s-plus-20.DeploymentStrategyRollingUpdateOptions)
 
 ---
 
 
 
-### EnvValue <a name="cdk8s-plus-22.EnvValue"></a>
+### EnvValue <a name="cdk8s-plus-20.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
@@ -9003,13 +9003,13 @@ The service object.
 
 
 
-### PercentOrAbsolute <a name="cdk8s-plus-22.PercentOrAbsolute"></a>
+### PercentOrAbsolute <a name="cdk8s-plus-20.PercentOrAbsolute"></a>
 
 Union like class repsenting either a ration in percents or an absolute number.
 
 #### Methods <a name="Methods"></a>
 
-##### `isZero` <a name="cdk8s-plus-22.PercentOrAbsolute.isZero"></a>
+##### `isZero` <a name="cdk8s-plus-20.PercentOrAbsolute.isZero"></a>
 
 ```typescript
 public isZero()
@@ -9017,29 +9017,29 @@ public isZero()
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `absolute` <a name="cdk8s-plus-22.PercentOrAbsolute.absolute"></a>
+##### `absolute` <a name="cdk8s-plus-20.PercentOrAbsolute.absolute"></a>
 
 ```typescript
-import { PercentOrAbsolute } from 'cdk8s-plus-22'
+import { PercentOrAbsolute } from 'cdk8s-plus-20'
 
 PercentOrAbsolute.absolute(num: number)
 ```
 
-###### `num`<sup>Required</sup> <a name="cdk8s-plus-22.PercentOrAbsolute.parameter.num"></a>
+###### `num`<sup>Required</sup> <a name="cdk8s-plus-20.PercentOrAbsolute.parameter.num"></a>
 
 - *Type:* `number`
 
 ---
 
-##### `percent` <a name="cdk8s-plus-22.PercentOrAbsolute.percent"></a>
+##### `percent` <a name="cdk8s-plus-20.PercentOrAbsolute.percent"></a>
 
 ```typescript
-import { PercentOrAbsolute } from 'cdk8s-plus-22'
+import { PercentOrAbsolute } from 'cdk8s-plus-20'
 
 PercentOrAbsolute.percent(percent: number)
 ```
 
-###### `percent`<sup>Required</sup> <a name="cdk8s-plus-22.PercentOrAbsolute.parameter.percent"></a>
+###### `percent`<sup>Required</sup> <a name="cdk8s-plus-20.PercentOrAbsolute.parameter.percent"></a>
 
 - *Type:* `number`
 
@@ -9047,7 +9047,7 @@ PercentOrAbsolute.percent(percent: number)
 
 #### Properties <a name="Properties"></a>
 
-##### `value`<sup>Required</sup> <a name="cdk8s-plus-22.PercentOrAbsolute.property.value"></a>
+##### `value`<sup>Required</sup> <a name="cdk8s-plus-20.PercentOrAbsolute.property.value"></a>
 
 ```typescript
 public readonly value: any;
@@ -9058,7 +9058,7 @@ public readonly value: any;
 ---
 
 
-### PodSecurityContext <a name="cdk8s-plus-22.PodSecurityContext"></a>
+### PodSecurityContext <a name="cdk8s-plus-20.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -913,7 +913,19 @@ public readonly securityContext: PodSecurityContext;
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.property.volumes"></a>
+##### `strategy`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.strategy"></a>
+
+```typescript
+public readonly strategy: DeploymentStrategy;
+```
+
+- *Type:* [`cdk8s-plus-22.DeploymentStrategy`](#cdk8s-plus-22.DeploymentStrategy)
+
+The upgrade strategy of this deployment.
+
+---
+
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.Deployment.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
@@ -4633,7 +4645,76 @@ Number of desired pods.
 
 ---
 
-### DockerConfigSecretProps <a name="cdk8s-plus-20.DockerConfigSecretProps"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentProps.property.strategy"></a>
+
+```typescript
+public readonly strategy: DeploymentStrategy;
+```
+
+- *Type:* [`cdk8s-plus-22.DeploymentStrategy`](#cdk8s-plus-22.DeploymentStrategy)
+- *Default:* RollingUpdate with maxSurge and maxUnavailable set to 25%.
+
+Specifies the strategy used to replace old Pods by new ones.
+
+---
+
+### DeploymentStrategyRollingUpdateOptions <a name="cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions"></a>
+
+Options for `DeploymentStrategy.rollingUpdate`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { DeploymentStrategyRollingUpdateOptions } from 'cdk8s-plus-22'
+
+const deploymentStrategyRollingUpdateOptions: DeploymentStrategyRollingUpdateOptions = { ... }
+```
+
+##### `maxSurge`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions.property.maxSurge"></a>
+
+```typescript
+public readonly maxSurge: PercentOrAbsolute;
+```
+
+- *Type:* [`cdk8s-plus-22.PercentOrAbsolute`](#cdk8s-plus-22.PercentOrAbsolute)
+- *Default:* '25%'
+
+The maximum number of pods that can be scheduled above the desired number of pods.
+
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding up.
+This can not be 0 if `maxUnavailable` is 0.
+
+Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update
+starts, such that the total number of old and new pods do not exceed 130% of desired pods.
+Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that
+total number of pods running at any time during the update is at most 130% of desired pods.
+
+---
+
+##### `maxUnavailable`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions.property.maxUnavailable"></a>
+
+```typescript
+public readonly maxUnavailable: PercentOrAbsolute;
+```
+
+- *Type:* [`cdk8s-plus-22.PercentOrAbsolute`](#cdk8s-plus-22.PercentOrAbsolute)
+- *Default:* '25%'
+
+The maximum number of pods that can be unavailable during the update.
+
+Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+Absolute number is calculated from percentage by rounding down.
+This can not be 0 if `maxSurge` is 0.
+
+Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired
+pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can
+be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total
+number of pods available at all times during the update is at least 70% of desired pods.
+
+---
+
+### DockerConfigSecretProps <a name="cdk8s-plus-22.DockerConfigSecretProps"></a>
 
 Options for `DockerConfigSecret`.
 
@@ -8621,7 +8702,38 @@ public readonly amount: string;
 ---
 
 
-### EnvValue <a name="cdk8s-plus-20.EnvValue"></a>
+### DeploymentStrategy <a name="cdk8s-plus-22.DeploymentStrategy"></a>
+
+Deployment strategies.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `recreate` <a name="cdk8s-plus-22.DeploymentStrategy.recreate"></a>
+
+```typescript
+import { DeploymentStrategy } from 'cdk8s-plus-22'
+
+DeploymentStrategy.recreate()
+```
+
+##### `rollingUpdate` <a name="cdk8s-plus-22.DeploymentStrategy.rollingUpdate"></a>
+
+```typescript
+import { DeploymentStrategy } from 'cdk8s-plus-22'
+
+DeploymentStrategy.rollingUpdate(options?: DeploymentStrategyRollingUpdateOptions)
+```
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.DeploymentStrategy.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions`](#cdk8s-plus-22.DeploymentStrategyRollingUpdateOptions)
+
+---
+
+
+
+### EnvValue <a name="cdk8s-plus-22.EnvValue"></a>
 
 Utility class for creating reading env values from various sources.
 
@@ -8891,7 +9003,62 @@ The service object.
 
 
 
-### PodSecurityContext <a name="cdk8s-plus-20.PodSecurityContext"></a>
+### PercentOrAbsolute <a name="cdk8s-plus-22.PercentOrAbsolute"></a>
+
+Union like class repsenting either a ration in percents or an absolute number.
+
+#### Methods <a name="Methods"></a>
+
+##### `isZero` <a name="cdk8s-plus-22.PercentOrAbsolute.isZero"></a>
+
+```typescript
+public isZero()
+```
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `absolute` <a name="cdk8s-plus-22.PercentOrAbsolute.absolute"></a>
+
+```typescript
+import { PercentOrAbsolute } from 'cdk8s-plus-22'
+
+PercentOrAbsolute.absolute(num: number)
+```
+
+###### `num`<sup>Required</sup> <a name="cdk8s-plus-22.PercentOrAbsolute.parameter.num"></a>
+
+- *Type:* `number`
+
+---
+
+##### `percent` <a name="cdk8s-plus-22.PercentOrAbsolute.percent"></a>
+
+```typescript
+import { PercentOrAbsolute } from 'cdk8s-plus-22'
+
+PercentOrAbsolute.percent(percent: number)
+```
+
+###### `percent`<sup>Required</sup> <a name="cdk8s-plus-22.PercentOrAbsolute.parameter.percent"></a>
+
+- *Type:* `number`
+
+---
+
+#### Properties <a name="Properties"></a>
+
+##### `value`<sup>Required</sup> <a name="cdk8s-plus-22.PercentOrAbsolute.property.value"></a>
+
+```typescript
+public readonly value: any;
+```
+
+- *Type:* `any`
+
+---
+
+
+### PodSecurityContext <a name="cdk8s-plus-22.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
 

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -15,6 +15,13 @@ Array [
           "cdk8s.deployment": "test-Deployment-c83f5e59",
         },
       },
+      "strategy": Object {
+        "rollingUpdate": Object {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%",
+        },
+        "type": "RollingUpdate",
+      },
       "template": Object {
         "metadata": Object {
           "labels": Object {

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -1,6 +1,8 @@
 import { Testing, ApiObject } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
+import { DeploymentStrategy, PercentOrAbsolute } from '../src';
+import * as k8s from '../src/imports/k8s';
 
 test('defaultChild', () => {
 
@@ -199,5 +201,60 @@ test('Synthesizes spec lazily', () => {
 
   expect(container.image).toEqual('image');
   expect(container.ports[0].containerPort).toEqual(9300);
+
+});
+
+test('default deployment strategy', () => {
+
+  const chart = Testing.chart();
+
+  const deployment = new kplus.Deployment(chart, 'Deployment');
+  deployment.addContainer({ image: 'image' });
+
+  const spec: k8s.DeploymentSpec = Testing.synth(chart)[0].spec;
+
+  expect(deployment.strategy).toEqual(DeploymentStrategy.rollingUpdate());
+  expect(spec.strategy).toEqual({
+    type: 'RollingUpdate',
+    rollingUpdate: {
+      maxSurge: '25%',
+      maxUnavailable: '25%',
+    },
+  });
+
+});
+
+test('custom deployment strategy', () => {
+
+  const chart = Testing.chart();
+
+  const deployment = new kplus.Deployment(chart, 'Deployment', {
+    strategy: DeploymentStrategy.recreate(),
+  });
+  deployment.addContainer({ image: 'image' });
+
+  const spec: k8s.DeploymentSpec = Testing.synth(chart)[0].spec;
+
+  expect(deployment.strategy).toEqual(DeploymentStrategy.recreate());
+  expect(spec.strategy).toEqual({ type: 'Recreate' });
+
+});
+
+test('throws is maxSurge and maxUnavailable is set to zero for rolling update', () => {
+
+  const chart = Testing.chart();
+
+  expect(() => new kplus.Deployment(chart, 'Deployment', {
+    containers: [{ image: 'image' }],
+    strategy: DeploymentStrategy.rollingUpdate({ maxSurge: PercentOrAbsolute.absolute(0), maxUnavailable: PercentOrAbsolute.percent(0) }),
+  })).toThrowError('\'maxSurge\' and \'maxUnavailable\' cannot be both zero');
+});
+
+test('PercentOrAbsoulte zero', () => {
+
+  expect(PercentOrAbsolute.percent(0).isZero()).toBeTruthy();
+  expect(PercentOrAbsolute.absolute(0).isZero()).toBeTruthy();
+  expect(PercentOrAbsolute.percent(1).isZero()).toBeFalsy();
+  expect(PercentOrAbsolute.absolute(1).isZero()).toBeFalsy();
 
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [feat(deployment): upgrade strategy (#521)](https://github.com/cdk8s-team/cdk8s-plus/pull/521)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)