### PR TITLE
feat(container): populate env from `ConfigMap` and `Secret`

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -913,7 +913,7 @@ export class EnvFrom {
 }
 
 /**
- * Container environment.
+ * Container environment variables.
  */
 export class Env {
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -4,6 +4,7 @@ import * as handler from './handler';
 import * as k8s from './imports/k8s';
 import * as probe from './probe';
 import * as secret from './secret';
+import { undefinedIfEmpty } from './utils';
 import * as volume from './volume';
 
 /**
@@ -482,6 +483,8 @@ export interface ContainerProps {
    * When a key exists in multiple sources, the value associated with
    * the last source will take precedence. Values defined by the `envVariables` property
    * with a duplicate key will take precedence.
+   *
+   * @default - No sources.
    */
   readonly envFrom?: EnvFrom[];
 
@@ -990,10 +993,10 @@ export class Env {
   /**
    * @internal
    */
-  public _toKube(): { variables: k8s.EnvVar[]; from: k8s.EnvFromSource[] } {
+  public _toKube(): { variables?: k8s.EnvVar[]; from?: k8s.EnvFromSource[] } {
     return {
-      from: this._sources.map(s => s._toKube()),
-      variables: this.renderEnv(this._variables),
+      from: undefinedIfEmpty(this._sources.map(s => s._toKube())),
+      variables: undefinedIfEmpty(this.renderEnv(this._variables)),
     };
   }
 }

--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -12,7 +12,6 @@ Array [
       "automountServiceAccountToken": true,
       "containers": Array [
         Object {
-          "env": Array [],
           "image": "image",
           "imagePullPolicy": "Always",
           "name": "main",

--- a/test/__snapshots__/daemon-set.test.ts.snap
+++ b/test/__snapshots__/daemon-set.test.ts.snap
@@ -26,7 +26,6 @@ Array [
           "automountServiceAccountToken": true,
           "containers": Array [
             Object {
-              "env": Array [],
               "image": "image",
               "imagePullPolicy": "Always",
               "name": "main",
@@ -87,7 +86,6 @@ Array [
           "automountServiceAccountToken": true,
           "containers": Array [
             Object {
-              "env": Array [],
               "image": "image",
               "imagePullPolicy": "Always",
               "name": "main",

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -35,7 +35,6 @@ Array [
           "automountServiceAccountToken": true,
           "containers": Array [
             Object {
-              "env": Array [],
               "image": "image",
               "imagePullPolicy": "Always",
               "name": "main",


### PR DESCRIPTION
Add support for the `envFrom` property of a container -- allowing to populate a container's environment with variables from other sources. 

Docs update: https://github.com/cdk8s-team/cdk8s/pull/913

BREAKING CHANGE: Use `container.env.addVariable()` instead of `container.addEnv()`. Property `env` of container renamed to `envVariables`. 

Resolves https://github.com/cdk8s-team/cdk8s-plus/issues/346

Signed-off-by: Eli Polonsky <epolon@amazon.com>