### PR TITLE
fix(deployment): unable to set `maxUnavailable` on a rolling update strategy

### DIFF
--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -310,7 +310,7 @@ export class DeploymentStrategy {
   public static rollingUpdate(options: DeploymentStrategyRollingUpdateOptions = {}): DeploymentStrategy {
 
     const maxSurge = options.maxSurge ?? PercentOrAbsolute.percent(25);
-    const maxUnavailable = options.maxSurge ?? PercentOrAbsolute.percent(25);
+    const maxUnavailable = options.maxUnavailable ?? PercentOrAbsolute.percent(25);
 
     if (maxSurge.isZero() && maxUnavailable.isZero()) {
       throw new Error('\'maxSurge\' and \'maxUnavailable\' cannot be both zero');

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -240,6 +240,29 @@ test('custom deployment strategy', () => {
 
 });
 
+test('rolling update deployment strategy with a custom maxSurge and maxUnavailable', () => {
+
+  const chart = Testing.chart();
+
+  const deployment = new kplus.Deployment(chart, 'Deployment', {
+    strategy: DeploymentStrategy.rollingUpdate({
+      maxSurge: PercentOrAbsolute.percent(50),
+      maxUnavailable: PercentOrAbsolute.absolute(1),
+    }),
+  });
+  deployment.addContainer({ image: 'image' });
+
+  const spec: k8s.DeploymentSpec = Testing.synth(chart)[0].spec;
+
+  expect(spec.strategy).toEqual({
+    type: 'RollingUpdate',
+    rollingUpdate: {
+      maxSurge: '50%',
+      maxUnavailable: 1,
+    },
+  });
+});
+
 test('throws is maxSurge and maxUnavailable is set to zero for rolling update', () => {
 
   const chart = Testing.chart();


### PR DESCRIPTION
This looks like a copy-paste error. I couldn't create a deployment strategy with different maxSurge and maxUnavailable values because of it. But with this fix different values for maxSurge and maxUnavailable simply work.