### PR TITLE
chore: set git identity on backport (#707)

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -17,6 +17,12 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
+          "exec": "git config user.name \"github-actions\""
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\""
+        },
+        {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --non-interactive",
           "cwd": "/tmp/.backport/"
         }
@@ -37,6 +43,12 @@
         },
         {
           "exec": "cp .backportrc.json /tmp/.backport/"
+        },
+        {
+          "exec": "git config user.name \"github-actions\""
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\""
         },
         {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-20/main",
@@ -61,6 +73,12 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
+          "exec": "git config user.name \"github-actions\""
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\""
+        },
+        {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-21/main",
           "cwd": "/tmp/.backport/"
         }
@@ -81,6 +99,12 @@
         },
         {
           "exec": "cp .backportrc.json /tmp/.backport/"
+        },
+        {
+          "exec": "git config user.name \"github-actions\""
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\""
         },
         {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-22/main",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -192,6 +192,8 @@ function createBackportTask(branch?: Number): Task {
   task.exec(`rm -rf ${backportHome}`);
   task.exec(`mkdir -p ${backportHome}`);
   task.exec(`cp ${backportConfig.path} ${backportHome}`);
+  task.exec('git config user.name "github-actions"');
+  task.exec('git config user.email "github-actions@github.com"');
 
   const command = ['npx', 'backport', '--accesstoken', '${GITHUB_TOKEN}', '--pr', '${BACKPORT_PR_NUMBER}'];
   if (branch) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [chore: set git identity on backport (#707)](https://github.com/cdk8s-team/cdk8s-plus/pull/707)

<!--- Backport version: 8.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)