### PR TITLE
feat(stateful-set): update strategy (#523)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -4087,6 +4087,7 @@ StatefulSet.Builder.create(Construct scope, java.lang.String id)
 //  .defaultSelector(java.lang.Boolean)
 //  .podManagementPolicy(PodManagementPolicy)
 //  .replicas(java.lang.Number)
+//  .strategy(StatefulSetUpdateStrategy)
     .build();
 ```
 
@@ -4257,6 +4258,15 @@ Pod management policy to use for this statefulset.
 - *Default:* 1
 
 Number of desired pods.
+
+---
+
+##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.strategy"></a>
+
+- *Type:* [`org.cdk8s.plus22.StatefulSetUpdateStrategy`](#org.cdk8s.plus22.StatefulSetUpdateStrategy)
+- *Default:* RollingUpdate with partition set to 0
+
+Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 
 ---
 
@@ -4437,7 +4447,19 @@ public PodSecurityContext getSecurityContext();
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus20.StatefulSet.property.volumes"></a>
+##### `strategy`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.strategy"></a>
+
+```java
+public StatefulSetUpdateStrategy getStrategy();
+```
+
+- *Type:* [`org.cdk8s.plus22.StatefulSetUpdateStrategy`](#org.cdk8s.plus22.StatefulSetUpdateStrategy)
+
+The update startegy of this stateful set.
+
+---
+
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
@@ -9929,6 +9951,7 @@ StatefulSetProps.builder()
 //  .defaultSelector(java.lang.Boolean)
 //  .podManagementPolicy(PodManagementPolicy)
 //  .replicas(java.lang.Number)
+//  .strategy(StatefulSetUpdateStrategy)
     .build();
 ```
 
@@ -10146,7 +10169,53 @@ Number of desired pods.
 
 ---
 
-### Sysctl <a name="org.cdk8s.plus20.Sysctl"></a>
+##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.strategy"></a>
+
+```java
+public StatefulSetUpdateStrategy getStrategy();
+```
+
+- *Type:* [`org.cdk8s.plus22.StatefulSetUpdateStrategy`](#org.cdk8s.plus22.StatefulSetUpdateStrategy)
+- *Default:* RollingUpdate with partition set to 0
+
+Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+
+---
+
+### StatefulSetUpdateStrategyRollingUpdateOptions <a name="org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
+
+Options for `StatefulSetUpdateStrategy.rollingUpdate`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions;
+
+StatefulSetUpdateStrategyRollingUpdateOptions.builder()
+//  .partition(java.lang.Number)
+    .build();
+```
+
+##### `partition`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
+
+```java
+public java.lang.Number getPartition();
+```
+
+- *Type:* `java.lang.Number`
+- *Default:* 0
+
+If specified, all Pods with an ordinal that is greater than or equal to the partition will be updated when the StatefulSet's .spec.template is updated. All Pods with an ordinal that is less than the partition will not be updated, and, even if they are deleted, they will be recreated at the previous version.
+
+If the partition is greater than replicas, updates to the pod template will not be propagated to Pods.
+In most cases you will not need to use a partition, but they are useful if you want to stage an
+update, roll out a canary, or perform a phased roll out.
+
+> https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+
+---
+
+### Sysctl <a name="org.cdk8s.plus22.Sysctl"></a>
 
 Sysctl defines a kernel parameter to be set.
 
@@ -12072,7 +12141,39 @@ Options.
 
 
 
-### Volume <a name="org.cdk8s.plus20.Volume"></a>
+### StatefulSetUpdateStrategy <a name="org.cdk8s.plus22.StatefulSetUpdateStrategy"></a>
+
+StatefulSet update strategies.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `onDelete` <a name="org.cdk8s.plus22.StatefulSetUpdateStrategy.onDelete"></a>
+
+```java
+import org.cdk8s.plus22.StatefulSetUpdateStrategy;
+
+StatefulSetUpdateStrategy.onDelete()
+```
+
+##### `rollingUpdate` <a name="org.cdk8s.plus22.StatefulSetUpdateStrategy.rollingUpdate"></a>
+
+```java
+import org.cdk8s.plus22.StatefulSetUpdateStrategy;
+
+StatefulSetUpdateStrategy.rollingUpdate()
+StatefulSetUpdateStrategy.rollingUpdate(StatefulSetUpdateStrategyRollingUpdateOptions options)
+```
+
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetUpdateStrategy.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions`](#org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions)
+
+---
+
+
+
+### Volume <a name="org.cdk8s.plus22.Volume"></a>
 
 - *Implements:* [`org.cdk8s.plus20.IStorage`](#org.cdk8s.plus20.IStorage)
 

--- a/docs/java.md
+++ b/docs/java.md
@@ -4261,9 +4261,9 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.parameter.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.parameter.strategy"></a>
 
-- *Type:* [`org.cdk8s.plus22.StatefulSetUpdateStrategy`](#org.cdk8s.plus22.StatefulSetUpdateStrategy)
+- *Type:* [`org.cdk8s.plus20.StatefulSetUpdateStrategy`](#org.cdk8s.plus20.StatefulSetUpdateStrategy)
 - *Default:* RollingUpdate with partition set to 0
 
 Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
@@ -4447,19 +4447,19 @@ public PodSecurityContext getSecurityContext();
 
 ---
 
-##### `strategy`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.strategy"></a>
+##### `strategy`<sup>Required</sup> <a name="org.cdk8s.plus20.StatefulSet.property.strategy"></a>
 
 ```java
 public StatefulSetUpdateStrategy getStrategy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.StatefulSetUpdateStrategy`](#org.cdk8s.plus22.StatefulSetUpdateStrategy)
+- *Type:* [`org.cdk8s.plus20.StatefulSetUpdateStrategy`](#org.cdk8s.plus20.StatefulSetUpdateStrategy)
 
 The update startegy of this stateful set.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus22.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="org.cdk8s.plus20.StatefulSet.property.volumes"></a>
 
 ```java
 public java.util.List<Volume> getVolumes();
@@ -10169,34 +10169,34 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetProps.property.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.property.strategy"></a>
 
 ```java
 public StatefulSetUpdateStrategy getStrategy();
 ```
 
-- *Type:* [`org.cdk8s.plus22.StatefulSetUpdateStrategy`](#org.cdk8s.plus22.StatefulSetUpdateStrategy)
+- *Type:* [`org.cdk8s.plus20.StatefulSetUpdateStrategy`](#org.cdk8s.plus20.StatefulSetUpdateStrategy)
 - *Default:* RollingUpdate with partition set to 0
 
 Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 
 ---
 
-### StatefulSetUpdateStrategyRollingUpdateOptions <a name="org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
+### StatefulSetUpdateStrategyRollingUpdateOptions <a name="org.cdk8s.plus20.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
 
 Options for `StatefulSetUpdateStrategy.rollingUpdate`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```java
-import org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions;
+import org.cdk8s.plus20.StatefulSetUpdateStrategyRollingUpdateOptions;
 
 StatefulSetUpdateStrategyRollingUpdateOptions.builder()
 //  .partition(java.lang.Number)
     .build();
 ```
 
-##### `partition`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
+##### `partition`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
 
 ```java
 public java.lang.Number getPartition();
@@ -10215,7 +10215,7 @@ update, roll out a canary, or perform a phased roll out.
 
 ---
 
-### Sysctl <a name="org.cdk8s.plus22.Sysctl"></a>
+### Sysctl <a name="org.cdk8s.plus20.Sysctl"></a>
 
 Sysctl defines a kernel parameter to be set.
 
@@ -12141,39 +12141,39 @@ Options.
 
 
 
-### StatefulSetUpdateStrategy <a name="org.cdk8s.plus22.StatefulSetUpdateStrategy"></a>
+### StatefulSetUpdateStrategy <a name="org.cdk8s.plus20.StatefulSetUpdateStrategy"></a>
 
 StatefulSet update strategies.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `onDelete` <a name="org.cdk8s.plus22.StatefulSetUpdateStrategy.onDelete"></a>
+##### `onDelete` <a name="org.cdk8s.plus20.StatefulSetUpdateStrategy.onDelete"></a>
 
 ```java
-import org.cdk8s.plus22.StatefulSetUpdateStrategy;
+import org.cdk8s.plus20.StatefulSetUpdateStrategy;
 
 StatefulSetUpdateStrategy.onDelete()
 ```
 
-##### `rollingUpdate` <a name="org.cdk8s.plus22.StatefulSetUpdateStrategy.rollingUpdate"></a>
+##### `rollingUpdate` <a name="org.cdk8s.plus20.StatefulSetUpdateStrategy.rollingUpdate"></a>
 
 ```java
-import org.cdk8s.plus22.StatefulSetUpdateStrategy;
+import org.cdk8s.plus20.StatefulSetUpdateStrategy;
 
 StatefulSetUpdateStrategy.rollingUpdate()
 StatefulSetUpdateStrategy.rollingUpdate(StatefulSetUpdateStrategyRollingUpdateOptions options)
 ```
 
-###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus22.StatefulSetUpdateStrategy.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetUpdateStrategy.parameter.options"></a>
 
-- *Type:* [`org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions`](#org.cdk8s.plus22.StatefulSetUpdateStrategyRollingUpdateOptions)
+- *Type:* [`org.cdk8s.plus20.StatefulSetUpdateStrategyRollingUpdateOptions`](#org.cdk8s.plus20.StatefulSetUpdateStrategyRollingUpdateOptions)
 
 ---
 
 
 
-### Volume <a name="org.cdk8s.plus22.Volume"></a>
+### Volume <a name="org.cdk8s.plus20.Volume"></a>
 
 - *Implements:* [`org.cdk8s.plus20.IStorage`](#org.cdk8s.plus20.IStorage)
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -6092,9 +6092,9 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.parameter.strategy"></a>
 
-- *Type:* [`cdk8s_plus_22.StatefulSetUpdateStrategy`](#cdk8s_plus_22.StatefulSetUpdateStrategy)
+- *Type:* [`cdk8s_plus_20.StatefulSetUpdateStrategy`](#cdk8s_plus_20.StatefulSetUpdateStrategy)
 - *Default:* RollingUpdate with partition set to 0
 
 Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
@@ -6652,19 +6652,19 @@ security_context: PodSecurityContext
 
 ---
 
-##### `strategy`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.strategy"></a>
+##### `strategy`<sup>Required</sup> <a name="cdk8s_plus_20.StatefulSet.property.strategy"></a>
 
 ```python
 strategy: StatefulSetUpdateStrategy
 ```
 
-- *Type:* [`cdk8s_plus_22.StatefulSetUpdateStrategy`](#cdk8s_plus_22.StatefulSetUpdateStrategy)
+- *Type:* [`cdk8s_plus_20.StatefulSetUpdateStrategy`](#cdk8s_plus_20.StatefulSetUpdateStrategy)
 
 The update startegy of this stateful set.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_20.StatefulSet.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
@@ -12376,34 +12376,34 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.property.strategy"></a>
 
 ```python
 strategy: StatefulSetUpdateStrategy
 ```
 
-- *Type:* [`cdk8s_plus_22.StatefulSetUpdateStrategy`](#cdk8s_plus_22.StatefulSetUpdateStrategy)
+- *Type:* [`cdk8s_plus_20.StatefulSetUpdateStrategy`](#cdk8s_plus_20.StatefulSetUpdateStrategy)
 - *Default:* RollingUpdate with partition set to 0
 
 Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 
 ---
 
-### StatefulSetUpdateStrategyRollingUpdateOptions <a name="cdk8s_plus_22.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
+### StatefulSetUpdateStrategyRollingUpdateOptions <a name="cdk8s_plus_20.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
 
 Options for `StatefulSetUpdateStrategy.rollingUpdate`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_20
 
-cdk8s_plus_22.StatefulSetUpdateStrategyRollingUpdateOptions(
+cdk8s_plus_20.StatefulSetUpdateStrategyRollingUpdateOptions(
   partition: typing.Union[int, float] = None
 )
 ```
 
-##### `partition`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
+##### `partition`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
 
 ```python
 partition: typing.Union[int, float]
@@ -12422,7 +12422,7 @@ update, roll out a canary, or perform a phased roll out.
 
 ---
 
-### Sysctl <a name="cdk8s_plus_22.Sysctl"></a>
+### Sysctl <a name="cdk8s_plus_20.Sysctl"></a>
 
 Sysctl defines a kernel parameter to be set.
 
@@ -15077,32 +15077,32 @@ The TCP port to connect to on the container.
 
 
 
-### StatefulSetUpdateStrategy <a name="cdk8s_plus_22.StatefulSetUpdateStrategy"></a>
+### StatefulSetUpdateStrategy <a name="cdk8s_plus_20.StatefulSetUpdateStrategy"></a>
 
 StatefulSet update strategies.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `on_delete` <a name="cdk8s_plus_22.StatefulSetUpdateStrategy.on_delete"></a>
+##### `on_delete` <a name="cdk8s_plus_20.StatefulSetUpdateStrategy.on_delete"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_20
 
-cdk8s_plus_22.StatefulSetUpdateStrategy.on_delete()
+cdk8s_plus_20.StatefulSetUpdateStrategy.on_delete()
 ```
 
-##### `rolling_update` <a name="cdk8s_plus_22.StatefulSetUpdateStrategy.rolling_update"></a>
+##### `rolling_update` <a name="cdk8s_plus_20.StatefulSetUpdateStrategy.rolling_update"></a>
 
 ```python
-import cdk8s_plus_22
+import cdk8s_plus_20
 
-cdk8s_plus_22.StatefulSetUpdateStrategy.rolling_update(
+cdk8s_plus_20.StatefulSetUpdateStrategy.rolling_update(
   partition: typing.Union[int, float] = None
 )
 ```
 
-###### `partition`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetUpdateStrategyRollingUpdateOptions.parameter.partition"></a>
+###### `partition`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetUpdateStrategyRollingUpdateOptions.parameter.partition"></a>
 
 - *Type:* `typing.Union[int, float]`
 - *Default:* 0
@@ -15119,7 +15119,7 @@ update, roll out a canary, or perform a phased roll out.
 
 
 
-### Volume <a name="cdk8s_plus_22.Volume"></a>
+### Volume <a name="cdk8s_plus_20.Volume"></a>
 
 - *Implements:* [`cdk8s_plus_20.IStorage`](#cdk8s_plus_20.IStorage)
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -5917,7 +5917,8 @@ cdk8s_plus_20.StatefulSet(
   service: Service,
   default_selector: bool = None,
   pod_management_policy: PodManagementPolicy = None,
-  replicas: typing.Union[int, float] = None
+  replicas: typing.Union[int, float] = None,
+  strategy: StatefulSetUpdateStrategy = None
 )
 ```
 
@@ -6088,6 +6089,15 @@ Pod management policy to use for this statefulset.
 - *Default:* 1
 
 Number of desired pods.
+
+---
+
+##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.parameter.strategy"></a>
+
+- *Type:* [`cdk8s_plus_22.StatefulSetUpdateStrategy`](#cdk8s_plus_22.StatefulSetUpdateStrategy)
+- *Default:* RollingUpdate with partition set to 0
+
+Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 
 ---
 
@@ -6642,7 +6652,19 @@ security_context: PodSecurityContext
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_20.StatefulSet.property.volumes"></a>
+##### `strategy`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.strategy"></a>
+
+```python
+strategy: StatefulSetUpdateStrategy
+```
+
+- *Type:* [`cdk8s_plus_22.StatefulSetUpdateStrategy`](#cdk8s_plus_22.StatefulSetUpdateStrategy)
+
+The update startegy of this stateful set.
+
+---
+
+##### `volumes`<sup>Required</sup> <a name="cdk8s_plus_22.StatefulSet.property.volumes"></a>
 
 ```python
 volumes: typing.List[Volume]
@@ -12135,7 +12157,8 @@ cdk8s_plus_20.StatefulSetProps(
   service: Service,
   default_selector: bool = None,
   pod_management_policy: PodManagementPolicy = None,
-  replicas: typing.Union[int, float] = None
+  replicas: typing.Union[int, float] = None,
+  strategy: StatefulSetUpdateStrategy = None
 )
 ```
 
@@ -12353,7 +12376,53 @@ Number of desired pods.
 
 ---
 
-### Sysctl <a name="cdk8s_plus_20.Sysctl"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetProps.property.strategy"></a>
+
+```python
+strategy: StatefulSetUpdateStrategy
+```
+
+- *Type:* [`cdk8s_plus_22.StatefulSetUpdateStrategy`](#cdk8s_plus_22.StatefulSetUpdateStrategy)
+- *Default:* RollingUpdate with partition set to 0
+
+Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+
+---
+
+### StatefulSetUpdateStrategyRollingUpdateOptions <a name="cdk8s_plus_22.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
+
+Options for `StatefulSetUpdateStrategy.rollingUpdate`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.StatefulSetUpdateStrategyRollingUpdateOptions(
+  partition: typing.Union[int, float] = None
+)
+```
+
+##### `partition`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
+
+```python
+partition: typing.Union[int, float]
+```
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* 0
+
+If specified, all Pods with an ordinal that is greater than or equal to the partition will be updated when the StatefulSet's .spec.template is updated. All Pods with an ordinal that is less than the partition will not be updated, and, even if they are deleted, they will be recreated at the previous version.
+
+If the partition is greater than replicas, updates to the pod template will not be propagated to Pods.
+In most cases you will not need to use a partition, but they are useful if you want to stage an
+update, roll out a canary, or perform a phased roll out.
+
+> https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+
+---
+
+### Sysctl <a name="cdk8s_plus_22.Sysctl"></a>
 
 Sysctl defines a kernel parameter to be set.
 
@@ -15008,7 +15077,49 @@ The TCP port to connect to on the container.
 
 
 
-### Volume <a name="cdk8s_plus_20.Volume"></a>
+### StatefulSetUpdateStrategy <a name="cdk8s_plus_22.StatefulSetUpdateStrategy"></a>
+
+StatefulSet update strategies.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `on_delete` <a name="cdk8s_plus_22.StatefulSetUpdateStrategy.on_delete"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.StatefulSetUpdateStrategy.on_delete()
+```
+
+##### `rolling_update` <a name="cdk8s_plus_22.StatefulSetUpdateStrategy.rolling_update"></a>
+
+```python
+import cdk8s_plus_22
+
+cdk8s_plus_22.StatefulSetUpdateStrategy.rolling_update(
+  partition: typing.Union[int, float] = None
+)
+```
+
+###### `partition`<sup>Optional</sup> <a name="cdk8s_plus_22.StatefulSetUpdateStrategyRollingUpdateOptions.parameter.partition"></a>
+
+- *Type:* `typing.Union[int, float]`
+- *Default:* 0
+
+If specified, all Pods with an ordinal that is greater than or equal to the partition will be updated when the StatefulSet's .spec.template is updated. All Pods with an ordinal that is less than the partition will not be updated, and, even if they are deleted, they will be recreated at the previous version.
+
+If the partition is greater than replicas, updates to the pod template will not be propagated to Pods.
+In most cases you will not need to use a partition, but they are useful if you want to stage an
+update, roll out a canary, or perform a phased roll out.
+
+> https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+
+---
+
+
+
+### Volume <a name="cdk8s_plus_22.Volume"></a>
 
 - *Implements:* [`cdk8s_plus_20.IStorage`](#cdk8s_plus_20.IStorage)
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2734,7 +2734,19 @@ public readonly securityContext: PodSecurityContext;
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-20.StatefulSet.property.volumes"></a>
+##### `strategy`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.strategy"></a>
+
+```typescript
+public readonly strategy: StatefulSetUpdateStrategy;
+```
+
+- *Type:* [`cdk8s-plus-22.StatefulSetUpdateStrategy`](#cdk8s-plus-22.StatefulSetUpdateStrategy)
+
+The update startegy of this stateful set.
+
+---
+
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
@@ -8049,7 +8061,51 @@ Number of desired pods.
 
 ---
 
-### Sysctl <a name="cdk8s-plus-20.Sysctl"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.strategy"></a>
+
+```typescript
+public readonly strategy: StatefulSetUpdateStrategy;
+```
+
+- *Type:* [`cdk8s-plus-22.StatefulSetUpdateStrategy`](#cdk8s-plus-22.StatefulSetUpdateStrategy)
+- *Default:* RollingUpdate with partition set to 0
+
+Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+
+---
+
+### StatefulSetUpdateStrategyRollingUpdateOptions <a name="cdk8s-plus-22.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
+
+Options for `StatefulSetUpdateStrategy.rollingUpdate`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { StatefulSetUpdateStrategyRollingUpdateOptions } from 'cdk8s-plus-22'
+
+const statefulSetUpdateStrategyRollingUpdateOptions: StatefulSetUpdateStrategyRollingUpdateOptions = { ... }
+```
+
+##### `partition`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
+
+```typescript
+public readonly partition: number;
+```
+
+- *Type:* `number`
+- *Default:* 0
+
+If specified, all Pods with an ordinal that is greater than or equal to the partition will be updated when the StatefulSet's .spec.template is updated. All Pods with an ordinal that is less than the partition will not be updated, and, even if they are deleted, they will be recreated at the previous version.
+
+If the partition is greater than replicas, updates to the pod template will not be propagated to Pods.
+In most cases you will not need to use a partition, but they are useful if you want to stage an
+update, roll out a canary, or perform a phased roll out.
+
+> https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+
+---
+
+### Sysctl <a name="cdk8s-plus-22.Sysctl"></a>
 
 Sysctl defines a kernel parameter to be set.
 
@@ -9425,7 +9481,38 @@ Options.
 
 
 
-### Volume <a name="cdk8s-plus-20.Volume"></a>
+### StatefulSetUpdateStrategy <a name="cdk8s-plus-22.StatefulSetUpdateStrategy"></a>
+
+StatefulSet update strategies.
+
+
+#### Static Functions <a name="Static Functions"></a>
+
+##### `onDelete` <a name="cdk8s-plus-22.StatefulSetUpdateStrategy.onDelete"></a>
+
+```typescript
+import { StatefulSetUpdateStrategy } from 'cdk8s-plus-22'
+
+StatefulSetUpdateStrategy.onDelete()
+```
+
+##### `rollingUpdate` <a name="cdk8s-plus-22.StatefulSetUpdateStrategy.rollingUpdate"></a>
+
+```typescript
+import { StatefulSetUpdateStrategy } from 'cdk8s-plus-22'
+
+StatefulSetUpdateStrategy.rollingUpdate(options?: StatefulSetUpdateStrategyRollingUpdateOptions)
+```
+
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetUpdateStrategy.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-22.StatefulSetUpdateStrategyRollingUpdateOptions`](#cdk8s-plus-22.StatefulSetUpdateStrategyRollingUpdateOptions)
+
+---
+
+
+
+### Volume <a name="cdk8s-plus-22.Volume"></a>
 
 - *Implements:* [`cdk8s-plus-20.IStorage`](#cdk8s-plus-20.IStorage)
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2734,19 +2734,19 @@ public readonly securityContext: PodSecurityContext;
 
 ---
 
-##### `strategy`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.strategy"></a>
+##### `strategy`<sup>Required</sup> <a name="cdk8s-plus-20.StatefulSet.property.strategy"></a>
 
 ```typescript
 public readonly strategy: StatefulSetUpdateStrategy;
 ```
 
-- *Type:* [`cdk8s-plus-22.StatefulSetUpdateStrategy`](#cdk8s-plus-22.StatefulSetUpdateStrategy)
+- *Type:* [`cdk8s-plus-20.StatefulSetUpdateStrategy`](#cdk8s-plus-20.StatefulSetUpdateStrategy)
 
 The update startegy of this stateful set.
 
 ---
 
-##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-22.StatefulSet.property.volumes"></a>
+##### `volumes`<sup>Required</sup> <a name="cdk8s-plus-20.StatefulSet.property.volumes"></a>
 
 ```typescript
 public readonly volumes: Volume[];
@@ -8061,32 +8061,32 @@ Number of desired pods.
 
 ---
 
-##### `strategy`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetProps.property.strategy"></a>
+##### `strategy`<sup>Optional</sup> <a name="cdk8s-plus-20.StatefulSetProps.property.strategy"></a>
 
 ```typescript
 public readonly strategy: StatefulSetUpdateStrategy;
 ```
 
-- *Type:* [`cdk8s-plus-22.StatefulSetUpdateStrategy`](#cdk8s-plus-22.StatefulSetUpdateStrategy)
+- *Type:* [`cdk8s-plus-20.StatefulSetUpdateStrategy`](#cdk8s-plus-20.StatefulSetUpdateStrategy)
 - *Default:* RollingUpdate with partition set to 0
 
 Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
 
 ---
 
-### StatefulSetUpdateStrategyRollingUpdateOptions <a name="cdk8s-plus-22.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
+### StatefulSetUpdateStrategyRollingUpdateOptions <a name="cdk8s-plus-20.StatefulSetUpdateStrategyRollingUpdateOptions"></a>
 
 Options for `StatefulSetUpdateStrategy.rollingUpdate`.
 
 #### Initializer <a name="[object Object].Initializer"></a>
 
 ```typescript
-import { StatefulSetUpdateStrategyRollingUpdateOptions } from 'cdk8s-plus-22'
+import { StatefulSetUpdateStrategyRollingUpdateOptions } from 'cdk8s-plus-20'
 
 const statefulSetUpdateStrategyRollingUpdateOptions: StatefulSetUpdateStrategyRollingUpdateOptions = { ... }
 ```
 
-##### `partition`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
+##### `partition`<sup>Optional</sup> <a name="cdk8s-plus-20.StatefulSetUpdateStrategyRollingUpdateOptions.property.partition"></a>
 
 ```typescript
 public readonly partition: number;
@@ -8105,7 +8105,7 @@ update, roll out a canary, or perform a phased roll out.
 
 ---
 
-### Sysctl <a name="cdk8s-plus-22.Sysctl"></a>
+### Sysctl <a name="cdk8s-plus-20.Sysctl"></a>
 
 Sysctl defines a kernel parameter to be set.
 
@@ -9481,38 +9481,38 @@ Options.
 
 
 
-### StatefulSetUpdateStrategy <a name="cdk8s-plus-22.StatefulSetUpdateStrategy"></a>
+### StatefulSetUpdateStrategy <a name="cdk8s-plus-20.StatefulSetUpdateStrategy"></a>
 
 StatefulSet update strategies.
 
 
 #### Static Functions <a name="Static Functions"></a>
 
-##### `onDelete` <a name="cdk8s-plus-22.StatefulSetUpdateStrategy.onDelete"></a>
+##### `onDelete` <a name="cdk8s-plus-20.StatefulSetUpdateStrategy.onDelete"></a>
 
 ```typescript
-import { StatefulSetUpdateStrategy } from 'cdk8s-plus-22'
+import { StatefulSetUpdateStrategy } from 'cdk8s-plus-20'
 
 StatefulSetUpdateStrategy.onDelete()
 ```
 
-##### `rollingUpdate` <a name="cdk8s-plus-22.StatefulSetUpdateStrategy.rollingUpdate"></a>
+##### `rollingUpdate` <a name="cdk8s-plus-20.StatefulSetUpdateStrategy.rollingUpdate"></a>
 
 ```typescript
-import { StatefulSetUpdateStrategy } from 'cdk8s-plus-22'
+import { StatefulSetUpdateStrategy } from 'cdk8s-plus-20'
 
 StatefulSetUpdateStrategy.rollingUpdate(options?: StatefulSetUpdateStrategyRollingUpdateOptions)
 ```
 
-###### `options`<sup>Optional</sup> <a name="cdk8s-plus-22.StatefulSetUpdateStrategy.parameter.options"></a>
+###### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.StatefulSetUpdateStrategy.parameter.options"></a>
 
-- *Type:* [`cdk8s-plus-22.StatefulSetUpdateStrategyRollingUpdateOptions`](#cdk8s-plus-22.StatefulSetUpdateStrategyRollingUpdateOptions)
+- *Type:* [`cdk8s-plus-20.StatefulSetUpdateStrategyRollingUpdateOptions`](#cdk8s-plus-20.StatefulSetUpdateStrategyRollingUpdateOptions)
 
 ---
 
 
 
-### Volume <a name="cdk8s-plus-22.Volume"></a>
+### Volume <a name="cdk8s-plus-20.Volume"></a>
 
 - *Implements:* [`cdk8s-plus-20.IStorage`](#cdk8s-plus-20.IStorage)
 

--- a/src/statefulset.ts
+++ b/src/statefulset.ts
@@ -57,6 +57,13 @@ export interface StatefulSetProps extends ResourceProps, PodTemplateProps {
     * @default PodManagementPolicy.ORDERED_READY
     */
   readonly podManagementPolicy?: PodManagementPolicy;
+
+  /**
+   * Indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+   *
+   * @default - RollingUpdate with partition set to 0
+   */
+  readonly strategy?: StatefulSetUpdateStrategy;
 }
 
 /**
@@ -97,6 +104,11 @@ export class StatefulSet extends Resource implements IPodTemplate {
   public readonly podManagementPolicy: PodManagementPolicy;
 
   /**
+   * The update startegy of this stateful set.
+   */
+  public readonly strategy: StatefulSetUpdateStrategy;
+
+  /**
     * @see base.Resource.apiObject
     */
   protected readonly apiObject: ApiObject;
@@ -118,6 +130,7 @@ export class StatefulSet extends Resource implements IPodTemplate {
     this.apiObject.addDependency(this._service);
 
     this.replicas = props.replicas ?? 1;
+    this.strategy = props.strategy ?? StatefulSetUpdateStrategy.rollingUpdate(),
     this.podManagementPolicy = props.podManagementPolicy ?? PodManagementPolicy.ORDERED_READY;
     this._podTemplate = new PodTemplate(props);
     this._labelSelector = {};
@@ -215,6 +228,70 @@ export class StatefulSet extends Resource implements IPodTemplate {
         matchLabels: this._labelSelector,
       },
       podManagementPolicy: this.podManagementPolicy,
+      updateStrategy: this.strategy._toKube(),
     };
   }
+}
+
+/**
+ * Options for `StatefulSetUpdateStrategy.rollingUpdate`.
+ */
+export interface StatefulSetUpdateStrategyRollingUpdateOptions {
+
+  /**
+   * If specified, all Pods with an ordinal that is greater than or equal to the partition will
+   * be updated when the StatefulSet's .spec.template is updated. All Pods with an ordinal that
+   * is less than the partition will not be updated, and, even if they are deleted, they will be
+   * recreated at the previous version.
+   *
+   * If the partition is greater than replicas, updates to the pod template will not be propagated to Pods.
+   * In most cases you will not need to use a partition, but they are useful if you want to stage an
+   * update, roll out a canary, or perform a phased roll out.
+   *
+   * @see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+   * @default 0
+   */
+  readonly partition?: number;
+
+}
+
+/**
+ * StatefulSet update strategies.
+ */
+export class StatefulSetUpdateStrategy {
+
+  /**
+   * The controller will not automatically update the Pods in a StatefulSet.
+   * Users must manually delete Pods to cause the controller to create new Pods
+   * that reflect modifications.
+   */
+  public static onDelete(): StatefulSetUpdateStrategy {
+    return new StatefulSetUpdateStrategy({
+      type: 'OnDelete',
+    });
+  }
+
+  /**
+   * The controller will delete and recreate each Pod in the StatefulSet.
+   * It will proceed in the same order as Pod termination (from the largest ordinal to the smallest),
+   * updating each Pod one at a time. The Kubernetes control plane waits until an updated
+   * Pod is Running and Ready prior to updating its predecessor.
+   */
+  public static rollingUpdate(options: StatefulSetUpdateStrategyRollingUpdateOptions = {}): StatefulSetUpdateStrategy {
+
+    return new StatefulSetUpdateStrategy({
+      type: 'RollingUpdate',
+      rollingUpdate: { partition: options.partition ?? 0 },
+    });
+  }
+
+  private constructor(private readonly strategy: k8s.StatefulSetUpdateStrategy) {}
+
+  /**
+   * @internal
+   */
+  public _toKube(): k8s.StatefulSetUpdateStrategy {
+    return this.strategy;
+  }
+
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [feat(stateful-set): update strategy (#523)](https://github.com/cdk8s-team/cdk8s-plus/pull/523)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)