### PR TITLE
chore: set git identity on backport

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -17,6 +17,12 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
+          "exec": "git config user.name \"github-actions\""
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\""
+        },
+        {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --non-interactive",
           "cwd": "/tmp/.backport/"
         }
@@ -37,6 +43,12 @@
         },
         {
           "exec": "cp .backportrc.json /tmp/.backport/"
+        },
+        {
+          "exec": "git config user.name \"github-actions\""
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\""
         },
         {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-20/main",
@@ -61,6 +73,12 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
+          "exec": "git config user.name \"github-actions\""
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\""
+        },
+        {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-21/main",
           "cwd": "/tmp/.backport/"
         }
@@ -81,6 +99,12 @@
         },
         {
           "exec": "cp .backportrc.json /tmp/.backport/"
+        },
+        {
+          "exec": "git config user.name \"github-actions\""
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\""
         },
         {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-22/main",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -192,6 +192,8 @@ function createBackportTask(branch?: Number): Task {
   task.exec(`rm -rf ${backportHome}`);
   task.exec(`mkdir -p ${backportHome}`);
   task.exec(`cp ${backportConfig.path} ${backportHome}`);
+  task.exec('git config user.name "github-actions"');
+  task.exec('git config user.email "github-actions@github.com"');
 
   const command = ['npx', 'backport', '--accesstoken', '${GITHUB_TOKEN}', '--pr', '${BACKPORT_PR_NUMBER}'];
   if (branch) {


### PR DESCRIPTION
Currently failing since we don't run from the repo directory:

```console
.","sha":"fe2ea8d3f6cba603b275ada1cce78bdf9638182b"}},"sourceBranch":"k8s-22/main","expectedTargetPullRequests":[{"branch":"k8s-21/main","state":"NOT_CREATED"},{"branch":"k8s-20/main","state":"NOT_CREATED"}]}],"results":[{"targetBranch":"k8s-21/main","status":"unhandled-error","error":{"name":"SpawnError","context":{"cmdArgs":["commit","--no-edit","--no-verify"],"code":128,"stderr":"Author identity unknown\n\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set your account's default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: empty ident name (for <runner@fv-az450-
```