### PR TITLE
chore: backport git identity fails (#710)

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -17,10 +17,16 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
-          "exec": "git config user.name \"github-actions\""
+          "exec": "git init",
+          "cwd": "/tmp/.backport/"
         },
         {
-          "exec": "git config user.email \"github-actions@github.com\""
+          "exec": "git config user.name \"github-actions\"",
+          "cwd": "/tmp/.backport/"
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\"",
+          "cwd": "/tmp/.backport/"
         },
         {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --non-interactive",
@@ -45,10 +51,16 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
-          "exec": "git config user.name \"github-actions\""
+          "exec": "git init",
+          "cwd": "/tmp/.backport/"
         },
         {
-          "exec": "git config user.email \"github-actions@github.com\""
+          "exec": "git config user.name \"github-actions\"",
+          "cwd": "/tmp/.backport/"
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\"",
+          "cwd": "/tmp/.backport/"
         },
         {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-20/main",
@@ -73,10 +85,16 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
-          "exec": "git config user.name \"github-actions\""
+          "exec": "git init",
+          "cwd": "/tmp/.backport/"
         },
         {
-          "exec": "git config user.email \"github-actions@github.com\""
+          "exec": "git config user.name \"github-actions\"",
+          "cwd": "/tmp/.backport/"
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\"",
+          "cwd": "/tmp/.backport/"
         },
         {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-21/main",
@@ -101,10 +119,16 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
-          "exec": "git config user.name \"github-actions\""
+          "exec": "git init",
+          "cwd": "/tmp/.backport/"
         },
         {
-          "exec": "git config user.email \"github-actions@github.com\""
+          "exec": "git config user.name \"github-actions\"",
+          "cwd": "/tmp/.backport/"
+        },
+        {
+          "exec": "git config user.email \"github-actions@github.com\"",
+          "cwd": "/tmp/.backport/"
         },
         {
           "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-22/main",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -192,15 +192,16 @@ function createBackportTask(branch?: Number): Task {
   task.exec(`rm -rf ${backportHome}`);
   task.exec(`mkdir -p ${backportHome}`);
   task.exec(`cp ${backportConfig.path} ${backportHome}`);
-  task.exec('git config user.name "github-actions"');
-  task.exec('git config user.email "github-actions@github.com"');
 
-  const command = ['npx', 'backport', '--accesstoken', '${GITHUB_TOKEN}', '--pr', '${BACKPORT_PR_NUMBER}'];
+  const backport = ['npx', 'backport', '--accesstoken', '${GITHUB_TOKEN}', '--pr', '${BACKPORT_PR_NUMBER}'];
   if (branch) {
-    command.push(...['--branch', `k8s-${branch}/main`]);
+    backport.push(...['--branch', `k8s-${branch}/main`]);
   } else {
-    command.push('--non-interactive');
+    backport.push('--non-interactive');
   }
-  task.exec(command.join(' '), { cwd: backportHome });
+  task.exec('git init', { cwd: backportHome });
+  task.exec('git config user.name "github-actions"', { cwd: backportHome });
+  task.exec('git config user.email "github-actions@github.com"', { cwd: backportHome });
+  task.exec(backport.join(' '), { cwd: backportHome });
   return task;
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-22/main` to `k8s-21/main`:
 - [chore: backport git identity fails (#710)](https://github.com/cdk8s-team/cdk8s-plus/pull/710)

<!--- Backport version: 8.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)