### PR TITLE
chore(backport): remove refs from checkout since the branch is deleted (#547)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: hooks
         run: npx projen hooks
       - name: backport

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -125,10 +125,6 @@ backport.addJob('backport', {
     {
       name: 'checkout',
       uses: 'actions/checkout@v2',
-      with: {
-        ref: '${{ github.event.pull_request.head.ref }}',
-        repository: '${{ github.event.pull_request.head.repo.full_name }}',
-      },
     },
     {
       name: hooks.name,


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [chore(backport): remove refs from checkout since the branch is deleted (#547)](https://github.com/cdk8s-team/cdk8s-plus/pull/547)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)