### PR TITLE
fix(container): unable to set partial container resources

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -704,8 +704,8 @@ export class Container {
     let resourceRequirements: k8s.ResourceRequirements | undefined = undefined;
     if (Object.keys(limits).length > 0 || Object.keys(requests).length > 0) {
       resourceRequirements = {
-        limits: limits,
-        requests: requests,
+        limits: undefinedIfEmpty(limits),
+        requests: undefinedIfEmpty(requests),
       };
     }
 
@@ -848,16 +848,16 @@ export enum MountPropagation {
  * CPU and memory compute resources
  */
 export interface ContainerResources {
-  readonly cpu: CpuResources;
-  readonly memory: MemoryResources;
+  readonly cpu?: CpuResources;
+  readonly memory?: MemoryResources;
 }
 
 /**
  * CPU request and limit
  */
 export interface CpuResources {
-  readonly request: Cpu;
-  readonly limit: Cpu;
+  readonly request?: Cpu;
+  readonly limit?: Cpu;
 }
 
 /**
@@ -881,8 +881,8 @@ export class Cpu {
  * Memory request and limit
  */
 export interface MemoryResources {
-  readonly request: container;
-  readonly limit: container;
+  readonly request?: container;
+  readonly limit?: container;
 }
 
 /**

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -395,6 +395,90 @@ describe('Container', () => {
 
 });
 
+test('Can add only resource requests', () => {
+  const container = new kplus.Container({
+    resources: {
+      cpu: {
+        request: Cpu.millis(300),
+      },
+      memory: {
+        request: Size.mebibytes(128),
+      },
+    },
+    image: 'image',
+  });
+
+  expect(container._toKube().resources).toEqual({
+    requests: {
+      cpu: k8s.Quantity.fromString('300m'),
+      memory: k8s.Quantity.fromString('128Mi'),
+    },
+  });
+});
+
+test('Can add only resource limits', () => {
+  const container = new kplus.Container({
+    resources: {
+      cpu: {
+        limit: Cpu.millis(500),
+      },
+      memory: {
+        limit: Size.mebibytes(1024),
+      },
+    },
+    image: 'image',
+  });
+
+  expect(container._toKube().resources).toEqual({
+    limits: {
+      cpu: k8s.Quantity.fromString('500m'),
+      memory: k8s.Quantity.fromString('1024Mi'),
+    },
+  });
+});
+
+test('Can add only limits and requests on memory', () => {
+  const container = new kplus.Container({
+    resources: {
+      memory: {
+        limit: Size.mebibytes(1024),
+        request: Size.mebibytes(512),
+      },
+    },
+    image: 'image',
+  });
+
+  expect(container._toKube().resources).toEqual({
+    limits: {
+      memory: k8s.Quantity.fromString('1024Mi'),
+    },
+    requests: {
+      memory: k8s.Quantity.fromString('512Mi'),
+    },
+  });
+});
+
+test('Can add only limits and requests on cpu', () => {
+  const container = new kplus.Container({
+    resources: {
+      cpu: {
+        limit: Cpu.units(1),
+        request: Cpu.millis(250),
+      },
+    },
+    image: 'image',
+  });
+
+  expect(container._toKube().resources).toEqual({
+    limits: {
+      cpu: k8s.Quantity.fromString('1'),
+    },
+    requests: {
+      cpu: k8s.Quantity.fromString('250m'),
+    },
+  });
+});
+
 test('default security context', () => {
 
   const container = new Container({ image: 'image' });


### PR DESCRIPTION
I noticed I couldn't specify just a limit or request in the container resources. I could either fully specify the limits and requests for both cpu and memory, or could I choose not specify anything at all, but nothing in between. After this change I can, for example, specify only the request and limits for memory, leaving cpu to best effort.

I consider this a fix since the code was already checking for non-null values in the `ContainerResources` parameter (see container.ts, lines 683-686). The values couldn't be null before (they were marked required), so these checks weren't functional. With this fix they can be null and the checks are functional again.