### PR TITLE
feat: everything is a construct

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -1,5 +1,5 @@
 import { ApiObjectMetadata, ApiObject, ApiObjectMetadataDefinition } from 'cdk8s';
-import { Construct } from 'constructs';
+import { Construct, IConstruct } from 'constructs';
 import { IApiResource, IApiEndpoint } from './api-resource.generated';
 
 /**
@@ -16,7 +16,7 @@ export interface ResourceProps {
 /**
  * Represents a resource.
  */
-export interface IResource {
+export interface IResource extends IConstruct {
   /**
    * The Kubernetes name of this resource.
    */

--- a/src/config-map.ts
+++ b/src/config-map.ts
@@ -52,20 +52,43 @@ export interface IConfigMap extends base.IResource {
 
 }
 
+class ImportedConfigMap extends Construct implements IConfigMap {
+
+  private readonly _name: string;
+
+  constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this._name = name;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get apiVersion(): string {
+    return k8s.KubeConfigMap.GVK.apiVersion;
+  }
+
+  public get apiGroup(): string {
+    return '';
+  }
+
+  public get kind(): string {
+    return k8s.KubeConfigMap.GVK.kind;
+  }
+
+}
+
 /**
  * ConfigMap holds configuration data for pods to consume.
  */
 export class ConfigMap extends base.Resource implements IConfigMap {
+
   /**
    * Represents a ConfigMap created elsewhere.
-   * @param name The name of the config map to import
    */
-  public static fromConfigMapName(name: string): IConfigMap {
-    return {
-      apiGroup: '',
-      name,
-      ...k8s.KubeConfigMap.GVK,
-    };
+  public static fromConfigMapName(scope: Construct, id: string, name: string): IConfigMap {
+    return new ImportedConfigMap(scope, id, name);
   }
 
   /**

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,5 +1,5 @@
 import { ApiObject, Lazy } from 'cdk8s';
-import { Construct } from 'constructs';
+import { Construct, IConstruct } from 'constructs';
 import * as base from './base';
 import * as k8s from './imports/k8s';
 import * as pod from './pod';
@@ -23,7 +23,7 @@ export interface NamespaceSelectorConfig {
 /**
  * Represents an object that can select namespaces.
  */
-export interface INamespaceSelector {
+export interface INamespaceSelector extends IConstruct {
   /**
    * Return the configuration of this selector.
    */
@@ -114,26 +114,28 @@ export interface NamespacesSelectOptions {
 /**
  * Represents a group of namespaces.
  */
-export class Namespaces implements INamespaceSelector {
+export class Namespaces extends Construct implements INamespaceSelector {
 
   /**
    * Select specific namespaces.
    */
-  public static select(options: NamespacesSelectOptions): Namespaces {
-    return new Namespaces(options.expressions, options.names, options.labels);
+  public static select(scope: Construct, id: string, options: NamespacesSelectOptions): Namespaces {
+    return new Namespaces(scope, id, options.expressions, options.names, options.labels);
   }
 
   /**
    * Select all namespaces.
    */
-  public static all(): Namespaces {
-    return Namespaces.select({ expressions: [], labels: {} });
+  public static all(scope: Construct, id: string): Namespaces {
+    return Namespaces.select(scope, id, { expressions: [], labels: {} });
   }
 
-  constructor(
+  constructor(scope: Construct, id: string,
     private readonly expressions?: pod.LabelExpression[],
     private readonly names?: string[],
-    private readonly labels?: { [key: string]: string }) { }
+    private readonly labels?: { [key: string]: string }) {
+    super(scope, id);
+  }
 
   /**
    * @see INamespaceSelector.toNamespaceSelectorConfig()

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -1,5 +1,5 @@
 import { ApiObject, ApiObjectMetadataDefinition, Duration, Lazy, Names } from 'cdk8s';
-import { Construct } from 'constructs';
+import { Construct, IConstruct } from 'constructs';
 import * as base from './base';
 import * as container from './container';
 import * as k8s from './imports/k8s';
@@ -450,7 +450,7 @@ export interface PodSelectorConfig {
 /**
  * Represents an object that can select pods.
  */
-export interface IPodSelector {
+export interface IPodSelector extends IConstruct {
   /**
    * Return the configuration of this selector.
    */
@@ -1092,19 +1092,21 @@ export interface PodSelectOptions {
 /**
  * Represents a group of pods.
  */
-export class Pods implements IPodSelector {
+export class Pods extends Construct implements IPodSelector {
 
   /**
    * Select pods in the cluster with various selectors.
    */
-  public static select(options: PodSelectOptions): Pods {
-    return new Pods(options.expressions, options.labels, options.namespaces);
+  public static select(scope: Construct, id: string, options: PodSelectOptions): Pods {
+    return new Pods(scope, id, options.expressions, options.labels, options.namespaces);
   }
 
-  constructor(
+  constructor(scope: Construct, id: string,
     private readonly expressions?: LabelExpression[],
     private readonly labels?: { [key: string]: string },
-    private readonly namespaces?: namespace.INamespaceSelector) { }
+    private readonly namespaces?: namespace.INamespaceSelector) {
+    super(scope, id);
+  }
 
   public toPodSelectorConfig(): PodSelectorConfig {
     return {

--- a/src/pv.ts
+++ b/src/pv.ts
@@ -236,7 +236,7 @@ export class PersistentVolume extends base.Resource implements IPersistentVolume
 
   public asVolume(): volume.Volume {
     const claim = this.reserve();
-    return volume.Volume.fromPersistentVolumeClaim(claim);
+    return volume.Volume.fromPersistentVolumeClaim(this, 'Volume', claim);
   }
 
   /**

--- a/src/pv.ts
+++ b/src/pv.ts
@@ -75,6 +75,33 @@ export interface PersistentVolumeProps extends base.ResourceProps {
 
 }
 
+class ImportedPersistentVolume extends Construct implements IPersistentVolume {
+
+  private readonly _name: string;
+
+  constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this._name = name;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get apiVersion(): string {
+    return k8s.KubePersistentVolume.GVK.apiVersion;
+  }
+
+  public get apiGroup(): string {
+    return '';
+  }
+
+  public get kind(): string {
+    return k8s.KubePersistentVolume.GVK.kind;
+  }
+
+}
+
 /**
  * A PersistentVolume (PV) is a piece of storage in the cluster that has been
  * provisioned by an administrator or dynamically provisioned using Storage Classes.
@@ -88,14 +115,9 @@ export class PersistentVolume extends base.Resource implements IPersistentVolume
 
   /**
    * Imports a pv from the cluster as a reference.
-   * @param volumeName The name of the pv to reference.
    */
-  public static fromPersistentVolumeName(volumeName: string): IPersistentVolume {
-    return {
-      apiGroup: '',
-      name: volumeName,
-      ...k8s.KubePersistentVolume.GVK,
-    };
+  public static fromPersistentVolumeName(scope: Construct, id: string, volumeName: string): IPersistentVolume {
+    return new ImportedPersistentVolume(scope, id, volumeName);
   }
 
   /**

--- a/src/pvc.ts
+++ b/src/pvc.ts
@@ -71,6 +71,33 @@ export interface PersistentVolumeClaimProps extends base.ResourceProps {
 
 }
 
+class ImportedPersistentVolumeClaim extends Construct implements IPersistentVolumeClaim {
+
+  private readonly _name: string;
+
+  constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this._name = name;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get apiVersion(): string {
+    return k8s.KubePersistentVolumeClaim.GVK.apiVersion;
+  }
+
+  public get apiGroup(): string {
+    return '';
+  }
+
+  public get kind(): string {
+    return k8s.KubePersistentVolumeClaim.GVK.kind;
+  }
+
+}
+
 /**
  * A PersistentVolumeClaim (PVC) is a request for storage by a user.
  * It is similar to a Pod. Pods consume node resources and PVCs consume PV resources.
@@ -81,14 +108,9 @@ export class PersistentVolumeClaim extends base.Resource implements IPersistentV
 
   /**
    * Imports a pvc from the cluster as a reference.
-   * @param claimName The name of the pvc to reference.
    */
-  public static fromClaimName(claimName: string): IPersistentVolumeClaim {
-    return {
-      apiGroup: '',
-      name: claimName,
-      ...k8s.KubePersistentVolumeClaim.GVK,
-    };
+  public static fromClaimName(scope: Construct, id: string, claimName: string): IPersistentVolumeClaim {
+    return new ImportedPersistentVolumeClaim(scope, id, claimName);
   }
 
   /**

--- a/src/role-binding.ts
+++ b/src/role-binding.ts
@@ -1,5 +1,5 @@
 import { ApiObject, Lazy } from 'cdk8s';
-import { Construct } from 'constructs';
+import { Construct, IConstruct } from 'constructs';
 import { Resource, ResourceProps } from './base';
 import * as k8s from './imports/k8s';
 import * as role from './role';
@@ -10,7 +10,7 @@ import { filterUndefined } from './utils';
  * applies to.  This can either hold a direct API object reference, or a value
  * for non-objects such as user and group names.
  */
-export interface ISubject {
+export interface ISubject extends IConstruct {
   /**
    * APIGroup holds the API group of the referenced subject. Defaults to "" for
    * ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User
@@ -183,45 +183,45 @@ export class ClusterRoleBinding extends Resource {
 }
 
 /**
- * Properties for `User`.
- */
-export interface UserProps {
-  /**
-   * The name of the user.
-   */
-  readonly name: string;
-}
-
-/**
  * Represents a user.
  */
-export class User implements ISubject {
+export class User extends Construct implements ISubject {
+
+  /**
+   * Reference a user in the cluster by name.
+   */
+  public static fromName(scope: Construct, id: string, name: string) {
+    return new User(scope, id, name);
+  }
+
   public readonly apiGroup: string | undefined = 'rbac.authorization.k8s.io';
   public readonly kind: string = 'User';
   public readonly name: string;
-  constructor(props: UserProps) {
-    this.name = props.name;
-  }
-}
 
-/**
- * Properties for `Group`.
- */
-export interface GroupProps {
-  /**
-   * The name of the group.
-   */
-  readonly name: string;
+  private constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this.name = name;
+  }
 }
 
 /**
  * Represents a group.
  */
-export class Group implements ISubject {
+export class Group extends Construct implements ISubject {
+
+  /**
+   * Reference a group in the cluster by name.
+   */
+  public static fromName(scope: Construct, id: string, name: string) {
+    return new Group(scope, id, name);
+  }
+
   public readonly apiGroup: string | undefined = 'rbac.authorization.k8s.io';
   public readonly kind: string = 'Group';
   public readonly name: string;
-  constructor(props: GroupProps) {
-    this.name = props.name;
+
+  private constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this.name = name;
   }
 }

--- a/src/role.ts
+++ b/src/role.ts
@@ -41,6 +41,31 @@ export interface RolePolicyRule {
   readonly resources: IApiResource[];
 }
 
+class ImportedRole extends Construct implements IRole {
+
+  private readonly _name: string;
+  constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this._name = name;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get apiVersion(): string {
+    return k8s.KubeRole.GVK.apiVersion;
+  }
+
+  public get apiGroup(): string {
+    return 'rbac.authorization.k8s.io';
+  }
+
+  public get kind(): string {
+    return k8s.KubeRole.GVK.kind;
+  }
+}
+
 /**
  * Role is a namespaced, logical grouping of PolicyRules that can be referenced
  * as a unit by a RoleBinding.
@@ -49,14 +74,9 @@ export class Role extends base.Resource implements IRole {
 
   /**
    * Imports a role from the cluster as a reference.
-   * @param name The name of the role resource.
    */
-  public static fromRoleName(name: string): IRole {
-    return {
-      apiGroup: 'rbac.authorization.k8s.io',
-      name,
-      ...k8s.KubeRole.GVK,
-    };
+  public static fromRoleName(scope: Construct, id: string, name: string): IRole {
+    return new ImportedRole(scope, id, name);
   }
 
   /**
@@ -253,6 +273,33 @@ export interface ClusterRolePolicyRule {
   readonly endpoints: IApiEndpoint[];
 }
 
+class ImportedClusterRole extends Construct implements IClusterRole {
+
+  private readonly _name: string;
+
+  constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this._name = name;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get apiVersion(): string {
+    return k8s.KubeClusterRole.GVK.apiVersion;
+  }
+
+  public get apiGroup(): string {
+    return 'rbac.authorization.k8s.io';
+  }
+
+  public get kind(): string {
+    return k8s.KubeClusterRole.GVK.kind;
+  }
+
+}
+
 /**
  * ClusterRole is a cluster level, logical grouping of PolicyRules that can be
  * referenced as a unit by a RoleBinding or ClusterRoleBinding.
@@ -261,14 +308,9 @@ export class ClusterRole extends base.Resource implements IClusterRole, IRole {
 
   /**
    * Imports a role from the cluster as a reference.
-   * @param name The name of the role resource.
    */
-  public static fromClusterRoleName(name: string): IClusterRole {
-    return {
-      apiGroup: 'rbac.authorization.k8s.io',
-      name,
-      ...k8s.KubeClusterRole.GVK,
-    };
+  public static fromClusterRoleName(scope: Construct, id: string, name: string): IClusterRole {
+    return new ImportedClusterRole(scope, id, name);
   }
 
   /**

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -60,6 +60,33 @@ export interface SecretValue {
   readonly key: string;
 }
 
+class ImportedSecret extends Construct implements ISecret {
+
+  private readonly _name: string;
+
+  constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this._name = name;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get apiVersion(): string {
+    return k8s.KubeSecret.GVK.apiVersion;
+  }
+
+  public get apiGroup(): string {
+    return '';
+  }
+
+  public get kind(): string {
+    return k8s.KubeSecret.GVK.kind;
+  }
+
+}
+
 /**
  * Kubernetes Secrets let you store and manage sensitive information, such as
  * passwords, OAuth tokens, and ssh keys. Storing confidential information in a
@@ -72,14 +99,9 @@ export class Secret extends base.Resource implements ISecret {
 
   /**
    * Imports a secret from the cluster as a reference.
-   * @param name The name of the secret to reference.
    */
-  public static fromSecretName(name: string): ISecret {
-    return {
-      apiGroup: '',
-      name,
-      ...k8s.KubeSecret.GVK,
-    };
+  public static fromSecretName(scope: Construct, id: string, name: string): ISecret {
+    return new ImportedSecret(scope, id, name);
   }
 
   /**

--- a/src/service-account.ts
+++ b/src/service-account.ts
@@ -33,6 +33,33 @@ export interface ServiceAccountProps extends base.ResourceProps {
   readonly automountToken?: boolean;
 }
 
+class ImportedServiceAccount extends Construct implements IServiceAccount {
+
+  private readonly _name: string;
+
+  constructor(scope: Construct, id: string, name: string) {
+    super(scope, id);
+    this._name = name;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get apiVersion(): string {
+    return k8s.KubeServiceAccount.GVK.apiVersion;
+  }
+
+  public get apiGroup(): string {
+    return '';
+  }
+
+  public get kind(): string {
+    return k8s.KubeServiceAccount.GVK.kind;
+  }
+
+}
+
 /**
  * A service account provides an identity for processes that run in a Pod.
  *
@@ -51,12 +78,8 @@ export class ServiceAccount extends base.Resource implements IServiceAccount, rb
    * Imports a service account from the cluster as a reference.
    * @param name The name of the service account resource.
    */
-  public static fromServiceAccountName(name: string): IServiceAccount {
-    return {
-      apiGroup: '',
-      name,
-      ...k8s.KubeServiceAccount.GVK,
-    };
+  public static fromServiceAccountName(scope: Construct, id: string, name: string): IServiceAccount {
+    return new ImportedServiceAccount(scope, id, name);
   }
 
   /**

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -257,7 +257,7 @@ describe('Container', () => {
     });
 
     const chart = Testing.chart();
-    const volume = kplus.Volume.fromConfigMap(kplus.ConfigMap.fromConfigMapName(chart, 'ConfigMap', 'ConfigMap'));
+    const volume = kplus.Volume.fromConfigMap(chart, 'Volume', kplus.ConfigMap.fromConfigMapName(chart, 'ConfigMap', 'ConfigMap'));
 
     container.mount('/path/to/mount', volume);
 
@@ -289,7 +289,7 @@ describe('Container', () => {
     });
 
     const chart = Testing.chart();
-    const volume = kplus.Volume.fromConfigMap(kplus.ConfigMap.fromConfigMapName(chart, 'ConfigMap', 'ConfigMap'));
+    const volume = kplus.Volume.fromConfigMap(chart, 'Volume', kplus.ConfigMap.fromConfigMapName(chart, 'ConfigMap', 'ConfigMap'));
 
     container.mount('/path/to/mount', volume, {
       propagation: kplus.MountPropagation.BIDIRECTIONAL,
@@ -307,12 +307,13 @@ describe('Container', () => {
   });
 
   test('mount from ctor', () => {
+    const chart = Testing.chart();
     const container = new kplus.Container({
       image: 'image',
       volumeMounts: [
         {
           path: '/foo',
-          volume: kplus.Volume.fromEmptyDir('empty'),
+          volume: kplus.Volume.fromEmptyDir(chart, 'Volume', 'empty'),
           subPath: 'subPath',
         },
       ],

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -17,7 +17,8 @@ describe('EnvValue', () => {
 
   test('Can be created from config map name', () => {
 
-    const actual = kplus.EnvValue.fromConfigMap(kplus.ConfigMap.fromConfigMapName('ConfigMap'), 'key');
+    const chart = Testing.chart();
+    const actual = kplus.EnvValue.fromConfigMap(kplus.ConfigMap.fromConfigMapName(chart, 'ConfigMap', 'ConfigMap'), 'key');
 
     expect(actual.value).toBeUndefined();
     expect(actual.valueFrom).toEqual({
@@ -30,8 +31,9 @@ describe('EnvValue', () => {
   });
 
   test('Can be created from secret value', () => {
+    const chart = Testing.chart();
     const secretValue = {
-      secret: kplus.Secret.fromSecretName('Secret'),
+      secret: kplus.Secret.fromSecretName(chart, 'Secret', 'Secret'),
       key: 'my-key',
     };
 
@@ -254,7 +256,8 @@ describe('Container', () => {
       image: 'image',
     });
 
-    const volume = kplus.Volume.fromConfigMap(kplus.ConfigMap.fromConfigMapName('ConfigMap'));
+    const chart = Testing.chart();
+    const volume = kplus.Volume.fromConfigMap(kplus.ConfigMap.fromConfigMapName(chart, 'ConfigMap', 'ConfigMap'));
 
     container.mount('/path/to/mount', volume);
 
@@ -285,7 +288,8 @@ describe('Container', () => {
       image: 'image',
     });
 
-    const volume = kplus.Volume.fromConfigMap(kplus.ConfigMap.fromConfigMapName('ConfigMap'));
+    const chart = Testing.chart();
+    const volume = kplus.Volume.fromConfigMap(kplus.ConfigMap.fromConfigMapName(chart, 'ConfigMap', 'ConfigMap'));
 
     container.mount('/path/to/mount', volume, {
       propagation: kplus.MountPropagation.BIDIRECTIONAL,

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -497,9 +497,9 @@ describe('scheduling', () => {
 
     const chart = Testing.chart();
 
-    const redis = kplus.Pods.select({
+    const redis = kplus.Pods.select(chart, 'Redis', {
       labels: { app: 'store' },
-      namespaces: kplus.Namespaces.select({ labels: { net: '1' } } ),
+      namespaces: kplus.Namespaces.select(chart, 'Net', { labels: { net: '1' } } ),
     });
 
     const web = new kplus.Deployment(chart, 'Web', {
@@ -516,9 +516,9 @@ describe('scheduling', () => {
 
     const chart = Testing.chart();
 
-    const redis = kplus.Pods.select({
+    const redis = kplus.Pods.select(chart, 'Redis', {
       labels: { app: 'store' },
-      namespaces: kplus.Namespaces.select({ labels: { net: '1' } } ),
+      namespaces: kplus.Namespaces.select(chart, 'Net', { labels: { net: '1' } } ),
     });
 
     const web = new kplus.Deployment(chart, 'Web', {
@@ -603,9 +603,9 @@ describe('scheduling', () => {
 
     const chart = Testing.chart();
 
-    const redis = kplus.Pods.select({
+    const redis = kplus.Pods.select(chart, 'Redis', {
       labels: { app: 'store' },
-      namespaces: kplus.Namespaces.select({ labels: { net: '1' } } ),
+      namespaces: kplus.Namespaces.select(chart, 'Net', { labels: { net: '1' } } ),
     });
 
     const web = new kplus.Deployment(chart, 'Web', {
@@ -622,9 +622,9 @@ describe('scheduling', () => {
 
     const chart = Testing.chart();
 
-    const redis = kplus.Pods.select({
+    const redis = kplus.Pods.select(chart, 'Redis', {
       labels: { app: 'store' },
-      namespaces: kplus.Namespaces.select({ labels: { net: '1' } } ),
+      namespaces: kplus.Namespaces.select(chart, 'Net', { labels: { net: '1' } } ),
     });
 
     const web = new kplus.Deployment(chart, 'Web', {

--- a/test/namespace.test.ts
+++ b/test/namespace.test.ts
@@ -23,7 +23,8 @@ test('defaults', () => {
 });
 
 test('can select namespaces', () => {
-  const namespaces = kplus.Namespaces.select({
+  const chart = Testing.chart();
+  const namespaces = kplus.Namespaces.select(chart, 'Namespaces', {
     labels: { foo: 'bar' },
     expressions: [kplus.LabelExpression.exists('web')],
     names: ['web'],
@@ -33,7 +34,8 @@ test('can select namespaces', () => {
 });
 
 test('can select all namespaces', () => {
-  const namespaces = kplus.Namespaces.all();
+  const chart = Testing.chart();
+  const namespaces = kplus.Namespaces.all(chart, 'All');
   expect(namespaces.toNamespaceSelectorConfig().names).toBeUndefined();
   expect(namespaces.toNamespaceSelectorConfig()?.labelSelector?._toKube()).toMatchSnapshot();
 });

--- a/test/pv.test.ts
+++ b/test/pv.test.ts
@@ -1,4 +1,5 @@
 import * as cdk8s from 'cdk8s';
+import { Testing } from 'cdk8s';
 import * as kplus from '../src';
 
 describe('PersistentVolume', () => {
@@ -50,7 +51,8 @@ describe('PersistentVolume', () => {
 
   test('can be imported', () => {
 
-    const pv = kplus.PersistentVolume.fromPersistentVolumeName('vol');
+    const chart = Testing.chart();
+    const pv = kplus.PersistentVolume.fromPersistentVolumeName(chart, 'Vol', 'vol');
     expect(pv.name).toEqual('vol');
 
   });
@@ -129,7 +131,7 @@ describe('PersistentVolume', () => {
   test('can be bound to a claim at instantiation', () => {
 
     const chart = cdk8s.Testing.chart();
-    const pvc = kplus.PersistentVolumeClaim.fromClaimName('claim');
+    const pvc = kplus.PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
     const vol = new kplus.AwsElasticBlockStorePersistentVolume(chart, 'Volume', {
       volumeId: 'vol1',
       claim: pvc,
@@ -145,7 +147,7 @@ describe('PersistentVolume', () => {
   test('can be bound to a claim post instantiation', () => {
 
     const chart = cdk8s.Testing.chart();
-    const pvc = kplus.PersistentVolumeClaim.fromClaimName('claim');
+    const pvc = kplus.PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
     const vol = new kplus.AwsElasticBlockStorePersistentVolume(chart, 'Volume', {
       volumeId: 'vol1',
     });
@@ -162,7 +164,7 @@ describe('PersistentVolume', () => {
   test('no-ops if bounded twice to the same claim', () => {
 
     const chart = cdk8s.Testing.chart();
-    const pvc = kplus.PersistentVolumeClaim.fromClaimName('claim');
+    const pvc = kplus.PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
     const vol = new kplus.AwsElasticBlockStorePersistentVolume(chart, 'Volume', {
       volumeId: 'vol1',
     });
@@ -177,8 +179,8 @@ describe('PersistentVolume', () => {
   test('throws if bounded twice to different claims', () => {
 
     const chart = cdk8s.Testing.chart();
-    const pvc1 = kplus.PersistentVolumeClaim.fromClaimName('claim1');
-    const pvc2 = kplus.PersistentVolumeClaim.fromClaimName('claim2');
+    const pvc1 = kplus.PersistentVolumeClaim.fromClaimName(chart, 'Claim1', 'claim1');
+    const pvc2 = kplus.PersistentVolumeClaim.fromClaimName(chart, 'Claim2', 'claim2');
     const vol = new kplus.AwsElasticBlockStorePersistentVolume(chart, 'Volume', {
       volumeId: 'vol1',
     });

--- a/test/pvc.test.ts
+++ b/test/pvc.test.ts
@@ -1,4 +1,5 @@
 import * as cdk8s from 'cdk8s';
+import { Testing } from 'cdk8s';
 import * as kplus from '../src';
 
 test('defaults', () => {
@@ -38,7 +39,8 @@ test('custom', () => {
 
 test('can be imported', () => {
 
-  const claim = kplus.PersistentVolumeClaim.fromClaimName('claim');
+  const chart = Testing.chart();
+  const claim = kplus.PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
   expect(claim.name).toEqual('claim');
 
 });
@@ -46,7 +48,7 @@ test('can be imported', () => {
 test('can be bounded to a volume at instantiation', () => {
 
   const chart = cdk8s.Testing.chart();
-  const vol = kplus.PersistentVolume.fromPersistentVolumeName('vol');
+  const vol = kplus.PersistentVolume.fromPersistentVolumeName(chart, 'Vol', 'vol');
   const pvc = new kplus.PersistentVolumeClaim(chart, 'PersistentVolumeClaim', {
     volume: vol,
   });
@@ -61,7 +63,7 @@ test('can be bounded to a volume at instantiation', () => {
 test('can be bounded to a volume post instantiation', () => {
 
   const chart = cdk8s.Testing.chart();
-  const vol = kplus.PersistentVolume.fromPersistentVolumeName('vol');
+  const vol = kplus.PersistentVolume.fromPersistentVolumeName(chart, 'Vol', 'vol');
   const pvc = new kplus.PersistentVolumeClaim(chart, 'PersistentVolumeClaim');
 
   pvc.bind(vol);
@@ -76,7 +78,7 @@ test('can be bounded to a volume post instantiation', () => {
 test('no-ops if bounded twice to the same volume', () => {
 
   const chart = cdk8s.Testing.chart();
-  const vol = kplus.PersistentVolume.fromPersistentVolumeName('vol');
+  const vol = kplus.PersistentVolume.fromPersistentVolumeName(chart, 'Vole', 'vol');
   const pvc = new kplus.PersistentVolumeClaim(chart, 'PersistentVolumeClaim');
 
   pvc.bind(vol);
@@ -89,8 +91,8 @@ test('no-ops if bounded twice to the same volume', () => {
 test('throws if bounded twice to different volumes', () => {
 
   const chart = cdk8s.Testing.chart();
-  const vol1 = kplus.PersistentVolume.fromPersistentVolumeName('vol1');
-  const vol2 = kplus.PersistentVolume.fromPersistentVolumeName('vol2');
+  const vol1 = kplus.PersistentVolume.fromPersistentVolumeName(chart, 'Vol1', 'vol1');
+  const vol2 = kplus.PersistentVolume.fromPersistentVolumeName(chart, 'Vol2', 'vol2');
   const pvc = new kplus.PersistentVolumeClaim(chart, 'PersistentVolumeClaim');
 
   pvc.bind(vol1);

--- a/test/role-binding.test.ts
+++ b/test/role-binding.test.ts
@@ -9,8 +9,8 @@ test('can create a RoleBinding from a Role', () => {
   role.allowRead(kplus.ApiResource.PODS);
 
   // WHEN
-  const user = new kplus.User({ name: 'alice@example.com' });
-  const group = new kplus.Group({ name: 'frontend-admins' });
+  const user = kplus.User.fromName(chart, 'Alice', 'alice@example.com');
+  const group = kplus.Group.fromName(chart, 'FrontendAdmins', 'frontend-admins');
   const binding = role.bind(user, group);
 
   // THEN
@@ -58,8 +58,8 @@ test('can create a RoleBinding from a ClusterRole', () => {
   role.allowRead(kplus.ApiResource.PODS);
 
   // WHEN
-  const user = new kplus.User({ name: 'alice@example.com' });
-  const group = new kplus.Group({ name: 'frontend-admins' });
+  const user = kplus.User.fromName(chart, 'Alice', 'alice@example.com');
+  const group = kplus.Group.fromName(chart, 'FrontendAdmins', 'frontend-admins');
   const binding = role.bindInNamespace('development', user, group);
 
   // THEN
@@ -109,8 +109,8 @@ test('can call bindInNamespace multiple times', () => {
   role.allowRead(kplus.ApiResource.PODS);
 
   // WHEN
-  const user1 = new kplus.User({ name: 'alice@example.com' });
-  const user2 = new kplus.User({ name: 'bob@example.com' });
+  const user1 = kplus.User.fromName(chart, 'Alice', 'alice@example.com');
+  const user2 = kplus.User.fromName(chart, 'Bob', 'bob@example.com');
   const binding1 = role.bindInNamespace('staging', user1);
   const binding2 = role.bindInNamespace('development', user2);
 
@@ -143,8 +143,8 @@ test('can create a ClusterRoleBinding from a ClusterRole', () => {
   role.allowRead(kplus.ApiResource.PODS);
 
   // WHEN
-  const user = new kplus.User({ name: 'alice@example.com' });
-  const group = new kplus.Group({ name: 'frontend-admins' });
+  const user = kplus.User.fromName(chart, 'Alice', 'alice@example.com');
+  const group = kplus.Group.fromName(chart, 'FrontendAdmins', 'frontend-admins');
   const binding = role.bind(user, group);
 
   // THEN
@@ -219,8 +219,8 @@ test('can add subjects to a RoleBinding after creating it', () => {
   role.allowRead(kplus.ApiResource.PODS);
 
   // WHEN
-  const user = new kplus.User({ name: 'alice@example.com' });
-  const group = new kplus.Group({ name: 'frontend-admins' });
+  const user = kplus.User.fromName(chart, 'Alice', 'alice@example.com');
+  const group = kplus.Group.fromName(chart, 'FrontendAdmins', 'frontend-admins');
   const binding = role.bind();
   binding.addSubjects(user, group);
 

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -12,7 +12,8 @@ test('defaultChild', () => {
 });
 
 test('Can be imported from secret name', () => {
-  const secret = kplus.Secret.fromSecretName('secret');
+  const chart = Testing.chart();
+  const secret = kplus.Secret.fromSecretName(chart, 'Secret', 'secret');
 
   expect(secret.name).toEqual('secret');
 });
@@ -287,7 +288,7 @@ test('can configure an immutable service account token secret', () => {
   const chart = Testing.chart();
 
   const secret = new kplus.ServiceAccountTokenSecret(chart, 'Secret', {
-    serviceAccount: kplus.ServiceAccount.fromServiceAccountName('sa'),
+    serviceAccount: kplus.ServiceAccount.fromServiceAccountName(chart, 'SA', 'sa'),
     immutable: true,
   });
 

--- a/test/service-account.test.ts
+++ b/test/service-account.test.ts
@@ -38,8 +38,8 @@ test('minimal definition', () => {
 test('secrets can be added to the service account', () => {
   // GIVEN
   const chart = Testing.chart();
-  const secret1 = kplus.Secret.fromSecretName('my-secret-1');
-  const secret2 = kplus.Secret.fromSecretName('my-secret-2');
+  const secret1 = kplus.Secret.fromSecretName(chart, 'Secret1', 'my-secret-1');
+  const secret2 = kplus.Secret.fromSecretName(chart, 'Secret2', 'my-secret-2');
 
   // WHEN
   const sa = new kplus.ServiceAccount(chart, 'my-service-account', {

--- a/test/volume.test.ts
+++ b/test/volume.test.ts
@@ -278,7 +278,9 @@ describe('fromPersistentVolumeClaim', () => {
 
   test('defaults', () => {
 
-    const pvc = PersistentVolumeClaim.fromClaimName('claim');
+    const chart = Testing.chart();
+
+    const pvc = PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
     const volume = Volume.fromPersistentVolumeClaim(pvc);
 
     expect(volume.name).toEqual('pvc-claim');
@@ -293,7 +295,9 @@ describe('fromPersistentVolumeClaim', () => {
 
   test('custom', () => {
 
-    const pvc = PersistentVolumeClaim.fromClaimName('claim');
+    const chart = Testing.chart();
+
+    const pvc = PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
     const volume = Volume.fromPersistentVolumeClaim(pvc, {
       name: 'custom',
       readOnly: true,

--- a/test/volume.test.ts
+++ b/test/volume.test.ts
@@ -8,7 +8,7 @@ describe('fromSecret', () => {
     const secret = new Secret(chart, 'my-secret');
 
     // WHEN
-    const vol = Volume.fromSecret(secret);
+    const vol = Volume.fromSecret(chart, 'Secret', secret);
 
     // THEN
     expect(vol._toKube()).toMatchInlineSnapshot(`
@@ -30,7 +30,7 @@ describe('fromSecret', () => {
     const secret = new Secret(chart, 'my-secret');
 
     // WHEN
-    const vol = Volume.fromSecret(secret, {
+    const vol = Volume.fromSecret(chart, 'Secret', secret, {
       name: 'filesystem',
     });
 
@@ -45,7 +45,7 @@ describe('fromSecret', () => {
     const secret = new Secret(chart, 'my-secret');
 
     // WHEN
-    const vol = Volume.fromSecret(secret, {
+    const vol = Volume.fromSecret(chart, 'Secret', secret, {
       defaultMode: 0o777,
     });
 
@@ -59,9 +59,9 @@ describe('fromSecret', () => {
     const secret = new Secret(chart, 'my-secret');
 
     // WHEN
-    const vol0 = Volume.fromSecret(secret);
-    const vol1 = Volume.fromSecret(secret, { optional: true });
-    const vol2 = Volume.fromSecret(secret, { optional: false });
+    const vol0 = Volume.fromSecret(chart, 'Secret1', secret);
+    const vol1 = Volume.fromSecret(chart, 'Secret2', secret, { optional: true });
+    const vol2 = Volume.fromSecret(chart, 'Secret3', secret, { optional: false });
 
     // THEN
     expect(vol0._toKube().secret?.optional).toBe(undefined);
@@ -75,7 +75,7 @@ describe('fromSecret', () => {
     const secret = new Secret(chart, 'my-secret');
 
     // WHEN
-    const vol = Volume.fromSecret(secret, {
+    const vol = Volume.fromSecret(chart, 'Secret', secret, {
       items: {
         key1: { path: 'path/to/key1' },
         key2: { path: 'path/key2', mode: 0o100 },
@@ -101,7 +101,7 @@ describe('fromSecret', () => {
     const secret = new Secret(chart, 'my-secret');
 
     // WHEN
-    const vol = Volume.fromSecret(secret, {
+    const vol = Volume.fromSecret(chart, 'Secret', secret, {
       items: {
         key2: { path: 'path2' },
         key1: { path: 'path1' },
@@ -129,7 +129,7 @@ describe('fromConfigMap', () => {
     const configMap = new ConfigMap(chart, 'my-config-map');
 
     // WHEN
-    const vol = Volume.fromConfigMap(configMap);
+    const vol = Volume.fromConfigMap(chart, 'ConfigMap', configMap);
 
     // THEN
     expect(vol._toKube()).toMatchInlineSnapshot(`
@@ -151,7 +151,7 @@ describe('fromConfigMap', () => {
     const configMap = new ConfigMap(chart, 'my-config-map');
 
     // WHEN
-    const vol = Volume.fromConfigMap(configMap, {
+    const vol = Volume.fromConfigMap(chart, 'ConfigMap', configMap, {
       name: 'filesystem',
     });
 
@@ -166,7 +166,7 @@ describe('fromConfigMap', () => {
     const configMap = new ConfigMap(chart, 'my-config-map');
 
     // WHEN
-    const vol = Volume.fromConfigMap(configMap, {
+    const vol = Volume.fromConfigMap(chart, 'ConfigMap', configMap, {
       defaultMode: 0o777,
     });
 
@@ -180,9 +180,9 @@ describe('fromConfigMap', () => {
     const configMap = new ConfigMap(chart, 'my-config-map');
 
     // WHEN
-    const vol0 = Volume.fromConfigMap(configMap);
-    const vol1 = Volume.fromConfigMap(configMap, { optional: true });
-    const vol2 = Volume.fromConfigMap(configMap, { optional: false });
+    const vol0 = Volume.fromConfigMap(chart, 'ConfigMap1', configMap);
+    const vol1 = Volume.fromConfigMap(chart, 'ConfigMap2', configMap, { optional: true });
+    const vol2 = Volume.fromConfigMap(chart, 'ConfigMap3', configMap, { optional: false });
 
     // THEN
     expect(vol0._toKube().configMap?.optional).toBe(undefined);
@@ -196,7 +196,7 @@ describe('fromConfigMap', () => {
     const configMap = new ConfigMap(chart, 'my-config-map');
 
     // WHEN
-    const vol = Volume.fromConfigMap(configMap, {
+    const vol = Volume.fromConfigMap(chart, 'ConfigMap', configMap, {
       items: {
         key1: { path: 'path/to/key1' },
         key2: { path: 'path/key2', mode: 0o100 },
@@ -222,7 +222,7 @@ describe('fromConfigMap', () => {
     const configMap = new ConfigMap(chart, 'my-config-map');
 
     // WHEN
-    const vol = Volume.fromConfigMap(configMap, {
+    const vol = Volume.fromConfigMap(chart, 'ConfigMap', configMap, {
       items: {
         key2: { path: 'path2' },
         key1: { path: 'path1' },
@@ -245,8 +245,9 @@ describe('fromConfigMap', () => {
 
 describe('fromEmptyDir', () => {
   test('minimal definition', () => {
+    const chart = Testing.chart();
     // GIVEN
-    const vol = Volume.fromEmptyDir('main');
+    const vol = Volume.fromEmptyDir(chart, 'Volume', 'main');
 
     // THEN
     expect(vol._toKube()).toStrictEqual({
@@ -259,17 +260,20 @@ describe('fromEmptyDir', () => {
   });
 
   test('default medium', () => {
-    const vol = Volume.fromEmptyDir('main', { medium: EmptyDirMedium.DEFAULT });
+    const chart = Testing.chart();
+    const vol = Volume.fromEmptyDir(chart, 'Volume', 'main', { medium: EmptyDirMedium.DEFAULT });
     expect(vol._toKube().emptyDir?.medium).toEqual('');
   });
 
   test('memory medium', () => {
-    const vol = Volume.fromEmptyDir('main', { medium: EmptyDirMedium.MEMORY });
+    const chart = Testing.chart();
+    const vol = Volume.fromEmptyDir(chart, 'Volume', 'main', { medium: EmptyDirMedium.MEMORY });
     expect(vol._toKube().emptyDir?.medium).toEqual('Memory');
   });
 
   test('size limit', () => {
-    const vol = Volume.fromEmptyDir('main', { sizeLimit: Size.gibibytes(20) });
+    const chart = Testing.chart();
+    const vol = Volume.fromEmptyDir(chart, 'Volume', 'main', { sizeLimit: Size.gibibytes(20) });
     expect(vol._toKube().emptyDir!.sizeLimit!.value).toEqual('20480Mi');
   });
 });
@@ -281,7 +285,7 @@ describe('fromPersistentVolumeClaim', () => {
     const chart = Testing.chart();
 
     const pvc = PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
-    const volume = Volume.fromPersistentVolumeClaim(pvc);
+    const volume = Volume.fromPersistentVolumeClaim(chart, 'Volume', pvc);
 
     expect(volume.name).toEqual('pvc-claim');
     expect(volume._toKube()).toEqual({
@@ -298,7 +302,7 @@ describe('fromPersistentVolumeClaim', () => {
     const chart = Testing.chart();
 
     const pvc = PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
-    const volume = Volume.fromPersistentVolumeClaim(pvc, {
+    const volume = Volume.fromPersistentVolumeClaim(chart, 'Volume', pvc, {
       name: 'custom',
       readOnly: true,
     });
@@ -319,7 +323,8 @@ describe('fromAwsElasticBlockStore', () => {
 
   test('defaults', () => {
 
-    const volume = Volume.fromAwsElasticBlockStore('vol');
+    const chart = Testing.chart();
+    const volume = Volume.fromAwsElasticBlockStore(chart, 'Volume', 'vol');
     const spec = volume._toKube();
     expect(spec).toEqual({
       name: 'ebs-vol',
@@ -334,7 +339,8 @@ describe('fromAwsElasticBlockStore', () => {
 
   test('custom', () => {
 
-    const volume = Volume.fromAwsElasticBlockStore('vol', {
+    const chart = Testing.chart();
+    const volume = Volume.fromAwsElasticBlockStore(chart, 'Volume', 'vol', {
       fsType: 'fs',
       name: 'name',
       partition: 1,
@@ -359,7 +365,8 @@ describe('fromGcePersistentDisk', () => {
 
   test('defaults', () => {
 
-    const volume = Volume.fromGcePersistentDisk('pd');
+    const chart = Testing.chart();
+    const volume = Volume.fromGcePersistentDisk(chart, 'Volume', 'pd');
     const spec = volume._toKube();
     expect(spec).toEqual({
       name: 'gcedisk-pd',
@@ -374,7 +381,8 @@ describe('fromGcePersistentDisk', () => {
 
   test('custom', () => {
 
-    const volume = Volume.fromGcePersistentDisk('pd', {
+    const chart = Testing.chart();
+    const volume = Volume.fromGcePersistentDisk(chart, 'Volume', 'pd', {
       fsType: 'fs',
       name: 'name',
       partition: 1,
@@ -399,7 +407,8 @@ describe('fromAzureDisk', () => {
 
   test('defaults', () => {
 
-    const volume = Volume.fromAzureDisk('disk', 'uri');
+    const chart = Testing.chart();
+    const volume = Volume.fromAzureDisk(chart, 'Volume', 'disk', 'uri');
     const spec = volume._toKube();
     expect(spec).toEqual({
       name: 'azuredisk-disk',
@@ -417,7 +426,8 @@ describe('fromAzureDisk', () => {
 
   test('custom', () => {
 
-    const volume = Volume.fromAzureDisk('disk', 'uri', {
+    const chart = Testing.chart();
+    const volume = Volume.fromAzureDisk(chart, 'Volume', 'disk', 'uri', {
       cachingMode: AzureDiskPersistentVolumeCachingMode.READ_ONLY,
       fsType: 'fs',
       kind: AzureDiskPersistentVolumeKind.DEDICATED,


### PR DESCRIPTION
Currently, imported resources are not treated as constructs. We didn't initially implement them this way because there was no need, and it makes the API slightly more awkward.

Lately, we've been adding more and more of those, and a use case for them being constructs has risen, when those resources are being used for constructing actual managed resources.

This PR makes it so all imported resources (and selected as well) are constructs, and thus have stable id's we can use.
Even though this hurts API ergonomics a little bit, its worth it for the simplicity and flexibility it gives us. This is also in-line with how the AWS CDK treats imported resources, and in general, having to pass scopes and id's to classes in a construct library is a well known practice. 

BREAKING CHANGE: You must now pass a `scope` and `id` to imported and selected resources