### PR TITLE
feat: bump cdk8s to version `2.x` (#696)

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -326,7 +326,7 @@
       "description": "Prepare a release from \"k8s-20/main\" branch",
       "env": {
         "RELEASE": "true",
-        "MAJOR": "1",
+        "MAJOR": "2",
         "PRERELEASE": "beta",
         "RELEASE_TAG_PREFIX": "cdk8s-plus-20/"
       },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -50,7 +50,7 @@ const project = new cdk.JsiiProject({
     'snake-case',
   ],
 
-  majorVersion: 1,
+  majorVersion: 2,
   releaseTagPrefix: `cdk8s-plus-${SPEC_VERSION}/`,
   releaseWorkflowName: `release-k8s.${SPEC_VERSION}`,
   defaultReleaseBranch: `k8s-${SPEC_VERSION}/main`,

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "cdk8s": "1.5.86",
-    "cdk8s-cli": "1.0.163",
-    "constructs": "3.3.283",
+    "cdk8s": "2.2.85",
+    "cdk8s-cli": "^1.0.163",
+    "constructs": "10.1.7",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^2.7.1",
@@ -77,8 +77,8 @@
     "typescript": "^4.6.4"
   },
   "peerDependencies": {
-    "cdk8s": "^1.5.86",
-    "constructs": "^3.3.283"
+    "cdk8s": "^2.2.85",
+    "constructs": "^10.1.7"
   },
   "dependencies": {
     "minimatch": "^3.1.2"

--- a/src/ingress-v1beta1.ts
+++ b/src/ingress-v1beta1.ts
@@ -82,9 +82,11 @@ export class IngressV1Beta1 extends base.Resource {
     if (props.tls) {
       this.addTls(props.tls);
     }
+
+    this.node.addValidation({ validate: () => this._validate() });
   }
 
-  protected onValidate() {
+  private _validate() {
     if (!this._defaultBackend && Object.keys(this._rulesPerHost).length === 0) {
       return ['ingress with no rules or default backend'];
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,7 +1415,16 @@ cdk8s-plus-22@^1.0.0-beta.216:
   dependencies:
     minimatch "^3.1.2"
 
-cdk8s@1.5.86, cdk8s@^1.5.85:
+cdk8s@2.2.85:
+  version "2.2.85"
+  resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-2.2.85.tgz#fff95213d2ee3b690a4a026f2b7d6cdeb2ad1e63"
+  integrity sha512-nZg+p44hqVT8MViNl7Ny/qwmys/BCkZbOifXSaKuIOLclXDLAak24sy2l1NsO4ugf9pn0hEqMQ9eLR41c+M/iQ==
+  dependencies:
+    fast-json-patch "^2.2.1"
+    follow-redirects "^1.14.9"
+    yaml "2.0.0-7"
+
+cdk8s@^1.5.85:
   version "1.5.86"
   resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-1.5.86.tgz#f695b699a55193c9925b5175c051515039b7e5d4"
   integrity sha512-5brCXdY69cJYff1njLMhbpj2lO5EAeeXbaR4l7m+vb/BIN/WpgiV9QatNgcxLqalcILnzGyDzlMB+TaCp//Rqw==
@@ -1638,7 +1647,12 @@ console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@3.3.283, constructs@^3.3.282:
+constructs@10.1.7:
+  version "10.1.7"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.1.7.tgz#d96fbeedb8d091720f4d3347c955bd42593abaa2"
+  integrity sha512-U4zMM7Iqa81hzLSfof9IW9R7kUWSMdhzV2JS8lXGISRFXljZrd4qwzYxhSO/VMB+CS24Tt0/YYLyNxET+6/3Mg==
+
+constructs@^3.3.282:
   version "3.3.283"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.283.tgz#de79629ea9442d8711b04b3472799e7fc5697171"
   integrity sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,10 +565,25 @@
     chalk "^4.1.2"
     semver "^7.3.5"
 
+"@jsii/check-node@1.59.0":
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.59.0.tgz#60112ad890432b9dec18d2d0528539e8ca23060f"
+  integrity sha512-rpQBTjmekIBdAjV6BHt9HWVRQH1qt9SER7Q/sQJ6ByvlIEN3QmV5FBiNF/i8/P0rE+Zot5Y0ErpthRBwPc6Heg==
+  dependencies:
+    chalk "^4.1.2"
+    semver "^7.3.7"
+
 "@jsii/spec@1.57.0", "@jsii/spec@^1.44.0", "@jsii/spec@^1.57.0":
   version "1.57.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.57.0.tgz#f22cf639fed22e1fb2cc39ae818e2c0eecf999bd"
   integrity sha512-Pt1wWIVeBN7UHJ9Flj676hNA3sNN06YSbErUd3loLgCUjRDOUzp2QysaRQK2Zsf2DBIjwLq048btoWkjPsTFJQ==
+  dependencies:
+    jsonschema "^1.4.0"
+
+"@jsii/spec@1.59.0", "@jsii/spec@^1.59.0":
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.59.0.tgz#ec926963514ab041eac4befb68f89e61d72b4413"
+  integrity sha512-ak72X8rQTheSk9QxjAuffFC5X0TtoR2pjh3bYWAPrWmniP/W3zqWSkVCPCgpS4yX2We8aF3zxg/iYm8feuS67w==
   dependencies:
     jsonschema "^1.4.0"
 
@@ -1393,30 +1408,30 @@ case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk8s-cli@1.0.163:
-  version "1.0.163"
-  resolved "https://registry.yarnpkg.com/cdk8s-cli/-/cdk8s-cli-1.0.163.tgz#09f5914c101bacdeb645a25ea96f52039d14b494"
-  integrity sha512-IL3X+VBTbiY48iFgN41C/iZ9GH3pKJFXqhUBtCS5zGfFIw6vMIY6olGoARLNO4AFyqUQnbTGdw+zD0WAbQ0Nog==
+cdk8s-cli@^1.0.163:
+  version "1.0.164"
+  resolved "https://registry.yarnpkg.com/cdk8s-cli/-/cdk8s-cli-1.0.164.tgz#40eccccca0436043ae2dbb6ffc9e51528c5cf9b9"
+  integrity sha512-1saDFNPhU3v1GI7KxuIj96oXV3x+QbqF9ZKBS9gRSj61YkZOsQ6L8UsMl1lFBBvKeO2OYc11Kvtrqxss0bIXkQ==
   dependencies:
     "@types/node" "^12"
     ajv "^8.11.0"
-    cdk8s "^1.5.85"
-    cdk8s-plus-22 "^1.0.0-beta.216"
+    cdk8s "^1.5.86"
+    cdk8s-plus-22 "^1.0.0-beta.217"
     codemaker "^1.57.0"
     colors "1.4.0"
-    constructs "^3.3.282"
+    constructs "^3.3.283"
     fs-extra "^8"
     jsii-pacmak "^1.57.0"
-    jsii-srcmak "^0.1.547"
-    json2jsii "^0.2.206"
-    sscaff "^1.2.273"
+    jsii-srcmak "^0.1.548"
+    json2jsii "^0.2.207"
+    sscaff "^1.2.274"
     yaml "2.0.0-11"
     yargs "^15"
 
-cdk8s-plus-22@^1.0.0-beta.216:
-  version "1.0.0-beta.217"
-  resolved "https://registry.yarnpkg.com/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.217.tgz#64244f22f0d4e516554ebb7de63291770b98ee6e"
-  integrity sha512-wOIUd6OpYRN5W/gqajeQt5uPO9hy2hT/5hHol/1z1cRRlhAcjTDmgcZW+AaF+rTQJi5hwv1mvb/Sj4KQQMAYOQ==
+cdk8s-plus-22@^1.0.0-beta.217:
+  version "1.0.0-beta.222"
+  resolved "https://registry.yarnpkg.com/cdk8s-plus-22/-/cdk8s-plus-22-1.0.0-beta.222.tgz#eaceeffe91565b818c2ed57c42f70d444794528c"
+  integrity sha512-SFqhacJUt9lnBdIgifvJZItB2sgDu4rjX991lMvT3EZl36ByBmMECNualocWj+e76bObriCxcmZ430XNxubuvQ==
   dependencies:
     minimatch "^3.1.2"
 
@@ -1429,7 +1444,7 @@ cdk8s@2.2.85:
     follow-redirects "^1.14.9"
     yaml "2.0.0-7"
 
-cdk8s@^1.5.85:
+cdk8s@^1.5.86:
   version "1.5.86"
   resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-1.5.86.tgz#f695b699a55193c9925b5175c051515039b7e5d4"
   integrity sha512-5brCXdY69cJYff1njLMhbpj2lO5EAeeXbaR4l7m+vb/BIN/WpgiV9QatNgcxLqalcILnzGyDzlMB+TaCp//Rqw==
@@ -1546,6 +1561,15 @@ codemaker@^1.57.0:
     decamelize "^5.0.1"
     fs-extra "^9.1.0"
 
+codemaker@^1.59.0:
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.59.0.tgz#71c8c179b2598f7867678d56859495ccbf6d391d"
+  integrity sha512-pVie4lGQgjejvGGcZnhO//9naGRNeHRq96kFrlfQQGABiToLcCy2/UQtAi2qw7FYrPRKqHn2DBR8PcP4avwEMw==
+  dependencies:
+    camelcase "^6.3.0"
+    decamelize "^5.0.1"
+    fs-extra "^9.1.0"
+
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
@@ -1657,10 +1681,10 @@ constructs@10.1.7:
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.1.7.tgz#d96fbeedb8d091720f4d3347c955bd42593abaa2"
   integrity sha512-U4zMM7Iqa81hzLSfof9IW9R7kUWSMdhzV2JS8lXGISRFXljZrd4qwzYxhSO/VMB+CS24Tt0/YYLyNxET+6/3Mg==
 
-constructs@^3.3.282:
-  version "3.3.283"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.283.tgz#de79629ea9442d8711b04b3472799e7fc5697171"
-  integrity sha512-0LbWDLDPE6sa19F87kTg/a+7ZhO6YXaGs3JYPYcYcd1vzastOUbJQ+GY9O7BweDMLj0Hcw4WP33qV0SFmGnipQ==
+constructs@^3.3.283:
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.4.10.tgz#4754e1ceb771a37dff65327f834e125b83e1291e"
+  integrity sha512-SAl+0oq6GxrgF+YVn9NV5ZbVK5vDyFCL4bCEPIhx61jYIH/npP/MFTBm0RO8Agf2it8iZTE0QtzOoOzuxk8tRA==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"
@@ -1895,6 +1919,11 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+date-format@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.10.tgz#7aa4bc0ad0c79f4ba858290e5dbb47f27d602e79"
+  integrity sha512-RuMIHocrVjF84bUSTcd1uokIsLsOsk1Awb7TexNOI3f48ukCu39mjslWquDTA08VaDMF2umr3MB9ow5EyJTWyA==
 
 date-format@^4.0.9:
   version "4.0.9"
@@ -3957,6 +3986,25 @@ jsii-pacmak@^1.57.0:
     xmlbuilder "^15.1.1"
     yargs "^16.2.0"
 
+jsii-pacmak@^1.59.0:
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.59.0.tgz#2e9ffafe1e343de74a20cfe1949e1d995962ca10"
+  integrity sha512-/ncoEz33NdxPYTFGp/FQf3Y+VqRp5PnE26Jjjf2k48dF3fzFY5axfujNdRO2KfEp1/GsLu8+EdSOpn7DxH09mA==
+  dependencies:
+    "@jsii/check-node" "1.59.0"
+    "@jsii/spec" "^1.59.0"
+    clone "^2.1.2"
+    codemaker "^1.59.0"
+    commonmark "^0.30.0"
+    escape-string-regexp "^4.0.0"
+    fs-extra "^9.1.0"
+    jsii-reflect "^1.59.0"
+    jsii-rosetta "^1.59.0"
+    semver "^7.3.7"
+    spdx-license-list "^6.5.0"
+    xmlbuilder "^15.1.1"
+    yargs "^16.2.0"
+
 jsii-reflect@^1.44.0, jsii-reflect@^1.57.0:
   version "1.57.0"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.57.0.tgz#4eb4b05664f5c71da3ecd4b05544e95436a8c4f4"
@@ -3967,6 +4015,18 @@ jsii-reflect@^1.44.0, jsii-reflect@^1.57.0:
     chalk "^4"
     fs-extra "^9.1.0"
     oo-ascii-tree "^1.57.0"
+    yargs "^16.2.0"
+
+jsii-reflect@^1.59.0:
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.59.0.tgz#099ca3b9b20c76a707ad7022d9f0a6f4ce17888f"
+  integrity sha512-17AeRkjuy+eFBC/HIhH7Yb72VXYA+Qvp+cccF1yWig5/2aFfNVuWo9bIy+nstiZAFWsNamODjm3i17P1mt0+aQ==
+  dependencies:
+    "@jsii/check-node" "1.59.0"
+    "@jsii/spec" "^1.59.0"
+    chalk "^4"
+    fs-extra "^9.1.0"
+    oo-ascii-tree "^1.59.0"
     yargs "^16.2.0"
 
 jsii-rosetta@^1.44.0, jsii-rosetta@^1.57.0:
@@ -3988,14 +4048,33 @@ jsii-rosetta@^1.44.0, jsii-rosetta@^1.57.0:
     workerpool "^6.2.0"
     yargs "^16.2.0"
 
-jsii-srcmak@^0.1.547:
-  version "0.1.548"
-  resolved "https://registry.yarnpkg.com/jsii-srcmak/-/jsii-srcmak-0.1.548.tgz#e08cb03e1212cc4140a74818901a7ccdc9a99389"
-  integrity sha512-T04iUa1449ajETALwI0QNiCy+ePrhU21cyGzcVrhF4dRTnfQeNwQkWZkcc6QIoL6rg/m9zuuxJl5wZaHDDXqhA==
+jsii-rosetta@^1.59.0:
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.59.0.tgz#009607ee8be05bcefa7eb3bf0a9c33853a57d85c"
+  integrity sha512-aJgfBwn3srai/4HGwYx5si+W4kuzaQh2/1xCzgpiOKwu/n0UZg0IB7z59IG6HQ/G5Yfu8Mc6AEfjAsi0kj2dbA==
+  dependencies:
+    "@jsii/check-node" "1.59.0"
+    "@jsii/spec" "1.59.0"
+    "@xmldom/xmldom" "^0.8.2"
+    commonmark "^0.30.0"
+    fast-glob "^3.2.11"
+    fs-extra "^9.1.0"
+    jsii "1.59.0"
+    semver "^7.3.7"
+    semver-intersect "^1.4.0"
+    sort-json "^2.0.1"
+    typescript "~3.9.10"
+    workerpool "^6.2.1"
+    yargs "^16.2.0"
+
+jsii-srcmak@^0.1.548:
+  version "0.1.563"
+  resolved "https://registry.yarnpkg.com/jsii-srcmak/-/jsii-srcmak-0.1.563.tgz#eecd9a5af47556725b48d207e241098dd96472c8"
+  integrity sha512-njEi6974vnNDTB0SLSBOiHgIYtOWZAWZsOVtKpEfvhyqaBq/qnxiPsUVXw+4riBXeLp7OnYBlmkU3vUiFFCVQg==
   dependencies:
     fs-extra "^9.1.0"
-    jsii "^1.57.0"
-    jsii-pacmak "^1.57.0"
+    jsii "^1.59.0"
+    jsii-pacmak "^1.59.0"
     ncp "^2.0.0"
     yargs "^15.4.1"
 
@@ -4012,6 +4091,25 @@ jsii@1.57.0, jsii@^1.57.0:
     fs-extra "^9.1.0"
     log4js "^6.4.4"
     semver "^7.3.5"
+    semver-intersect "^1.4.0"
+    sort-json "^2.0.1"
+    spdx-license-list "^6.5.0"
+    typescript "~3.9.10"
+    yargs "^16.2.0"
+
+jsii@1.59.0, jsii@^1.59.0:
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.59.0.tgz#65d3454311f931345b4996177135321f8bfd506d"
+  integrity sha512-vTVMRN5ViX1aCe0K7P8ECKi2CseNDEcvIWvw4xyg+nCg9a73XZ16ONOqBAGjKUnJv2gOsecsb1FyuqcRbfs+zQ==
+  dependencies:
+    "@jsii/check-node" "1.59.0"
+    "@jsii/spec" "^1.59.0"
+    case "^1.6.3"
+    chalk "^4"
+    deep-equal "^2.0.5"
+    fs-extra "^9.1.0"
+    log4js "^6.4.6"
+    semver "^7.3.7"
     semver-intersect "^1.4.0"
     sort-json "^2.0.1"
     spdx-license-list "^6.5.0"
@@ -4065,7 +4163,7 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json2jsii@^0.2.206:
+json2jsii@^0.2.207:
   version "0.2.207"
   resolved "https://registry.yarnpkg.com/json2jsii/-/json2jsii-0.2.207.tgz#1294c922bf8c224d64adb4cfee87b63735e92484"
   integrity sha512-WhmFUfUX/iOqoFaZiFqsWRzIz4LohsPzhf7IcosE6Ap94bpQ+i1dwHn1mjuSJDx8tzCCyE80h5h0zRADX0berA==
@@ -4246,6 +4344,17 @@ log4js@^6.4.4:
     flatted "^3.2.5"
     rfdc "^1.3.0"
     streamroller "^3.0.8"
+
+log4js@^6.4.6:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.4.7.tgz#adba3797606664e83567d2fbf38fa14b9d809167"
+  integrity sha512-q/9Eyw/hkvQ4e9DNHLbK2AfuDDm5QnNnmF022aamyw4nUnVLQRhvGoryccN5aEI4J/UcA4W36xttBCrlrdzt2g==
+  dependencies:
+    date-format "^4.0.10"
+    debug "^4.3.4"
+    flatted "^3.2.5"
+    rfdc "^1.3.0"
+    streamroller "^3.0.9"
 
 lower-case@^2.0.2:
   version "2.0.2"
@@ -4788,6 +4897,11 @@ oo-ascii-tree@^1.57.0:
   version "1.57.0"
   resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.57.0.tgz#7948791e43699130ae6cee8a750abac784c8da7c"
   integrity sha512-f0YTN8p0IN/X05R3N8yfENqCx7seBtDdVdJa8yQc2kx/v5OuEz/femhwEerxSsVXlb/OKjo2u4QAXTkjWjbPHA==
+
+oo-ascii-tree@^1.59.0:
+  version "1.59.0"
+  resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.59.0.tgz#02e7511dcbbc68e262aaa2bc3d970b5bed8243be"
+  integrity sha512-vRUOZ6ViKLh6Ib9wpW4WTiKcgSU6wsLhfg5ngFVX42J3NLOTtDT3AXaKU2HKfbU4HjvcfLmDXWfNv86q1T+ZVQ==
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -5612,7 +5726,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sscaff@^1.2.273:
+sscaff@^1.2.274:
   version "1.2.274"
   resolved "https://registry.yarnpkg.com/sscaff/-/sscaff-1.2.274.tgz#3ae52042fbeb244b01b89542a56ce5b247284be9"
   integrity sha512-sztRa50SL1LVxZnF1au6QT1SC2z0S1oEOyi2Kpnlg6urDns93aL32YxiJcNkLcY+VHFtVqm/SRv4cb+6LeoBQA==
@@ -5658,6 +5772,15 @@ streamroller@^3.0.8:
   integrity sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==
   dependencies:
     date-format "^4.0.9"
+    debug "^4.3.4"
+    fs-extra "^10.1.0"
+
+streamroller@^3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.0.9.tgz#23b956f2f6e3d679c95a519b0680b8b70fb84040"
+  integrity sha512-Y46Aq/ftqFP6Wb6sK79hgnZeRfEVz2F0nquBy4lMftUuJoTiwKa6Y96AWAUGV1F3CjhFark9sQmzL9eDpltkRw==
+  dependencies:
+    date-format "^4.0.10"
     debug "^4.3.4"
     fs-extra "^10.1.0"
 
@@ -6262,7 +6385,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-workerpool@^6.2.0:
+workerpool@^6.2.0, workerpool@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-20/main`:
 - [feat: bump cdk8s to version `2.x` (#696)](https://github.com/cdk8s-team/cdk8s-plus/pull/696)

<!--- Backport version: 8.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)