### PR TITLE
feat(pod): pod dns settings (#497)

### DIFF
--- a/docs/java.md
+++ b/docs/java.md
@@ -816,6 +816,7 @@ import org.cdk8s.plus20.DaemonSet;
 DaemonSet.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -860,6 +861,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.DaemonSetProps.parameter.dns"></a>
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -1067,6 +1080,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="org.cdk8s.plus20.DaemonSet.property.dns"></a>
+
+```java
+public PodDns getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDns`](#org.cdk8s.plus20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus20.DaemonSet.property.hostAliases"></a>
 
 ```java
@@ -1138,6 +1163,8 @@ public PodSecurityContext getSecurityContext();
 ```
 
 - *Type:* [`org.cdk8s.plus20.PodSecurityContext`](#org.cdk8s.plus20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -1216,6 +1243,7 @@ import org.cdk8s.plus20.Deployment;
 Deployment.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -1261,6 +1289,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.parameter.dns"></a>
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -1519,6 +1559,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.property.dns"></a>
+
+```java
+public PodDns getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDns`](#org.cdk8s.plus20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus20.Deployment.property.hostAliases"></a>
 
 ```java
@@ -1592,6 +1644,8 @@ public PodSecurityContext getSecurityContext();
 ```
 
 - *Type:* [`org.cdk8s.plus20.PodSecurityContext`](#org.cdk8s.plus20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -2158,6 +2212,7 @@ import org.cdk8s.plus20.Job;
 Job.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -2203,6 +2258,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.parameter.dns"></a>
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -2405,6 +2472,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="org.cdk8s.plus20.Job.property.dns"></a>
+
+```java
+public PodDns getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDns`](#org.cdk8s.plus20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus20.Job.property.hostAliases"></a>
 
 ```java
@@ -2452,6 +2531,8 @@ public PodSecurityContext getSecurityContext();
 ```
 
 - *Type:* [`org.cdk8s.plus20.PodSecurityContext`](#org.cdk8s.plus20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -3023,6 +3104,7 @@ import org.cdk8s.plus20.Pod;
 Pod.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -3064,6 +3146,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.parameter.dns"></a>
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -3224,6 +3318,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="org.cdk8s.plus20.Pod.property.dns"></a>
+
+```java
+public PodDns getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDns`](#org.cdk8s.plus20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus20.Pod.property.hostAliases"></a>
 
 ```java
@@ -3259,6 +3365,8 @@ public PodSecurityContext getSecurityContext();
 ```
 
 - *Type:* [`org.cdk8s.plus20.PodSecurityContext`](#org.cdk8s.plus20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -4075,6 +4183,7 @@ import org.cdk8s.plus20.StatefulSet;
 StatefulSet.Builder.create(Construct scope, java.lang.String id)
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -4122,6 +4231,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.parameter.dns"></a>
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -4359,6 +4480,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="org.cdk8s.plus20.StatefulSet.property.dns"></a>
+
+```java
+public PodDns getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDns`](#org.cdk8s.plus20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus20.StatefulSet.property.hostAliases"></a>
 
 ```java
@@ -4444,6 +4577,8 @@ public PodSecurityContext getSecurityContext();
 ```
 
 - *Type:* [`org.cdk8s.plus20.PodSecurityContext`](#org.cdk8s.plus20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -6114,6 +6249,7 @@ import org.cdk8s.plus20.DaemonSetProps;
 DaemonSetProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -6154,6 +6290,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.DaemonSetProps.property.dns"></a>
+
+```java
+public PodDnsProps getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -6328,6 +6480,7 @@ import org.cdk8s.plus20.DeploymentProps;
 DeploymentProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -6369,6 +6522,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.DeploymentProps.property.dns"></a>
+
+```java
+public PodDnsProps getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -6600,6 +6769,46 @@ Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% o
 pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can
 be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total
 number of pods available at all times during the update is at least 70% of desired pods.
+
+---
+
+### DnsOption <a name="org.cdk8s.plus20.DnsOption"></a>
+
+Custom DNS option.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus20.DnsOption;
+
+DnsOption.builder()
+    .name(java.lang.String)
+//  .value(java.lang.String)
+    .build();
+```
+
+##### `name`<sup>Required</sup> <a name="org.cdk8s.plus20.DnsOption.property.name"></a>
+
+```java
+public java.lang.String getName();
+```
+
+- *Type:* `java.lang.String`
+
+Option name.
+
+---
+
+##### `value`<sup>Optional</sup> <a name="org.cdk8s.plus20.DnsOption.property.value"></a>
+
+```java
+public java.lang.String getValue();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* No value.
+
+Option value.
 
 ---
 
@@ -7800,6 +8009,7 @@ import org.cdk8s.plus20.JobProps;
 JobProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -7841,6 +8051,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.JobProps.property.dns"></a>
+
+```java
+public PodDnsProps getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -8481,6 +8707,137 @@ Defines what type of volume is required by the claim.
 
 ---
 
+### PodDnsProps <a name="org.cdk8s.plus20.PodDnsProps"></a>
+
+Properties for `PodDns`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```java
+import org.cdk8s.plus20.PodDnsProps;
+
+PodDnsProps.builder()
+//  .hostname(java.lang.String)
+//  .hostnameAsFQDN(java.lang.Boolean)
+//  .nameservers(java.util.List<java.lang.String>)
+//  .options(java.util.List<DnsOption>)
+//  .policy(DnsPolicy)
+//  .searches(java.util.List<java.lang.String>)
+//  .subdomain(java.lang.String)
+    .build();
+```
+
+##### `hostname`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.property.hostname"></a>
+
+```java
+public java.lang.String getHostname();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* Set to a system-defined value.
+
+Specifies the hostname of the Pod.
+
+---
+
+##### `hostnameAsFQDN`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.property.hostnameAsFQDN"></a>
+
+```java
+public java.lang.Boolean getHostnameAsFQDN();
+```
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+
+In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+In Windows containers, this means setting the registry value of hostname for the registry
+key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN.
+If a pod does not have FQDN, this has no effect.
+
+---
+
+##### `nameservers`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.property.nameservers"></a>
+
+```java
+public java.util.List<java.lang.String> getNameservers();
+```
+
+- *Type:* java.util.List<`java.lang.String`>
+
+A list of IP addresses that will be used as DNS servers for the Pod.
+
+There can be at most 3 IP addresses specified.
+When the policy is set to "NONE", the list must contain at least one IP address,
+otherwise this property is optional.
+The servers listed will be combined to the base nameservers generated from
+the specified DNS policy with duplicate addresses removed.
+
+---
+
+##### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.property.options"></a>
+
+```java
+public java.util.List<DnsOption> getOptions();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.DnsOption`](#org.cdk8s.plus20.DnsOption)>
+
+List of objects where each object may have a name property (required) and a value property (optional).
+
+The contents in this property
+will be merged to the options generated from the specified DNS policy.
+Duplicate entries are removed.
+
+---
+
+##### `policy`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.property.policy"></a>
+
+```java
+public DnsPolicy getPolicy();
+```
+
+- *Type:* [`org.cdk8s.plus20.DnsPolicy`](#org.cdk8s.plus20.DnsPolicy)
+- *Default:* DnsPolicy.CLUSTER_FIRST
+
+Set DNS policy for the pod.
+
+If policy is set to `None`, other configuration must be supplied.
+
+---
+
+##### `searches`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.property.searches"></a>
+
+```java
+public java.util.List<java.lang.String> getSearches();
+```
+
+- *Type:* java.util.List<`java.lang.String`>
+
+A list of DNS search domains for hostname lookup in the Pod.
+
+When specified, the provided list will be merged into the base
+search domain names generated from the chosen DNS policy.
+Duplicate domain names are removed.
+
+Kubernetes allows for at most 6 search domains.
+
+---
+
+##### `subdomain`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.property.subdomain"></a>
+
+```java
+public java.lang.String getSubdomain();
+```
+
+- *Type:* `java.lang.String`
+- *Default:* No subdomain.
+
+If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+
+---
+
 ### PodProps <a name="org.cdk8s.plus20.PodProps"></a>
 
 Properties for initialization of `Pod`.
@@ -8493,6 +8850,7 @@ import org.cdk8s.plus20.PodProps;
 PodProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -8530,6 +8888,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodProps.property.dns"></a>
+
+```java
+public PodDnsProps getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -8767,6 +9141,7 @@ import org.cdk8s.plus20.PodSpecProps;
 
 PodSpecProps.builder()
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -8792,6 +9167,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.property.dns"></a>
+
+```java
+public PodDnsProps getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -8926,6 +9317,7 @@ import org.cdk8s.plus20.PodTemplateProps;
 
 PodTemplateProps.builder()
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -8952,6 +9344,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.property.dns"></a>
+
+```java
+public PodDnsProps getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -9939,6 +10347,7 @@ import org.cdk8s.plus20.StatefulSetProps;
 StatefulSetProps.builder()
 //  .metadata(ApiObjectMetadata)
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -9982,6 +10391,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.StatefulSetProps.property.dns"></a>
+
+```java
+public PodDnsProps getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -11485,6 +11910,237 @@ public java.lang.Object getValue();
 ---
 
 
+### PodDns <a name="org.cdk8s.plus20.PodDns"></a>
+
+Holds dns settings of the pod.
+
+#### Initializers <a name="org.cdk8s.plus20.PodDns.Initializer"></a>
+
+```java
+import org.cdk8s.plus20.PodDns;
+
+PodDns.Builder.create()
+//  .hostname(java.lang.String)
+//  .hostnameAsFQDN(java.lang.Boolean)
+//  .nameservers(java.util.List<java.lang.String>)
+//  .options(java.util.List<DnsOption>)
+//  .policy(DnsPolicy)
+//  .searches(java.util.List<java.lang.String>)
+//  .subdomain(java.lang.String)
+    .build();
+```
+
+##### `hostname`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.parameter.hostname"></a>
+
+- *Type:* `java.lang.String`
+- *Default:* Set to a system-defined value.
+
+Specifies the hostname of the Pod.
+
+---
+
+##### `hostnameAsFQDN`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.parameter.hostnameAsFQDN"></a>
+
+- *Type:* `java.lang.Boolean`
+- *Default:* false
+
+If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+
+In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+In Windows containers, this means setting the registry value of hostname for the registry
+key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN.
+If a pod does not have FQDN, this has no effect.
+
+---
+
+##### `nameservers`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.parameter.nameservers"></a>
+
+- *Type:* java.util.List<`java.lang.String`>
+
+A list of IP addresses that will be used as DNS servers for the Pod.
+
+There can be at most 3 IP addresses specified.
+When the policy is set to "NONE", the list must contain at least one IP address,
+otherwise this property is optional.
+The servers listed will be combined to the base nameservers generated from
+the specified DNS policy with duplicate addresses removed.
+
+---
+
+##### `options`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.parameter.options"></a>
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.DnsOption`](#org.cdk8s.plus20.DnsOption)>
+
+List of objects where each object may have a name property (required) and a value property (optional).
+
+The contents in this property
+will be merged to the options generated from the specified DNS policy.
+Duplicate entries are removed.
+
+---
+
+##### `policy`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.parameter.policy"></a>
+
+- *Type:* [`org.cdk8s.plus20.DnsPolicy`](#org.cdk8s.plus20.DnsPolicy)
+- *Default:* DnsPolicy.CLUSTER_FIRST
+
+Set DNS policy for the pod.
+
+If policy is set to `None`, other configuration must be supplied.
+
+---
+
+##### `searches`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.parameter.searches"></a>
+
+- *Type:* java.util.List<`java.lang.String`>
+
+A list of DNS search domains for hostname lookup in the Pod.
+
+When specified, the provided list will be merged into the base
+search domain names generated from the chosen DNS policy.
+Duplicate domain names are removed.
+
+Kubernetes allows for at most 6 search domains.
+
+---
+
+##### `subdomain`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDnsProps.parameter.subdomain"></a>
+
+- *Type:* `java.lang.String`
+- *Default:* No subdomain.
+
+If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+
+---
+
+#### Methods <a name="Methods"></a>
+
+##### `addNameserver` <a name="org.cdk8s.plus20.PodDns.addNameserver"></a>
+
+```java
+public addNameserver(java.lang.String nameservers)
+```
+
+###### `nameservers`<sup>Required</sup> <a name="org.cdk8s.plus20.PodDns.parameter.nameservers"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+##### `addOption` <a name="org.cdk8s.plus20.PodDns.addOption"></a>
+
+```java
+public addOption(DnsOption options)
+```
+
+###### `options`<sup>Required</sup> <a name="org.cdk8s.plus20.PodDns.parameter.options"></a>
+
+- *Type:* [`org.cdk8s.plus20.DnsOption`](#org.cdk8s.plus20.DnsOption)
+
+---
+
+##### `addSearch` <a name="org.cdk8s.plus20.PodDns.addSearch"></a>
+
+```java
+public addSearch(java.lang.String searches)
+```
+
+###### `searches`<sup>Required</sup> <a name="org.cdk8s.plus20.PodDns.parameter.searches"></a>
+
+- *Type:* `java.lang.String`
+
+---
+
+
+#### Properties <a name="Properties"></a>
+
+##### `hostnameAsFQDN`<sup>Required</sup> <a name="org.cdk8s.plus20.PodDns.property.hostnameAsFQDN"></a>
+
+```java
+public java.lang.Boolean getHostnameAsFQDN();
+```
+
+- *Type:* `java.lang.Boolean`
+
+Whether or not the pods hostname is set to its FQDN.
+
+---
+
+##### `nameservers`<sup>Required</sup> <a name="org.cdk8s.plus20.PodDns.property.nameservers"></a>
+
+```java
+public java.util.List<java.lang.String> getNameservers();
+```
+
+- *Type:* java.util.List<`java.lang.String`>
+
+Nameservers defined for this pod.
+
+---
+
+##### `options`<sup>Required</sup> <a name="org.cdk8s.plus20.PodDns.property.options"></a>
+
+```java
+public java.util.List<DnsOption> getOptions();
+```
+
+- *Type:* java.util.List<[`org.cdk8s.plus20.DnsOption`](#org.cdk8s.plus20.DnsOption)>
+
+Custom dns options defined for this pod.
+
+---
+
+##### `policy`<sup>Required</sup> <a name="org.cdk8s.plus20.PodDns.property.policy"></a>
+
+```java
+public DnsPolicy getPolicy();
+```
+
+- *Type:* [`org.cdk8s.plus20.DnsPolicy`](#org.cdk8s.plus20.DnsPolicy)
+
+The DNS policy of this pod.
+
+---
+
+##### `searches`<sup>Required</sup> <a name="org.cdk8s.plus20.PodDns.property.searches"></a>
+
+```java
+public java.util.List<java.lang.String> getSearches();
+```
+
+- *Type:* java.util.List<`java.lang.String`>
+
+Search domains defined for this pod.
+
+---
+
+##### `hostname`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDns.property.hostname"></a>
+
+```java
+public java.lang.String getHostname();
+```
+
+- *Type:* `java.lang.String`
+
+The configured hostname of the pod.
+
+Undefined means its set to a system-defined value.
+
+---
+
+##### `subdomain`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodDns.property.subdomain"></a>
+
+```java
+public java.lang.String getSubdomain();
+```
+
+- *Type:* `java.lang.String`
+
+The configured subdomain of the pod.
+
+---
+
+
 ### PodSecurityContext <a name="org.cdk8s.plus20.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
@@ -11644,6 +12300,7 @@ import org.cdk8s.plus20.PodSpec;
 
 PodSpec.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -11665,6 +12322,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodSpecProps.parameter.dns"></a>
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -11825,6 +12494,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="org.cdk8s.plus20.PodSpec.property.dns"></a>
+
+```java
+public PodDns getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDns`](#org.cdk8s.plus20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus20.PodSpec.property.hostAliases"></a>
 
 ```java
@@ -11860,6 +12541,8 @@ public PodSecurityContext getSecurityContext();
 ```
 
 - *Type:* [`org.cdk8s.plus20.PodSecurityContext`](#org.cdk8s.plus20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -11925,6 +12608,7 @@ import org.cdk8s.plus20.PodTemplate;
 
 PodTemplate.Builder.create()
 //  .containers(java.util.List<ContainerProps>)
+//  .dns(PodDnsProps)
 //  .dockerRegistryAuth(DockerConfigSecret)
 //  .hostAliases(java.util.List<HostAlias>)
 //  .initContainers(java.util.List<ContainerProps>)
@@ -11947,6 +12631,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="org.cdk8s.plus20.PodTemplateProps.parameter.dns"></a>
+
+- *Type:* [`org.cdk8s.plus20.PodDnsProps`](#org.cdk8s.plus20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -12533,6 +13229,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodSpec.property.dns"></a>
+
+```java
+public PodDns getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDns`](#org.cdk8s.plus20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodSpec.property.hostAliases"></a>
 
 ```java
@@ -12558,6 +13266,18 @@ public java.util.List<Container> getInitContainers();
 The init containers belonging to the pod.
 
 Use `addInitContainer` to add init containers.
+
+---
+
+##### `securityContext`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodSpec.property.securityContext"></a>
+
+```java
+public PodSecurityContext getSecurityContext();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodSecurityContext`](#org.cdk8s.plus20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -12626,6 +13346,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodTemplate.property.dns"></a>
+
+```java
+public PodDns getDns();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodDns`](#org.cdk8s.plus20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodTemplate.property.hostAliases"></a>
 
 ```java
@@ -12651,6 +13383,18 @@ public java.util.List<Container> getInitContainers();
 The init containers belonging to the pod.
 
 Use `addInitContainer` to add init containers.
+
+---
+
+##### `securityContext`<sup>Required</sup> <a name="org.cdk8s.plus20.IPodTemplate.property.securityContext"></a>
+
+```java
+public PodSecurityContext getSecurityContext();
+```
+
+- *Type:* [`org.cdk8s.plus20.PodSecurityContext`](#org.cdk8s.plus20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -12830,6 +13574,41 @@ Single blob disk per storage account.
 #### `MANAGED` <a name="org.cdk8s.plus20.AzureDiskPersistentVolumeKind.MANAGED"></a>
 
 Azure managed data disk.
+
+---
+
+
+### DnsPolicy <a name="DnsPolicy"></a>
+
+Pod DNS policies.
+
+#### `CLUSTER_FIRST` <a name="org.cdk8s.plus20.DnsPolicy.CLUSTER_FIRST"></a>
+
+Any DNS query that does not match the configured cluster domain suffix, such as "www.kubernetes.io", is forwarded to the upstream nameserver inherited from the node. Cluster administrators may have extra stub-domain and upstream DNS servers configured.
+
+---
+
+
+#### `CLUSTER_FIRST_WITH_HOST_NET` <a name="org.cdk8s.plus20.DnsPolicy.CLUSTER_FIRST_WITH_HOST_NET"></a>
+
+For Pods running with hostNetwork, you should explicitly set its DNS policy "ClusterFirstWithHostNet".
+
+---
+
+
+#### `DEFAULT` <a name="org.cdk8s.plus20.DnsPolicy.DEFAULT"></a>
+
+The Pod inherits the name resolution configuration from the node that the pods run on.
+
+---
+
+
+#### `NONE` <a name="org.cdk8s.plus20.DnsPolicy.NONE"></a>
+
+It allows a Pod to ignore DNS settings from the Kubernetes environment.
+
+All DNS settings are supposed to be provided using the dnsConfig
+field in the Pod Spec.
 
 ---
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -849,6 +849,7 @@ cdk8s_plus_20.DaemonSet(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -893,6 +894,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.DaemonSetProps.parameter.dns"></a>
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -1474,6 +1487,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s_plus_20.DaemonSet.property.dns"></a>
+
+```python
+dns: PodDns
+```
+
+- *Type:* [`cdk8s_plus_20.PodDns`](#cdk8s_plus_20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_20.DaemonSet.property.host_aliases"></a>
 
 ```python
@@ -1545,6 +1570,8 @@ security_context: PodSecurityContext
 ```
 
 - *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -1625,6 +1652,7 @@ cdk8s_plus_20.Deployment(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -1670,6 +1698,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.parameter.dns"></a>
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -2405,6 +2445,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s_plus_20.Deployment.property.dns"></a>
+
+```python
+dns: PodDns
+```
+
+- *Type:* [`cdk8s_plus_20.PodDns`](#cdk8s_plus_20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_20.Deployment.property.host_aliases"></a>
 
 ```python
@@ -2478,6 +2530,8 @@ security_context: PodSecurityContext
 ```
 
 - *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -3098,6 +3152,7 @@ cdk8s_plus_20.Job(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -3143,6 +3198,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.parameter.dns"></a>
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -3716,6 +3783,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s_plus_20.Job.property.dns"></a>
+
+```python
+dns: PodDns
+```
+
+- *Type:* [`cdk8s_plus_20.PodDns`](#cdk8s_plus_20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_20.Job.property.host_aliases"></a>
 
 ```python
@@ -3763,6 +3842,8 @@ security_context: PodSecurityContext
 ```
 
 - *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -4348,6 +4429,7 @@ cdk8s_plus_20.Pod(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -4389,6 +4471,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.parameter.dns"></a>
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -4920,6 +5014,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s_plus_20.Pod.property.dns"></a>
+
+```python
+dns: PodDns
+```
+
+- *Type:* [`cdk8s_plus_20.PodDns`](#cdk8s_plus_20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_20.Pod.property.host_aliases"></a>
 
 ```python
@@ -4955,6 +5061,8 @@ security_context: PodSecurityContext
 ```
 
 - *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -5906,6 +6014,7 @@ cdk8s_plus_20.StatefulSet(
   id: str,
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -5953,6 +6062,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.parameter.dns"></a>
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -6564,6 +6685,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s_plus_20.StatefulSet.property.dns"></a>
+
+```python
+dns: PodDns
+```
+
+- *Type:* [`cdk8s_plus_20.PodDns`](#cdk8s_plus_20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_20.StatefulSet.property.host_aliases"></a>
 
 ```python
@@ -6649,6 +6782,8 @@ security_context: PodSecurityContext
 ```
 
 - *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -8321,6 +8456,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.DaemonSetProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -8361,6 +8497,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.DaemonSetProps.property.dns"></a>
+
+```python
+dns: PodDnsProps
+```
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -8535,6 +8687,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.DeploymentProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -8576,6 +8729,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.DeploymentProps.property.dns"></a>
+
+```python
+dns: PodDnsProps
+```
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -8807,6 +8976,46 @@ Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% o
 pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can
 be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total
 number of pods available at all times during the update is at least 70% of desired pods.
+
+---
+
+### DnsOption <a name="cdk8s_plus_20.DnsOption"></a>
+
+Custom DNS option.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.DnsOption(
+  name: str,
+  value: str = None
+)
+```
+
+##### `name`<sup>Required</sup> <a name="cdk8s_plus_20.DnsOption.property.name"></a>
+
+```python
+name: str
+```
+
+- *Type:* `str`
+
+Option name.
+
+---
+
+##### `value`<sup>Optional</sup> <a name="cdk8s_plus_20.DnsOption.property.value"></a>
+
+```python
+value: str
+```
+
+- *Type:* `str`
+- *Default:* No value.
+
+Option value.
 
 ---
 
@@ -10007,6 +10216,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.JobProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -10048,6 +10258,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.JobProps.property.dns"></a>
+
+```python
+dns: PodDnsProps
+```
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -10688,6 +10914,137 @@ Defines what type of volume is required by the claim.
 
 ---
 
+### PodDnsProps <a name="cdk8s_plus_20.PodDnsProps"></a>
+
+Properties for `PodDns`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.PodDnsProps(
+  hostname: str = None,
+  hostname_as_fqd_n: bool = None,
+  nameservers: typing.List[str] = None,
+  options: typing.List[DnsOption] = None,
+  policy: DnsPolicy = None,
+  searches: typing.List[str] = None,
+  subdomain: str = None
+)
+```
+
+##### `hostname`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.property.hostname"></a>
+
+```python
+hostname: str
+```
+
+- *Type:* `str`
+- *Default:* Set to a system-defined value.
+
+Specifies the hostname of the Pod.
+
+---
+
+##### `hostname_as_fqd_n`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.property.hostname_as_fqd_n"></a>
+
+```python
+hostname_as_fqd_n: bool
+```
+
+- *Type:* `bool`
+- *Default:* false
+
+If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+
+In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+In Windows containers, this means setting the registry value of hostname for the registry
+key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN.
+If a pod does not have FQDN, this has no effect.
+
+---
+
+##### `nameservers`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.property.nameservers"></a>
+
+```python
+nameservers: typing.List[str]
+```
+
+- *Type:* typing.List[`str`]
+
+A list of IP addresses that will be used as DNS servers for the Pod.
+
+There can be at most 3 IP addresses specified.
+When the policy is set to "NONE", the list must contain at least one IP address,
+otherwise this property is optional.
+The servers listed will be combined to the base nameservers generated from
+the specified DNS policy with duplicate addresses removed.
+
+---
+
+##### `options`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.property.options"></a>
+
+```python
+options: typing.List[DnsOption]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.DnsOption`](#cdk8s_plus_20.DnsOption)]
+
+List of objects where each object may have a name property (required) and a value property (optional).
+
+The contents in this property
+will be merged to the options generated from the specified DNS policy.
+Duplicate entries are removed.
+
+---
+
+##### `policy`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.property.policy"></a>
+
+```python
+policy: DnsPolicy
+```
+
+- *Type:* [`cdk8s_plus_20.DnsPolicy`](#cdk8s_plus_20.DnsPolicy)
+- *Default:* DnsPolicy.CLUSTER_FIRST
+
+Set DNS policy for the pod.
+
+If policy is set to `None`, other configuration must be supplied.
+
+---
+
+##### `searches`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.property.searches"></a>
+
+```python
+searches: typing.List[str]
+```
+
+- *Type:* typing.List[`str`]
+
+A list of DNS search domains for hostname lookup in the Pod.
+
+When specified, the provided list will be merged into the base
+search domain names generated from the chosen DNS policy.
+Duplicate domain names are removed.
+
+Kubernetes allows for at most 6 search domains.
+
+---
+
+##### `subdomain`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.property.subdomain"></a>
+
+```python
+subdomain: str
+```
+
+- *Type:* `str`
+- *Default:* No subdomain.
+
+If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+
+---
+
 ### PodProps <a name="cdk8s_plus_20.PodProps"></a>
 
 Properties for initialization of `Pod`.
@@ -10700,6 +11057,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.PodProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -10737,6 +11095,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.PodProps.property.dns"></a>
+
+```python
+dns: PodDnsProps
+```
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -10974,6 +11348,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodSpecProps(
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -10999,6 +11374,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.property.dns"></a>
+
+```python
+dns: PodDnsProps
+```
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -11133,6 +11524,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodTemplateProps(
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -11159,6 +11551,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.property.dns"></a>
+
+```python
+dns: PodDnsProps
+```
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -12146,6 +12554,7 @@ import cdk8s_plus_20
 cdk8s_plus_20.StatefulSetProps(
   metadata: ApiObjectMetadata = None,
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -12189,6 +12598,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.StatefulSetProps.property.dns"></a>
+
+```python
+dns: PodDnsProps
+```
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -13856,6 +14281,255 @@ value: typing.Any
 ---
 
 
+### PodDns <a name="cdk8s_plus_20.PodDns"></a>
+
+Holds dns settings of the pod.
+
+#### Initializers <a name="cdk8s_plus_20.PodDns.Initializer"></a>
+
+```python
+import cdk8s_plus_20
+
+cdk8s_plus_20.PodDns(
+  hostname: str = None,
+  hostname_as_fqd_n: bool = None,
+  nameservers: typing.List[str] = None,
+  options: typing.List[DnsOption] = None,
+  policy: DnsPolicy = None,
+  searches: typing.List[str] = None,
+  subdomain: str = None
+)
+```
+
+##### `hostname`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.parameter.hostname"></a>
+
+- *Type:* `str`
+- *Default:* Set to a system-defined value.
+
+Specifies the hostname of the Pod.
+
+---
+
+##### `hostname_as_fqd_n`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.parameter.hostname_as_fqd_n"></a>
+
+- *Type:* `bool`
+- *Default:* false
+
+If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+
+In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+In Windows containers, this means setting the registry value of hostname for the registry
+key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN.
+If a pod does not have FQDN, this has no effect.
+
+---
+
+##### `nameservers`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.parameter.nameservers"></a>
+
+- *Type:* typing.List[`str`]
+
+A list of IP addresses that will be used as DNS servers for the Pod.
+
+There can be at most 3 IP addresses specified.
+When the policy is set to "NONE", the list must contain at least one IP address,
+otherwise this property is optional.
+The servers listed will be combined to the base nameservers generated from
+the specified DNS policy with duplicate addresses removed.
+
+---
+
+##### `options`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.parameter.options"></a>
+
+- *Type:* typing.List[[`cdk8s_plus_20.DnsOption`](#cdk8s_plus_20.DnsOption)]
+
+List of objects where each object may have a name property (required) and a value property (optional).
+
+The contents in this property
+will be merged to the options generated from the specified DNS policy.
+Duplicate entries are removed.
+
+---
+
+##### `policy`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.parameter.policy"></a>
+
+- *Type:* [`cdk8s_plus_20.DnsPolicy`](#cdk8s_plus_20.DnsPolicy)
+- *Default:* DnsPolicy.CLUSTER_FIRST
+
+Set DNS policy for the pod.
+
+If policy is set to `None`, other configuration must be supplied.
+
+---
+
+##### `searches`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.parameter.searches"></a>
+
+- *Type:* typing.List[`str`]
+
+A list of DNS search domains for hostname lookup in the Pod.
+
+When specified, the provided list will be merged into the base
+search domain names generated from the chosen DNS policy.
+Duplicate domain names are removed.
+
+Kubernetes allows for at most 6 search domains.
+
+---
+
+##### `subdomain`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDnsProps.parameter.subdomain"></a>
+
+- *Type:* `str`
+- *Default:* No subdomain.
+
+If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+
+---
+
+#### Methods <a name="Methods"></a>
+
+##### `add_nameserver` <a name="cdk8s_plus_20.PodDns.add_nameserver"></a>
+
+```python
+def add_nameserver(
+  nameservers: str
+)
+```
+
+###### `nameservers`<sup>Required</sup> <a name="cdk8s_plus_20.PodDns.parameter.nameservers"></a>
+
+- *Type:* `str`
+
+---
+
+##### `add_option` <a name="cdk8s_plus_20.PodDns.add_option"></a>
+
+```python
+def add_option(
+  name: str,
+  value: str = None
+)
+```
+
+###### `name`<sup>Required</sup> <a name="cdk8s_plus_20.DnsOption.parameter.name"></a>
+
+- *Type:* `str`
+
+Option name.
+
+---
+
+###### `value`<sup>Optional</sup> <a name="cdk8s_plus_20.DnsOption.parameter.value"></a>
+
+- *Type:* `str`
+- *Default:* No value.
+
+Option value.
+
+---
+
+##### `add_search` <a name="cdk8s_plus_20.PodDns.add_search"></a>
+
+```python
+def add_search(
+  searches: str
+)
+```
+
+###### `searches`<sup>Required</sup> <a name="cdk8s_plus_20.PodDns.parameter.searches"></a>
+
+- *Type:* `str`
+
+---
+
+
+#### Properties <a name="Properties"></a>
+
+##### `hostname_as_fqd_n`<sup>Required</sup> <a name="cdk8s_plus_20.PodDns.property.hostname_as_fqd_n"></a>
+
+```python
+hostname_as_fqd_n: bool
+```
+
+- *Type:* `bool`
+
+Whether or not the pods hostname is set to its FQDN.
+
+---
+
+##### `nameservers`<sup>Required</sup> <a name="cdk8s_plus_20.PodDns.property.nameservers"></a>
+
+```python
+nameservers: typing.List[str]
+```
+
+- *Type:* typing.List[`str`]
+
+Nameservers defined for this pod.
+
+---
+
+##### `options`<sup>Required</sup> <a name="cdk8s_plus_20.PodDns.property.options"></a>
+
+```python
+options: typing.List[DnsOption]
+```
+
+- *Type:* typing.List[[`cdk8s_plus_20.DnsOption`](#cdk8s_plus_20.DnsOption)]
+
+Custom dns options defined for this pod.
+
+---
+
+##### `policy`<sup>Required</sup> <a name="cdk8s_plus_20.PodDns.property.policy"></a>
+
+```python
+policy: DnsPolicy
+```
+
+- *Type:* [`cdk8s_plus_20.DnsPolicy`](#cdk8s_plus_20.DnsPolicy)
+
+The DNS policy of this pod.
+
+---
+
+##### `searches`<sup>Required</sup> <a name="cdk8s_plus_20.PodDns.property.searches"></a>
+
+```python
+searches: typing.List[str]
+```
+
+- *Type:* typing.List[`str`]
+
+Search domains defined for this pod.
+
+---
+
+##### `hostname`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDns.property.hostname"></a>
+
+```python
+hostname: str
+```
+
+- *Type:* `str`
+
+The configured hostname of the pod.
+
+Undefined means its set to a system-defined value.
+
+---
+
+##### `subdomain`<sup>Optional</sup> <a name="cdk8s_plus_20.PodDns.property.subdomain"></a>
+
+```python
+subdomain: str
+```
+
+- *Type:* `str`
+
+The configured subdomain of the pod.
+
+---
+
+
 ### PodSecurityContext <a name="cdk8s_plus_20.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
@@ -14015,6 +14689,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodSpec(
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -14036,6 +14711,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.PodSpecProps.parameter.dns"></a>
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -14567,6 +15254,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s_plus_20.PodSpec.property.dns"></a>
+
+```python
+dns: PodDns
+```
+
+- *Type:* [`cdk8s_plus_20.PodDns`](#cdk8s_plus_20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_20.PodSpec.property.host_aliases"></a>
 
 ```python
@@ -14602,6 +15301,8 @@ security_context: PodSecurityContext
 ```
 
 - *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -14667,6 +15368,7 @@ import cdk8s_plus_20
 
 cdk8s_plus_20.PodTemplate(
   containers: typing.List[ContainerProps] = None,
+  dns: PodDnsProps = None,
   docker_registry_auth: DockerConfigSecret = None,
   host_aliases: typing.List[HostAlias] = None,
   init_containers: typing.List[ContainerProps] = None,
@@ -14689,6 +15391,18 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s_plus_20.PodTemplateProps.parameter.dns"></a>
+
+- *Type:* [`cdk8s_plus_20.PodDnsProps`](#cdk8s_plus_20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -16102,6 +16816,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s_plus_20.IPodSpec.property.dns"></a>
+
+```python
+dns: PodDns
+```
+
+- *Type:* [`cdk8s_plus_20.PodDns`](#cdk8s_plus_20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_20.IPodSpec.property.host_aliases"></a>
 
 ```python
@@ -16127,6 +16853,18 @@ init_containers: typing.List[Container]
 The init containers belonging to the pod.
 
 Use `addInitContainer` to add init containers.
+
+---
+
+##### `security_context`<sup>Required</sup> <a name="cdk8s_plus_20.IPodSpec.property.security_context"></a>
+
+```python
+security_context: PodSecurityContext
+```
+
+- *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -16195,6 +16933,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s_plus_20.IPodTemplate.property.dns"></a>
+
+```python
+dns: PodDns
+```
+
+- *Type:* [`cdk8s_plus_20.PodDns`](#cdk8s_plus_20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `host_aliases`<sup>Required</sup> <a name="cdk8s_plus_20.IPodTemplate.property.host_aliases"></a>
 
 ```python
@@ -16220,6 +16970,18 @@ init_containers: typing.List[Container]
 The init containers belonging to the pod.
 
 Use `addInitContainer` to add init containers.
+
+---
+
+##### `security_context`<sup>Required</sup> <a name="cdk8s_plus_20.IPodTemplate.property.security_context"></a>
+
+```python
+security_context: PodSecurityContext
+```
+
+- *Type:* [`cdk8s_plus_20.PodSecurityContext`](#cdk8s_plus_20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -16399,6 +17161,41 @@ Single blob disk per storage account.
 #### `MANAGED` <a name="cdk8s_plus_20.AzureDiskPersistentVolumeKind.MANAGED"></a>
 
 Azure managed data disk.
+
+---
+
+
+### DnsPolicy <a name="DnsPolicy"></a>
+
+Pod DNS policies.
+
+#### `CLUSTER_FIRST` <a name="cdk8s_plus_20.DnsPolicy.CLUSTER_FIRST"></a>
+
+Any DNS query that does not match the configured cluster domain suffix, such as "www.kubernetes.io", is forwarded to the upstream nameserver inherited from the node. Cluster administrators may have extra stub-domain and upstream DNS servers configured.
+
+---
+
+
+#### `CLUSTER_FIRST_WITH_HOST_NET` <a name="cdk8s_plus_20.DnsPolicy.CLUSTER_FIRST_WITH_HOST_NET"></a>
+
+For Pods running with hostNetwork, you should explicitly set its DNS policy "ClusterFirstWithHostNet".
+
+---
+
+
+#### `DEFAULT` <a name="cdk8s_plus_20.DnsPolicy.DEFAULT"></a>
+
+The Pod inherits the name resolution configuration from the node that the pods run on.
+
+---
+
+
+#### `NONE` <a name="cdk8s_plus_20.DnsPolicy.NONE"></a>
+
+It allows a Pod to ignore DNS settings from the Kubernetes environment.
+
+All DNS settings are supposed to be provided using the dnsConfig
+field in the Pod Spec.
 
 ---
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -544,6 +544,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s-plus-20.DaemonSet.property.dns"></a>
+
+```typescript
+public readonly dns: PodDns;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDns`](#cdk8s-plus-20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-20.DaemonSet.property.hostAliases"></a>
 
 ```typescript
@@ -615,6 +627,8 @@ public readonly securityContext: PodSecurityContext;
 ```
 
 - *Type:* [`cdk8s-plus-20.PodSecurityContext`](#cdk8s-plus-20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -837,6 +851,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.property.dns"></a>
+
+```typescript
+public readonly dns: PodDns;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDns`](#cdk8s-plus-20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-20.Deployment.property.hostAliases"></a>
 
 ```typescript
@@ -910,6 +936,8 @@ public readonly securityContext: PodSecurityContext;
 ```
 
 - *Type:* [`cdk8s-plus-20.PodSecurityContext`](#cdk8s-plus-20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -1345,6 +1373,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s-plus-20.Job.property.dns"></a>
+
+```typescript
+public readonly dns: PodDns;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDns`](#cdk8s-plus-20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-20.Job.property.hostAliases"></a>
 
 ```typescript
@@ -1392,6 +1432,8 @@ public readonly securityContext: PodSecurityContext;
 ```
 
 - *Type:* [`cdk8s-plus-20.PodSecurityContext`](#cdk8s-plus-20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -1884,6 +1926,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s-plus-20.Pod.property.dns"></a>
+
+```typescript
+public readonly dns: PodDns;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDns`](#cdk8s-plus-20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-20.Pod.property.hostAliases"></a>
 
 ```typescript
@@ -1919,6 +1973,8 @@ public readonly securityContext: PodSecurityContext;
 ```
 
 - *Type:* [`cdk8s-plus-20.PodSecurityContext`](#cdk8s-plus-20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -2646,6 +2702,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s-plus-20.StatefulSet.property.dns"></a>
+
+```typescript
+public readonly dns: PodDns;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDns`](#cdk8s-plus-20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-20.StatefulSet.property.hostAliases"></a>
 
 ```typescript
@@ -2731,6 +2799,8 @@ public readonly securityContext: PodSecurityContext;
 ```
 
 - *Type:* [`cdk8s-plus-20.PodSecurityContext`](#cdk8s-plus-20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -4297,6 +4367,22 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `dns`<sup>Optional</sup> <a name="cdk8s-plus-20.DaemonSetProps.property.dns"></a>
+
+```typescript
+public readonly dns: PodDnsProps;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDnsProps`](#cdk8s-plus-20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+
+---
+
 ##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.DaemonSetProps.property.dockerRegistryAuth"></a>
 
 ```typescript
@@ -4495,6 +4581,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s-plus-20.DeploymentProps.property.dns"></a>
+
+```typescript
+public readonly dns: PodDnsProps;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDnsProps`](#cdk8s-plus-20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -4723,6 +4825,43 @@ Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% o
 pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can
 be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total
 number of pods available at all times during the update is at least 70% of desired pods.
+
+---
+
+### DnsOption <a name="cdk8s-plus-20.DnsOption"></a>
+
+Custom DNS option.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { DnsOption } from 'cdk8s-plus-20'
+
+const dnsOption: DnsOption = { ... }
+```
+
+##### `name`<sup>Required</sup> <a name="cdk8s-plus-20.DnsOption.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* `string`
+
+Option name.
+
+---
+
+##### `value`<sup>Optional</sup> <a name="cdk8s-plus-20.DnsOption.property.value"></a>
+
+```typescript
+public readonly value: string;
+```
+
+- *Type:* `string`
+- *Default:* No value.
+
+Option value.
 
 ---
 
@@ -5874,6 +6013,22 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `dns`<sup>Optional</sup> <a name="cdk8s-plus-20.JobProps.property.dns"></a>
+
+```typescript
+public readonly dns: PodDnsProps;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDnsProps`](#cdk8s-plus-20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+
+---
+
 ##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.JobProps.property.dockerRegistryAuth"></a>
 
 ```typescript
@@ -6481,6 +6636,129 @@ Defines what type of volume is required by the claim.
 
 ---
 
+### PodDnsProps <a name="cdk8s-plus-20.PodDnsProps"></a>
+
+Properties for `PodDns`.
+
+#### Initializer <a name="[object Object].Initializer"></a>
+
+```typescript
+import { PodDnsProps } from 'cdk8s-plus-20'
+
+const podDnsProps: PodDnsProps = { ... }
+```
+
+##### `hostname`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDnsProps.property.hostname"></a>
+
+```typescript
+public readonly hostname: string;
+```
+
+- *Type:* `string`
+- *Default:* Set to a system-defined value.
+
+Specifies the hostname of the Pod.
+
+---
+
+##### `hostnameAsFQDN`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDnsProps.property.hostnameAsFQDN"></a>
+
+```typescript
+public readonly hostnameAsFQDN: boolean;
+```
+
+- *Type:* `boolean`
+- *Default:* false
+
+If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+
+In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+In Windows containers, this means setting the registry value of hostname for the registry
+key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN.
+If a pod does not have FQDN, this has no effect.
+
+---
+
+##### `nameservers`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDnsProps.property.nameservers"></a>
+
+```typescript
+public readonly nameservers: string[];
+```
+
+- *Type:* `string`[]
+
+A list of IP addresses that will be used as DNS servers for the Pod.
+
+There can be at most 3 IP addresses specified.
+When the policy is set to "NONE", the list must contain at least one IP address,
+otherwise this property is optional.
+The servers listed will be combined to the base nameservers generated from
+the specified DNS policy with duplicate addresses removed.
+
+---
+
+##### `options`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDnsProps.property.options"></a>
+
+```typescript
+public readonly options: DnsOption[];
+```
+
+- *Type:* [`cdk8s-plus-20.DnsOption`](#cdk8s-plus-20.DnsOption)[]
+
+List of objects where each object may have a name property (required) and a value property (optional).
+
+The contents in this property
+will be merged to the options generated from the specified DNS policy.
+Duplicate entries are removed.
+
+---
+
+##### `policy`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDnsProps.property.policy"></a>
+
+```typescript
+public readonly policy: DnsPolicy;
+```
+
+- *Type:* [`cdk8s-plus-20.DnsPolicy`](#cdk8s-plus-20.DnsPolicy)
+- *Default:* DnsPolicy.CLUSTER_FIRST
+
+Set DNS policy for the pod.
+
+If policy is set to `None`, other configuration must be supplied.
+
+---
+
+##### `searches`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDnsProps.property.searches"></a>
+
+```typescript
+public readonly searches: string[];
+```
+
+- *Type:* `string`[]
+
+A list of DNS search domains for hostname lookup in the Pod.
+
+When specified, the provided list will be merged into the base
+search domain names generated from the chosen DNS policy.
+Duplicate domain names are removed.
+
+Kubernetes allows for at most 6 search domains.
+
+---
+
+##### `subdomain`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDnsProps.property.subdomain"></a>
+
+```typescript
+public readonly subdomain: string;
+```
+
+- *Type:* `string`
+- *Default:* No subdomain.
+
+If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+
+---
+
 ### PodProps <a name="cdk8s-plus-20.PodProps"></a>
 
 Properties for initialization of `Pod`.
@@ -6520,6 +6798,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s-plus-20.PodProps.property.dns"></a>
+
+```typescript
+public readonly dns: PodDnsProps;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDnsProps`](#cdk8s-plus-20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -6769,6 +7063,22 @@ You can add additionnal containers using `podSpec.addContainer()`
 
 ---
 
+##### `dns`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpecProps.property.dns"></a>
+
+```typescript
+public readonly dns: PodDnsProps;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDnsProps`](#cdk8s-plus-20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+
+---
+
 ##### `dockerRegistryAuth`<sup>Optional</sup> <a name="cdk8s-plus-20.PodSpecProps.property.dockerRegistryAuth"></a>
 
 ```typescript
@@ -6916,6 +7226,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s-plus-20.PodTemplateProps.property.dns"></a>
+
+```typescript
+public readonly dns: PodDnsProps;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDnsProps`](#cdk8s-plus-20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -7874,6 +8200,22 @@ Containers cannot currently be
 added or removed. There must be at least one container in a Pod.
 
 You can add additionnal containers using `podSpec.addContainer()`
+
+---
+
+##### `dns`<sup>Optional</sup> <a name="cdk8s-plus-20.StatefulSetProps.property.dns"></a>
+
+```typescript
+public readonly dns: PodDnsProps;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDnsProps`](#cdk8s-plus-20.PodDnsProps)
+- *Default:* policy: DnsPolicy.CLUSTER_FIRST
+ hostnameAsFQDN: false
+
+DNS settings for the pod.
+
+> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
 
 ---
 
@@ -9114,6 +9456,152 @@ public readonly value: any;
 ---
 
 
+### PodDns <a name="cdk8s-plus-20.PodDns"></a>
+
+Holds dns settings of the pod.
+
+#### Initializers <a name="cdk8s-plus-20.PodDns.Initializer"></a>
+
+```typescript
+import { PodDns } from 'cdk8s-plus-20'
+
+new PodDns(props?: PodDnsProps)
+```
+
+##### `props`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDns.parameter.props"></a>
+
+- *Type:* [`cdk8s-plus-20.PodDnsProps`](#cdk8s-plus-20.PodDnsProps)
+
+---
+
+#### Methods <a name="Methods"></a>
+
+##### `addNameserver` <a name="cdk8s-plus-20.PodDns.addNameserver"></a>
+
+```typescript
+public addNameserver(nameservers: string)
+```
+
+###### `nameservers`<sup>Required</sup> <a name="cdk8s-plus-20.PodDns.parameter.nameservers"></a>
+
+- *Type:* `string`
+
+---
+
+##### `addOption` <a name="cdk8s-plus-20.PodDns.addOption"></a>
+
+```typescript
+public addOption(options: DnsOption)
+```
+
+###### `options`<sup>Required</sup> <a name="cdk8s-plus-20.PodDns.parameter.options"></a>
+
+- *Type:* [`cdk8s-plus-20.DnsOption`](#cdk8s-plus-20.DnsOption)
+
+---
+
+##### `addSearch` <a name="cdk8s-plus-20.PodDns.addSearch"></a>
+
+```typescript
+public addSearch(searches: string)
+```
+
+###### `searches`<sup>Required</sup> <a name="cdk8s-plus-20.PodDns.parameter.searches"></a>
+
+- *Type:* `string`
+
+---
+
+
+#### Properties <a name="Properties"></a>
+
+##### `hostnameAsFQDN`<sup>Required</sup> <a name="cdk8s-plus-20.PodDns.property.hostnameAsFQDN"></a>
+
+```typescript
+public readonly hostnameAsFQDN: boolean;
+```
+
+- *Type:* `boolean`
+
+Whether or not the pods hostname is set to its FQDN.
+
+---
+
+##### `nameservers`<sup>Required</sup> <a name="cdk8s-plus-20.PodDns.property.nameservers"></a>
+
+```typescript
+public readonly nameservers: string[];
+```
+
+- *Type:* `string`[]
+
+Nameservers defined for this pod.
+
+---
+
+##### `options`<sup>Required</sup> <a name="cdk8s-plus-20.PodDns.property.options"></a>
+
+```typescript
+public readonly options: DnsOption[];
+```
+
+- *Type:* [`cdk8s-plus-20.DnsOption`](#cdk8s-plus-20.DnsOption)[]
+
+Custom dns options defined for this pod.
+
+---
+
+##### `policy`<sup>Required</sup> <a name="cdk8s-plus-20.PodDns.property.policy"></a>
+
+```typescript
+public readonly policy: DnsPolicy;
+```
+
+- *Type:* [`cdk8s-plus-20.DnsPolicy`](#cdk8s-plus-20.DnsPolicy)
+
+The DNS policy of this pod.
+
+---
+
+##### `searches`<sup>Required</sup> <a name="cdk8s-plus-20.PodDns.property.searches"></a>
+
+```typescript
+public readonly searches: string[];
+```
+
+- *Type:* `string`[]
+
+Search domains defined for this pod.
+
+---
+
+##### `hostname`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDns.property.hostname"></a>
+
+```typescript
+public readonly hostname: string;
+```
+
+- *Type:* `string`
+
+The configured hostname of the pod.
+
+Undefined means its set to a system-defined value.
+
+---
+
+##### `subdomain`<sup>Optional</sup> <a name="cdk8s-plus-20.PodDns.property.subdomain"></a>
+
+```typescript
+public readonly subdomain: string;
+```
+
+- *Type:* `string`
+
+The configured subdomain of the pod.
+
+---
+
+
 ### PodSecurityContext <a name="cdk8s-plus-20.PodSecurityContext"></a>
 
 Holds pod-level security attributes and common container settings.
@@ -9284,6 +9772,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s-plus-20.PodSpec.property.dns"></a>
+
+```typescript
+public readonly dns: PodDns;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDns`](#cdk8s-plus-20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-20.PodSpec.property.hostAliases"></a>
 
 ```typescript
@@ -9319,6 +9819,8 @@ public readonly securityContext: PodSecurityContext;
 ```
 
 - *Type:* [`cdk8s-plus-20.PodSecurityContext`](#cdk8s-plus-20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -9865,6 +10367,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s-plus-20.IPodSpec.property.dns"></a>
+
+```typescript
+public readonly dns: PodDns;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDns`](#cdk8s-plus-20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-20.IPodSpec.property.hostAliases"></a>
 
 ```typescript
@@ -9890,6 +10404,18 @@ public readonly initContainers: Container[];
 The init containers belonging to the pod.
 
 Use `addInitContainer` to add init containers.
+
+---
+
+##### `securityContext`<sup>Required</sup> <a name="cdk8s-plus-20.IPodSpec.property.securityContext"></a>
+
+```typescript
+public readonly securityContext: PodSecurityContext;
+```
+
+- *Type:* [`cdk8s-plus-20.PodSecurityContext`](#cdk8s-plus-20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -9958,6 +10484,18 @@ Use `addContainer` to add containers.
 
 ---
 
+##### `dns`<sup>Required</sup> <a name="cdk8s-plus-20.IPodTemplate.property.dns"></a>
+
+```typescript
+public readonly dns: PodDns;
+```
+
+- *Type:* [`cdk8s-plus-20.PodDns`](#cdk8s-plus-20.PodDns)
+
+The pod's DNS settings.
+
+---
+
 ##### `hostAliases`<sup>Required</sup> <a name="cdk8s-plus-20.IPodTemplate.property.hostAliases"></a>
 
 ```typescript
@@ -9983,6 +10521,18 @@ public readonly initContainers: Container[];
 The init containers belonging to the pod.
 
 Use `addInitContainer` to add init containers.
+
+---
+
+##### `securityContext`<sup>Required</sup> <a name="cdk8s-plus-20.IPodTemplate.property.securityContext"></a>
+
+```typescript
+public readonly securityContext: PodSecurityContext;
+```
+
+- *Type:* [`cdk8s-plus-20.PodSecurityContext`](#cdk8s-plus-20.PodSecurityContext)
+
+The pod's security context.
 
 ---
 
@@ -10162,6 +10712,41 @@ Single blob disk per storage account.
 #### `MANAGED` <a name="cdk8s-plus-20.AzureDiskPersistentVolumeKind.MANAGED"></a>
 
 Azure managed data disk.
+
+---
+
+
+### DnsPolicy <a name="DnsPolicy"></a>
+
+Pod DNS policies.
+
+#### `CLUSTER_FIRST` <a name="cdk8s-plus-20.DnsPolicy.CLUSTER_FIRST"></a>
+
+Any DNS query that does not match the configured cluster domain suffix, such as "www.kubernetes.io", is forwarded to the upstream nameserver inherited from the node. Cluster administrators may have extra stub-domain and upstream DNS servers configured.
+
+---
+
+
+#### `CLUSTER_FIRST_WITH_HOST_NET` <a name="cdk8s-plus-20.DnsPolicy.CLUSTER_FIRST_WITH_HOST_NET"></a>
+
+For Pods running with hostNetwork, you should explicitly set its DNS policy "ClusterFirstWithHostNet".
+
+---
+
+
+#### `DEFAULT` <a name="cdk8s-plus-20.DnsPolicy.DEFAULT"></a>
+
+The Pod inherits the name resolution configuration from the node that the pods run on.
+
+---
+
+
+#### `NONE` <a name="cdk8s-plus-20.DnsPolicy.NONE"></a>
+
+It allows a Pod to ignore DNS settings from the Kubernetes environment.
+
+All DNS settings are supposed to be provided using the dnsConfig
+field in the Pod Spec.
 
 ---
 

--- a/src/daemon-set.ts
+++ b/src/daemon-set.ts
@@ -3,7 +3,7 @@ import { Construct } from 'constructs';
 import { Resource, ResourceProps } from './base';
 import { Container, ContainerProps } from './container';
 import * as k8s from './imports/k8s';
-import { HostAlias, IPodTemplate, PodSecurityContext, PodTemplate, PodTemplateProps, RestartPolicy } from './pod';
+import { HostAlias, IPodTemplate, PodSecurityContext, PodTemplate, PodTemplateProps, RestartPolicy, PodDns } from './pod';
 import { IServiceAccount } from './service-account';
 import { Volume } from './volume';
 
@@ -121,6 +121,10 @@ export class DaemonSet extends Resource implements IPodTemplate {
 
   public get securityContext(): PodSecurityContext {
     return this._podTemplate.securityContext;
+  }
+
+  public get dns(): PodDns {
+    return this._podTemplate.dns;
   }
 
   public addContainer(container: ContainerProps): Container {

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -4,7 +4,7 @@ import { Resource, ResourceProps } from './base';
 import { Container, ContainerProps } from './container';
 import * as k8s from './imports/k8s';
 import { IngressV1Beta1 } from './ingress-v1beta1';
-import { RestartPolicy, PodTemplate, IPodTemplate, PodTemplateProps, PodSecurityContext, HostAlias } from './pod';
+import { RestartPolicy, PodTemplate, IPodTemplate, PodTemplateProps, PodSecurityContext, HostAlias, PodDns } from './pod';
 import { ExposeServiceViaIngressOptions, Protocol, Service, ServiceType } from './service';
 import { IServiceAccount } from './service-account';
 import { Volume } from './volume';
@@ -195,6 +195,10 @@ export class Deployment extends Resource implements IPodTemplate {
 
   public get securityContext(): PodSecurityContext {
     return this._podTemplate.securityContext;
+  }
+
+  public get dns(): PodDns {
+    return this._podTemplate.dns;
   }
 
   /**

--- a/src/job.ts
+++ b/src/job.ts
@@ -3,7 +3,7 @@ import { Construct } from 'constructs';
 import { Resource, ResourceProps } from './base';
 import { Container, ContainerProps } from './container';
 import * as k8s from './imports/k8s';
-import { RestartPolicy, PodTemplateProps, IPodTemplate, PodTemplate, PodSecurityContext, HostAlias } from './pod';
+import { RestartPolicy, PodTemplateProps, IPodTemplate, PodTemplate, PodSecurityContext, HostAlias, PodDns } from './pod';
 import { IServiceAccount } from './service-account';
 import { Volume } from './volume';
 
@@ -122,6 +122,10 @@ export class Job extends Resource implements IPodTemplate {
 
   public get securityContext(): PodSecurityContext {
     return this._podTemplate.securityContext;
+  }
+
+  public get dns(): PodDns {
+    return this._podTemplate.dns;
   }
 
   public addContainer(container: ContainerProps): Container {

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -52,6 +52,16 @@ export interface IPodSpec {
   readonly hostAliases: HostAlias[];
 
   /**
+   * The pod's DNS settings.
+   */
+  readonly dns: PodDns;
+
+  /**
+   * The pod's security context.
+   */
+  readonly securityContext: PodSecurityContext;
+
+  /**
    * Add a container to the pod.
    *
    * @param container The container.
@@ -95,6 +105,7 @@ export class PodSpec implements IPodSpec {
   public readonly restartPolicy?: RestartPolicy;
   public readonly serviceAccount?: IServiceAccount;
   public readonly securityContext: PodSecurityContext;
+  public readonly dns: PodDns;
   public readonly dockerRegistryAuth?: DockerConfigSecret;
 
   private readonly _containers: Container[] = [];
@@ -106,6 +117,7 @@ export class PodSpec implements IPodSpec {
     this.restartPolicy = props.restartPolicy;
     this.serviceAccount = props.serviceAccount;
     this.securityContext = new PodSecurityContext(props.securityContext);
+    this.dns = new PodDns(props.dns);
     this.dockerRegistryAuth = props.dockerRegistryAuth;
 
     if (props.containers) {
@@ -229,6 +241,8 @@ export class PodSpec implements IPodSpec {
       volumes.set(volume.name, volume);
     }
 
+    const dns = this.dns._toKube();
+
     return {
       restartPolicy: this.restartPolicy,
       serviceAccountName: this.serviceAccount?.name,
@@ -237,6 +251,11 @@ export class PodSpec implements IPodSpec {
       initContainers: initContainers,
       hostAliases: this.hostAliases,
       volumes: Array.from(volumes.values()).map(v => v._toKube()),
+      dnsPolicy: dns.policy,
+      dnsConfig: dns.config,
+      hostname: dns.hostname,
+      subdomain: dns.subdomain,
+      setHostnameAsFqdn: dns.hostnameAsFQDN,
       imagePullSecrets: this.dockerRegistryAuth ? [{ name: this.dockerRegistryAuth.name }] : undefined,
     };
 
@@ -440,12 +459,23 @@ export interface PodSpecProps {
   readonly hostAliases?: HostAlias[];
 
   /**
+   * DNS settings for the pod.
+   *
+   * @see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
+   *
+   * @default
+   *
+   *  policy: DnsPolicy.CLUSTER_FIRST
+   *  hostnameAsFQDN: false
+   */
+  readonly dns?: PodDnsProps;
+
+  /**
    * A secret containing docker credentials for authenticating to a registry.
    *
    * @default - No auth. Images are assumed to be publicly available.
    */
   readonly dockerRegistryAuth?: DockerConfigSecret;
-
 }
 
 /**
@@ -500,6 +530,10 @@ export class Pod extends Resource implements IPodSpec {
     return this._spec.hostAliases;
   }
 
+  public get dns(): PodDns {
+    return this._spec.dns;
+  }
+
   public addContainer(container: ContainerProps): Container {
     return this._spec.addContainer(container);
   }
@@ -514,6 +548,186 @@ export class Pod extends Resource implements IPodSpec {
 
   public addHostAlias(hostAlias: HostAlias): void {
     return this._spec.addHostAlias(hostAlias);
+  }
+
+}
+
+/**
+ * Properties for `PodDns`.
+ */
+export interface PodDnsProps {
+
+  /**
+   * Specifies the hostname of the Pod.
+   *
+   * @default - Set to a system-defined value.
+   */
+  readonly hostname?: string;
+
+  /**
+   * If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+   *
+   * @default - No subdomain.
+   */
+  readonly subdomain?: string;
+
+  /**
+   * If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+   * In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+   * In Windows containers, this means setting the registry value of hostname for the registry
+   * key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters to FQDN.
+   * If a pod does not have FQDN, this has no effect.
+   *
+   * @default false
+   */
+  readonly hostnameAsFQDN?: boolean;
+
+  /**
+   * Set DNS policy for the pod.
+   *
+   * If policy is set to `None`, other configuration must be supplied.
+   *
+   * @default DnsPolicy.CLUSTER_FIRST
+   */
+  readonly policy?: DnsPolicy;
+
+  /**
+   * A list of IP addresses that will be used as DNS servers for the Pod. There can be at most 3 IP addresses specified.
+   * When the policy is set to "NONE", the list must contain at least one IP address,
+   * otherwise this property is optional.
+   * The servers listed will be combined to the base nameservers generated from
+   * the specified DNS policy with duplicate addresses removed.
+   */
+  readonly nameservers?: string[];
+
+  /**
+   * A list of DNS search domains for hostname lookup in the Pod.
+   * When specified, the provided list will be merged into the base
+   * search domain names generated from the chosen DNS policy.
+   * Duplicate domain names are removed.
+   *
+   * Kubernetes allows for at most 6 search domains.
+   */
+  readonly searches?: string[];
+
+  /**
+   * List of objects where each object may have a name property (required)
+   * and a value property (optional). The contents in this property
+   * will be merged to the options generated from the specified DNS policy.
+   * Duplicate entries are removed.
+   */
+  readonly options?: DnsOption[];
+}
+
+/**
+ * Holds dns settings of the pod.
+ */
+export class PodDns {
+
+  /**
+   * The DNS policy of this pod.
+   */
+  public readonly policy: DnsPolicy;
+
+  /**
+   * The configured hostname of the pod. Undefined means its set to a system-defined value.
+   */
+  public readonly hostname?: string;
+
+  /**
+   * The configured subdomain of the pod.
+   */
+  public readonly subdomain?: string;
+
+  /**
+   * Whether or not the pods hostname is set to its FQDN.
+   */
+  public readonly hostnameAsFQDN: boolean;
+
+  private readonly _nameservers: string[];
+  private readonly _searches: string[];
+  private readonly _options: DnsOption[];
+
+  constructor(props: PodDnsProps = {}) {
+    this.hostname = props.hostname;
+    this.subdomain = props.subdomain;
+    this.policy = props.policy ?? DnsPolicy.CLUSTER_FIRST;
+    this.hostnameAsFQDN = props.hostnameAsFQDN ?? false;
+    this._nameservers = props.nameservers ?? [];
+    this._searches = props.searches ?? [];
+    this._options = props.options ?? [];
+  }
+
+  /**
+   * Nameservers defined for this pod.
+   */
+  public get nameservers(): string[] {
+    return [...this._nameservers];
+  }
+
+  /**
+   * Search domains defined for this pod.
+   */
+  public get searches(): string[] {
+    return [...this._searches];
+  }
+
+  /**
+   * Custom dns options defined for this pod.
+   */
+  public get options(): DnsOption[] {
+    return [...this._options];
+  }
+
+  /**
+   * Add a nameserver.
+   */
+  public addNameserver(...nameservers: string[]) {
+    this._nameservers.push(...nameservers);
+  }
+
+  /**
+   * Add a search domain.
+   */
+  public addSearch(...searches: string[]) {
+    this._searches.push(...searches);
+  }
+
+  /**
+   * Add a custom option.
+   */
+  public addOption(...options: DnsOption[]) {
+    this._options.push(...options);
+  }
+
+  /**
+   * @internal
+   */
+  public _toKube(): { hostname?: string; subdomain?: string; hostnameAsFQDN: boolean; policy: string; config: k8s.PodDnsConfig } {
+
+    if (this.policy === DnsPolicy.NONE && this.nameservers.length === 0) {
+      throw new Error('When dns policy is set to NONE, at least one nameserver is required');
+    }
+
+    if (this.nameservers.length > 3) {
+      throw new Error('There can be at most 3 nameservers specified');
+    }
+
+    if (this.searches.length > 6) {
+      throw new Error('There can be at most 6 search domains specified');
+    }
+
+    return {
+      hostname: this.hostname,
+      subdomain: this.subdomain,
+      hostnameAsFQDN: this.hostnameAsFQDN,
+      policy: this.policy,
+      config: {
+        nameservers: this.nameservers,
+        searches: this.searches,
+        options: this.options,
+      },
+    };
   }
 
 }
@@ -597,6 +811,58 @@ export enum FsGroupChangePolicy {
    * Always change permission and ownership of the volume when volume is mounted.
    */
   ALWAYS = 'Always'
+}
+
+/**
+ * Custom DNS option.
+ */
+export interface DnsOption {
+
+  /**
+   * Option name.
+   */
+  readonly name: string;
+
+  /**
+   * Option value.
+   *
+   * @default - No value.
+   */
+  readonly value?: string;
+}
+
+/**
+ * Pod DNS policies.
+ */
+export enum DnsPolicy {
+
+  /**
+   * Any DNS query that does not match the configured cluster domain suffix,
+   * such as "www.kubernetes.io", is forwarded to the
+   * upstream nameserver inherited from the node.
+   * Cluster administrators may have extra stub-domain and upstream DNS servers configured.
+   */
+  CLUSTER_FIRST = 'ClusterFirst',
+
+  /**
+   * For Pods running with hostNetwork, you should
+   * explicitly set its DNS policy "ClusterFirstWithHostNet".
+   */
+  CLUSTER_FIRST_WITH_HOST_NET = 'ClusterFirstWithHostNet',
+
+  /**
+   * The Pod inherits the name resolution configuration
+   * from the node that the pods run on.
+   */
+  DEFAULT = 'Default',
+
+  /**
+   * It allows a Pod to ignore DNS settings from the Kubernetes environment.
+   * All DNS settings are supposed to be provided using the dnsConfig
+   * field in the Pod Spec.
+   */
+  NONE = 'None',
+
 }
 
 /**

--- a/src/statefulset.ts
+++ b/src/statefulset.ts
@@ -3,7 +3,7 @@ import { Construct } from 'constructs';
 import { Resource, ResourceProps } from './base';
 import { Container, ContainerProps } from './container';
 import * as k8s from './imports/k8s';
-import { RestartPolicy, PodTemplate, IPodTemplate, PodTemplateProps, PodSecurityContext, HostAlias } from './pod';
+import { RestartPolicy, PodTemplate, IPodTemplate, PodTemplateProps, PodSecurityContext, HostAlias, PodDns } from './pod';
 import { Service } from './service';
 import { IServiceAccount } from './service-account';
 import { Volume } from './volume';
@@ -183,6 +183,10 @@ export class StatefulSet extends Resource implements IPodTemplate {
 
   public get serviceAccount(): IServiceAccount | undefined {
     return this._podTemplate.serviceAccount;
+  }
+
+  public get dns(): PodDns {
+    return this._podTemplate.dns;
   }
 
   /**

--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -29,6 +29,12 @@ Array [
           ],
         },
       ],
+      "dnsConfig": Object {
+        "nameservers": Array [],
+        "options": Array [],
+        "searches": Array [],
+      },
+      "dnsPolicy": "ClusterFirst",
       "hostAliases": Array [],
       "initContainers": Array [],
       "securityContext": Object {
@@ -36,6 +42,7 @@ Array [
         "runAsNonRoot": false,
         "sysctls": Array [],
       },
+      "setHostnameAsFQDN": false,
       "volumes": Array [
         Object {
           "name": "pvc-pvc-test-pv-c8b2a2c6",

--- a/test/__snapshots__/daemon-set.test.ts.snap
+++ b/test/__snapshots__/daemon-set.test.ts.snap
@@ -37,6 +37,12 @@ Array [
               "volumeMounts": Array [],
             },
           ],
+          "dnsConfig": Object {
+            "nameservers": Array [],
+            "options": Array [],
+            "searches": Array [],
+          },
+          "dnsPolicy": "ClusterFirst",
           "hostAliases": Array [],
           "initContainers": Array [],
           "securityContext": Object {
@@ -44,6 +50,7 @@ Array [
             "runAsNonRoot": false,
             "sysctls": Array [],
           },
+          "setHostnameAsFQDN": false,
           "volumes": Array [],
         },
       },
@@ -89,6 +96,12 @@ Array [
               "volumeMounts": Array [],
             },
           ],
+          "dnsConfig": Object {
+            "nameservers": Array [],
+            "options": Array [],
+            "searches": Array [],
+          },
+          "dnsPolicy": "ClusterFirst",
           "hostAliases": Array [],
           "initContainers": Array [],
           "securityContext": Object {
@@ -96,6 +109,7 @@ Array [
             "runAsNonRoot": false,
             "sysctls": Array [],
           },
+          "setHostnameAsFQDN": false,
           "volumes": Array [],
         },
       },

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -48,6 +48,12 @@ Array [
               "volumeMounts": Array [],
             },
           ],
+          "dnsConfig": Object {
+            "nameservers": Array [],
+            "options": Array [],
+            "searches": Array [],
+          },
+          "dnsPolicy": "ClusterFirst",
           "hostAliases": Array [],
           "initContainers": Array [],
           "securityContext": Object {
@@ -55,6 +61,7 @@ Array [
             "runAsNonRoot": false,
             "sysctls": Array [],
           },
+          "setHostnameAsFQDN": false,
           "volumes": Array [],
         },
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [feat(pod): pod dns settings (#497)](https://github.com/cdk8s-team/cdk8s-plus/pull/497)

<!--- Backport version: 8.3.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)