### PR TITLE
chore(backport): fix hooks setup (#546)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,8 +11,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: setup-hooks
-        run: ./git-hooks/setup.sh
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: hooks
+        run: npx projen hooks
       - name: backport
         uses: tibdex/backport@v1
         with:

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -139,6 +139,14 @@
         }
       ]
     },
+    "hooks": {
+      "name": "hooks",
+      "steps": [
+        {
+          "exec": "./git-hooks/setup.sh"
+        }
+      ]
+    },
     "import": {
       "name": "import",
       "description": "Updates imports based on latest version of cdk8s-cli.",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -109,6 +109,9 @@ docgenTask.exec('jsii-docgen -l typescript -o docs/typescript.md');
 docgenTask.exec('jsii-docgen -l python -o docs/python.md');
 docgenTask.exec('jsii-docgen -l java -o docs/java.md');
 
+const hooks = project.addTask('hooks');
+hooks.exec('./git-hooks/setup.sh');
+
 // backport PR's to other branches
 // see https://github.com/tibdex/backport
 const backport = project.github.addWorkflow('backport');
@@ -120,8 +123,16 @@ backport.addJob('backport', {
   },
   steps: [
     {
-      name: 'setup-hooks',
-      run: './git-hooks/setup.sh',
+      name: 'checkout',
+      uses: 'actions/checkout@v2',
+      with: {
+        ref: '${{ github.event.pull_request.head.ref }}',
+        repository: '${{ github.event.pull_request.head.repo.full_name }}',
+      },
+    },
+    {
+      name: hooks.name,
+      run: `npx projen ${hooks.name}`,
     },
     {
       name: 'backport',

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docgen": "npx projen docgen",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "hooks": "npx projen hooks",
     "import": "npx projen import",
     "package": "npx projen package",
     "package-all": "npx projen package-all",


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [chore(backport): fix hooks setup (#546)](https://github.com/cdk8s-team/cdk8s-plus/pull/546)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)