### PR TITLE
feat: network policies (#737)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,5 +19,6 @@ export * from './daemon-set';
 export * from './role';
 export * from './role-binding';
 export * from './namespace';
+export * from './network-policy';
 
 export * from './api-resource.generated';

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -2,6 +2,7 @@ import { ApiObject, Lazy } from 'cdk8s';
 import { Construct, IConstruct } from 'constructs';
 import * as base from './base';
 import * as k8s from './imports/k8s';
+import * as networkpolicy from './network-policy';
 import * as pod from './pod';
 
 /**
@@ -41,7 +42,7 @@ export interface NamespaceProps extends base.ResourceProps {}
  * Namespace-based scoping is applicable only for namespaced objects (e.g. Deployments, Services, etc) and
  * not for cluster-wide objects (e.g. StorageClass, Nodes, PersistentVolumes, etc).
  */
-export class Namespace extends base.Resource implements INamespaceSelector {
+export class Namespace extends base.Resource implements INamespaceSelector, networkpolicy.INetworkPolicyPeer {
 
   /**
    * @see https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#automatic-labelling
@@ -55,6 +56,8 @@ export class Namespace extends base.Resource implements INamespaceSelector {
 
   public readonly resourceType: string = 'namespaces';
 
+  private readonly _pods: pod.Pods;
+
   public constructor(scope: Construct, id: string, props: NamespaceProps = {}) {
     super(scope, id);
 
@@ -62,6 +65,11 @@ export class Namespace extends base.Resource implements INamespaceSelector {
       metadata: props.metadata,
       spec: Lazy.any({ produce: () => this._toKube() }),
     });
+
+    this._pods = pod.Pods.all(this, 'Pods', {
+      namespaces: Namespaces.select(this, 'Namespaces', { names: [this.name] }),
+    });
+
   }
 
   /**
@@ -69,6 +77,20 @@ export class Namespace extends base.Resource implements INamespaceSelector {
    */
   public toNamespaceSelectorConfig(): NamespaceSelectorConfig {
     return { names: [this.name] };
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toNetworkPolicyPeerConfig()
+   */
+  public toNetworkPolicyPeerConfig(): networkpolicy.NetworkPolicyPeerConfig {
+    return this._pods.toNetworkPolicyPeerConfig();
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toPodSelector()
+   */
+  public toPodSelector(): pod.IPodSelector | undefined {
+    return this._pods.toPodSelector();
   }
 
   /**
@@ -114,7 +136,7 @@ export interface NamespacesSelectOptions {
 /**
  * Represents a group of namespaces.
  */
-export class Namespaces extends Construct implements INamespaceSelector {
+export class Namespaces extends Construct implements INamespaceSelector, networkpolicy.INetworkPolicyPeer {
 
   /**
    * Select specific namespaces.
@@ -130,11 +152,15 @@ export class Namespaces extends Construct implements INamespaceSelector {
     return Namespaces.select(scope, id, { expressions: [], labels: {} });
   }
 
+  private readonly _pods: pod.Pods;
+
   constructor(scope: Construct, id: string,
     private readonly expressions?: pod.LabelExpression[],
     private readonly names?: string[],
     private readonly labels?: { [key: string]: string }) {
     super(scope, id);
+
+    this._pods = pod.Pods.all(this, 'Pods', { namespaces: this });
   }
 
   /**
@@ -145,6 +171,20 @@ export class Namespaces extends Construct implements INamespaceSelector {
       labelSelector: pod.LabelSelector.of({ expressions: this.expressions, labels: this.labels } ),
       names: this.names,
     };
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toNetworkPolicyPeerConfig()
+   */
+  public toNetworkPolicyPeerConfig(): networkpolicy.NetworkPolicyPeerConfig {
+    return this._pods.toNetworkPolicyPeerConfig();
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toPodSelector()
+   */
+  public toPodSelector(): pod.IPodSelector | undefined {
+    return this._pods.toPodSelector();
   }
 
 }

--- a/src/network-policy.ts
+++ b/src/network-policy.ts
@@ -1,0 +1,536 @@
+import { ApiObject, Lazy } from 'cdk8s';
+import { Construct, IConstruct } from 'constructs';
+import * as base from './base';
+import * as k8s from './imports/k8s';
+import * as namespace from './namespace';
+import * as pod from './pod';
+import { undefinedIfEmpty } from './utils';
+
+/**
+ * Properties for `NetworkPolicyPort`.
+ */
+export interface NetworkPolicyPortProps {
+
+  /**
+   * Specific port number.
+   *
+   * @default - all ports are allowed.
+   */
+  readonly port?: number;
+
+  /**
+   * End port (relative to `port`). Only applies if `port` is defined.
+   * Use this to specify a port range, rather that a specific one.
+   *
+   * @default - not a port range.
+   */
+  readonly endPort?: number;
+
+  /**
+   * Protocol.
+   *
+   * @default NetworkProtocol.TCP
+   */
+  readonly protocol?: NetworkProtocol;
+}
+
+/**
+ * Describes a port to allow traffic on.
+ */
+export class NetworkPolicyPort {
+
+  /**
+   * Distinct TCP ports
+   */
+  public static tcp(port: number): NetworkPolicyPort {
+    return new NetworkPolicyPort(k8s.IntOrString.fromNumber(port), undefined, NetworkProtocol.TCP);
+  }
+
+  /**
+   * A TCP port range
+   */
+  public static tcpRange(startPort: number, endPort: number) {
+    return new NetworkPolicyPort(k8s.IntOrString.fromNumber(startPort), endPort, NetworkProtocol.TCP);
+  }
+
+  /**
+   * Any TCP traffic
+   */
+  public static allTcp() {
+    return new NetworkPolicyPort(k8s.IntOrString.fromNumber(0), 65535, NetworkProtocol.TCP);
+  }
+
+  /**
+   * Distinct UDP ports
+   */
+  public static udp(port: number): NetworkPolicyPort {
+    return new NetworkPolicyPort(k8s.IntOrString.fromNumber(port), undefined, NetworkProtocol.UDP);
+  }
+
+  /**
+   * A UDP port range
+   */
+  public static udpRange(startPort: number, endPort: number) {
+    return new NetworkPolicyPort(k8s.IntOrString.fromNumber(startPort), endPort, NetworkProtocol.UDP);
+  }
+
+  /**
+   * Any UDP traffic
+   */
+  public static allUdp() {
+    return new NetworkPolicyPort(k8s.IntOrString.fromNumber(0), 65535, NetworkProtocol.UDP);
+  }
+
+  /**
+   * Custom port configuration.
+   */
+  public static of(props: NetworkPolicyPortProps): NetworkPolicyPort {
+    return new NetworkPolicyPort(props.port ? k8s.IntOrString.fromNumber(props.port) : undefined, props.endPort, props.protocol);
+  }
+
+  private constructor(
+    private readonly port?: k8s.IntOrString,
+    private readonly endPort?: number,
+    private readonly protocol?: NetworkProtocol) {}
+
+  /**
+   * @internal
+   */
+  public _toKube(): k8s.NetworkPolicyPort {
+    return { port: this.port, endPort: this.endPort, protocol: this.protocol };
+  }
+
+}
+
+/**
+ * Configuration for network peers.
+ * A peer can either by an ip block, or a selection of pods, not both.
+ */
+export interface NetworkPolicyPeerConfig {
+
+  /**
+   * The ip block this peer represents.
+   */
+  readonly ipBlock?: NetworkPolicyIpBlock;
+
+  /**
+   * The pod selector this peer represents.
+   */
+  readonly podSelector?: pod.PodSelectorConfig;
+
+}
+
+/**
+ * Describes a peer to allow traffic to/from.
+ */
+export interface INetworkPolicyPeer extends IConstruct {
+  /**
+   * Return the configuration of this peer.
+   */
+  toNetworkPolicyPeerConfig(): NetworkPolicyPeerConfig;
+
+  /**
+   * Convert the peer into a pod selector, if possible.
+   */
+  toPodSelector(): pod.IPodSelector | undefined;
+}
+
+/**
+ * Describes a rule allowing traffic from / to pods matched by a network policy selector.
+ */
+export interface NetworkPolicyRule {
+
+  /**
+   * The ports of the rule.
+   *
+   * @default - traffic is allowed on all ports.
+   */
+  readonly ports?: NetworkPolicyPort[];
+
+  /**
+   * Peer this rule interacts with.
+   */
+  readonly peer: INetworkPolicyPeer;
+
+}
+
+/**
+ * Describes a particular CIDR (Ex. "192.168.1.1/24","2001:db9::/64") that is
+ * allowed to the pods matched by a network policy selector.
+ * The except entry describes CIDRs that should not be included within this rule.
+ */
+export class NetworkPolicyIpBlock extends Construct implements INetworkPolicyPeer {
+
+  /**
+   * Create an IPv4 peer from a CIDR
+   */
+  public static ipv4(scope: Construct, id: string, cidrIp: string, except?: string[]): NetworkPolicyIpBlock {
+    const cidrMatch = cidrIp.match(/^(\d{1,3}\.){3}\d{1,3}(\/\d+)?$/);
+
+    if (!cidrMatch) {
+      throw new Error(`Invalid IPv4 CIDR: "${cidrIp}"`);
+    }
+
+    if (!cidrMatch[2]) {
+      throw new Error(`CIDR mask is missing in IPv4: "${cidrIp}". Did you mean "${cidrIp}/32"?`);
+    }
+
+    return new NetworkPolicyIpBlock(scope, id, cidrIp, except);
+  }
+
+  /**
+   * Any IPv4 address
+   */
+  public static anyIpv4(scope: Construct, id: string): NetworkPolicyIpBlock {
+    return new NetworkPolicyIpBlock(scope, id, '0.0.0.0/0');
+  }
+
+  /**
+   * Create an IPv6 peer from a CIDR
+   */
+  public static ipv6(scope: Construct, id: string, cidrIp: string, except?: string[]): NetworkPolicyIpBlock {
+
+    const cidrMatch = cidrIp.match(/^([\da-f]{0,4}:){2,7}([\da-f]{0,4})?(\/\d+)?$/);
+
+    if (!cidrMatch) {
+      throw new Error(`Invalid IPv6 CIDR: "${cidrIp}"`);
+    }
+
+    if (!cidrMatch[3]) {
+      throw new Error(`CIDR mask is missing in IPv6: "${cidrIp}". Did you mean "${cidrIp}/128"?`);
+    }
+
+    return new NetworkPolicyIpBlock(scope, id, cidrIp, except);
+  }
+
+  /**
+   * Any IPv6 address
+   */
+  public static anyIpv6(scope: Construct, id: string): NetworkPolicyIpBlock {
+    return new NetworkPolicyIpBlock(scope, id, '::/0');
+  }
+
+  private constructor(scope: Construct, id: string,
+    /**
+     * A string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64".
+     */
+    public readonly cidr: string,
+    /**
+     * A slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64".
+     * Except values will be rejected if they are outside the CIDR range.
+     */
+    public readonly except?: string[]) {
+    super(scope, id);
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toNetworkPolicyPeerConfig()
+   */
+  public toNetworkPolicyPeerConfig(): NetworkPolicyPeerConfig {
+    return { ipBlock: this };
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toPodSelector()
+   */
+  public toPodSelector(): pod.IPodSelector | undefined {
+    return undefined;
+  }
+
+  /**
+   * @internal
+   */
+  public _toKube(): k8s.IpBlock {
+    return { cidr: this.cidr, except: this.except };
+  }
+
+}
+
+/**
+ * Network protocols.
+ */
+export enum NetworkProtocol {
+  /**
+   * TCP.
+   */
+  TCP = 'TCP',
+  /**
+   * UDP.
+   */
+  UDP = 'UDP',
+  /**
+   * SCTP.
+   */
+  SCTP = 'SCTP',
+}
+
+/**
+ * Default behaviors of network traffic in policies.
+ */
+export enum NetworkPolicyTrafficDefault {
+  /**
+   * The policy denies all traffic.
+   * Since rules are additive, additional rules or policies can allow
+   * specific traffic.
+   */
+  DENY = 'DENY',
+  /**
+   * The policy allows all traffic (either ingress or egress).
+   * Since rules are additive, no additional rule or policies can
+   * subsequently deny the traffic.
+   */
+  ALLOW = 'ALLOW',
+}
+
+/**
+ * Describes how the network policy should configure egress / ingress traffic.
+ */
+export interface NetworkPolicyTraffic {
+
+  /**
+   * Specifies the default behavior of the policy when
+   * no rules are defined.
+   *
+   * @default - unset, the policy does not change the behavior.
+   */
+  readonly default?: NetworkPolicyTrafficDefault;
+
+  /**
+   * List of rules to be applied to the selected pods.
+   * If empty, the behavior of the policy is dictated by the `default` property.
+   *
+   * @default - no rules
+   */
+  readonly rules?: NetworkPolicyRule[];
+}
+
+/**
+ * Options for `NetworkPolicy.addEgressRule`.
+ */
+export interface NetworkPolicyAddEgressRuleOptions {
+
+  /**
+   * Ports the rule should allow outgoing traffic to.
+   *
+   * @default - If the peer is a managed pod, take its ports. Otherwise, all ports are allowed.
+   */
+  readonly ports?: NetworkPolicyPort[];
+
+}
+
+
+/**
+ * Properties for `NetworkPolicy`.
+ */
+export interface NetworkPolicyProps extends base.ResourceProps {
+
+  /**
+   * Which pods does this policy object applies to.
+   *
+   * This can either be a single pod / workload, or a grouping of pods selected
+   * via the `Pods.select` function. Rules is applied to any pods selected by this property.
+   * Multiple network policies can select the same set of pods.
+   * In this case, the rules for each are combined additively.
+   *
+   * Note that
+   *
+   * @default - will select all pods in the namespace of the policy.
+   */
+  readonly selector?: pod.IPodSelector;
+
+  /**
+   * Egress traffic configuration.
+   *
+   * @default - the policy doesn't change egress behavior of the pods it selects.
+   */
+  readonly egress?: NetworkPolicyTraffic;
+
+  /**
+   * Ingress traffic configuration.
+   *
+   * @default - the policy doesn't change ingress behavior of the pods it selects.
+   */
+  readonly ingress?: NetworkPolicyTraffic;
+}
+
+/**
+ * Control traffic flow at the IP address or port level (OSI layer 3 or 4),
+ * network policies are an application-centric construct which allow you
+ * to specify how a pod is allowed to communicate with various network peers.
+ *
+ * - Outgoing traffic is allowed if there are no network policies selecting
+ *   the pod (and cluster policy otherwise allows the traffic),
+ *   OR if the traffic matches at least one egress rule across all of the
+ *   network policies that select the pod.
+ *
+ * - Incoming traffic is allowed to a pod if there are no network policies
+ *   selecting the pod (and cluster policy otherwise allows the traffic),
+ *   OR if the traffic source is the pod's local node,
+ *   OR if the traffic matches at least one ingress rule across all of
+ *   the network policies that select the pod.
+ *
+ * Network policies do not conflict; they are additive.
+ * If any policy or policies apply to a given pod for a given
+ * direction, the connections allowed in that direction from
+ * that pod is the union of what the applicable policies allow.
+ * Thus, order of evaluation does not affect the policy result.
+ *
+ * For a connection from a source pod to a destination pod to be allowed,
+ * both the egress policy on the source pod and the ingress policy on the
+ * destination pod need to allow the connection.
+ * If either side does not allow the connection, it will not happen.
+ *
+ * @see https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource
+ */
+export class NetworkPolicy extends base.Resource {
+
+  /**
+   * @see base.Resource.apiObject
+   */
+  protected readonly apiObject: ApiObject;
+
+  public readonly resourceType: string = 'networkpolicies';
+
+  private readonly _podSelectorConfig: pod.PodSelectorConfig;
+  private readonly _egressRules: k8s.NetworkPolicyEgressRule[] = [];
+  private readonly _ingressRules: k8s.NetworkPolicyIngressRule[] = [];
+  private readonly _policyTypes: Set<string> = new Set();
+
+  public constructor(scope: Construct, id: string, props: NetworkPolicyProps = {}) {
+    super(scope, id);
+
+    const podSelector = props.selector ?? pod.Pods.all(this, 'AllPods');
+    this._podSelectorConfig = podSelector.toPodSelectorConfig();
+
+    let ns;
+
+    if (!props.metadata?.namespace) {
+
+      if (this._podSelectorConfig.namespaces?.labelSelector && !this._podSelectorConfig.namespaces?.labelSelector.isEmpty()) {
+        throw new Error(`Unable to create a network policy for a selector (${podSelector.node.path}) that selects pods in namespaces based on labels`);
+      }
+
+      if (this._podSelectorConfig.namespaces?.names && this._podSelectorConfig.namespaces.names.length > 1) {
+        throw new Error(`Unable to create a network policy for a selector (${podSelector.node.path}) that selects pods in multiple namespaces`);
+      }
+
+      ns = this._podSelectorConfig.namespaces?.names ? this._podSelectorConfig.namespaces?.names[0] : undefined;
+
+    } else {
+      ns = props.metadata.namespace;
+    }
+
+    this.apiObject = new k8s.KubeNetworkPolicy(this, 'Resource', {
+      metadata: { ...props.metadata, namespace: ns },
+      spec: Lazy.any({ produce: () => this._toKube() }),
+    });
+
+    this.configureDefaultBehavior('Egress', props.egress?.default);
+    this.configureDefaultBehavior('Ingress', props.ingress?.default);
+
+    for (const rule of props.egress?.rules ?? []) {
+      this.addEgressRule(rule.peer, rule.ports);
+    }
+
+    for (const rule of props.ingress?.rules ?? []) {
+      this.addIngressRule(rule.peer, rule.ports);
+    }
+  }
+
+  /**
+   * Allow outgoing traffic to the peer.
+   *
+   * If ports are not passed, traffic will be allowed on all ports.
+   */
+  public addEgressRule(peer: INetworkPolicyPeer, ports?: NetworkPolicyPort[]) {
+    this._policyTypes.add('Egress');
+    this._egressRules.push({ ports: (ports ?? []).map(p => p._toKube()), to: this.createNetworkPolicyPeers(peer) });
+  }
+
+  /**
+   * Allow incoming traffic from the peer.
+   *
+   * If ports are not passed, traffic will be allowed on all ports.
+   */
+  public addIngressRule(peer: INetworkPolicyPeer, ports?: NetworkPolicyPort[]) {
+    this._policyTypes.add('Ingress');
+    this._ingressRules.push({ ports: (ports ?? []).map(p => p._toKube()), from: this.createNetworkPolicyPeers(peer) });
+  }
+
+  private createNetworkPolicyPeers(peer: INetworkPolicyPeer): k8s.NetworkPolicyPeer[] {
+
+    const config = peer.toNetworkPolicyPeerConfig();
+
+    validatePeerConfig(config);
+
+    if (config.ipBlock) {
+      // ip block is a single peer.
+      return [{ ipBlock: config.ipBlock._toKube() }];
+    }
+
+    if (!config.podSelector!.namespaces?.names) {
+      // when no explicit namespaces are defined we can just use
+      // the selector as is
+      return [{
+        namespaceSelector: config.podSelector!.namespaces?.labelSelector?._toKube(),
+        podSelector: config.podSelector!.labelSelector._toKube(),
+      }];
+    }
+
+    // when explicit namespaces are defined, we need to create a separate
+    // peer for each, since a label selector cannot have multiple name labels. (they will conflict)
+    const namespaceSelector = config.podSelector?.namespaces?.labelSelector?._toKube() ?? {};
+    return config.podSelector!.namespaces.names!.map(n => ({
+      podSelector: config.podSelector!.labelSelector._toKube(),
+      namespaceSelector: {
+        matchExpressions: namespaceSelector.matchExpressions,
+        matchLabels: {
+          ...namespaceSelector.matchLabels,
+          [namespace.Namespace.NAME_LABEL]: n,
+        },
+      },
+    }));
+  }
+
+  private configureDefaultBehavior(direction: 'Ingress' | 'Egress', _default?: NetworkPolicyTrafficDefault) {
+
+    if (!_default) { return;}
+
+    if (_default === NetworkPolicyTrafficDefault.DENY) {
+      // https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-egress-traffic
+      this._policyTypes.add(direction);
+    }
+
+    if (_default === NetworkPolicyTrafficDefault.ALLOW) {
+      // https://kubernetes.io/docs/concepts/services-networking/network-policies/#allow-all-egress-traffic
+      this._policyTypes.add(direction);
+      if (direction === 'Egress') {
+        this._egressRules.push({});
+      } else {
+        this._ingressRules.push({});
+      }
+    }
+  }
+
+  /**
+   * @internal
+   */
+  public _toKube(): k8s.NetworkPolicySpec {
+    return {
+      podSelector: this._podSelectorConfig.labelSelector._toKube(),
+      egress: undefinedIfEmpty(this._egressRules),
+      ingress: undefinedIfEmpty(this._ingressRules),
+      policyTypes: undefinedIfEmpty(Array.from(this._policyTypes)),
+    };
+  }
+
+}
+
+export function validatePeerConfig(peerConfig: NetworkPolicyPeerConfig) {
+  if (!peerConfig.ipBlock && !peerConfig.podSelector) {
+    throw new Error('Inavlid peer: either \'ipBlock\' or \'podSelector\' must be defined');
+  }
+  if (peerConfig.ipBlock && peerConfig.podSelector) {
+    throw new Error('Inavlid peer: only one of \'ipBlock\' and \'podSelector\' must be defined');
+  }
+}

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -4,12 +4,13 @@ import * as base from './base';
 import * as container from './container';
 import * as k8s from './imports/k8s';
 import * as namespace from './namespace';
+import * as networkpolicy from './network-policy';
 import * as secret from './secret';
 import * as serviceaccount from './service-account';
-import { undefinedIfEmpty } from './utils';
+import { undefinedIfEmpty, address } from './utils';
 import * as volume from './volume';
 
-export abstract class AbstractPod extends base.Resource implements IPodSelector {
+export abstract class AbstractPod extends base.Resource implements IPodSelector, networkpolicy.INetworkPolicyPeer {
 
   public readonly restartPolicy?: RestartPolicy;
   public readonly serviceAccount?: serviceaccount.IServiceAccount;
@@ -53,10 +54,6 @@ export abstract class AbstractPod extends base.Resource implements IPodSelector 
 
   }
 
-  private get _namespaceName(): string {
-    return this.podMetadata.namespace ?? 'default';
-  }
-
   public get containers(): container.Container[] {
     return [...this._containers];
   }
@@ -84,10 +81,24 @@ export abstract class AbstractPod extends base.Resource implements IPodSelector 
     }
     return {
       labelSelector: LabelSelector.of({ labels: { [Pod.ADDRESS_LABEL]: podAddress } }),
-      namespaces: {
-        names: [this._namespaceName],
-      },
+      namespaces: this.metadata.namespace ? {
+        names: [this.metadata.namespace],
+      } : undefined,
     };
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toNetworkPolicyPeerConfig()
+   */
+  public toNetworkPolicyPeerConfig(): networkpolicy.NetworkPolicyPeerConfig {
+    return { podSelector: this.toPodSelectorConfig() };
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toPodSelector()
+   */
+  public toPodSelector(): IPodSelector | undefined {
+    return this;
   }
 
   public addContainer(cont: container.ContainerProps): container.Container {
@@ -429,11 +440,15 @@ export class LabelSelector {
     private readonly expressions: LabelExpression[],
     private readonly labels: { [key: string]: string }) {}
 
+  public isEmpty() {
+    return this.expressions.length === 0 && Object.keys(this.labels).length === 0;
+  }
+
   /**
    * @internal
    */
   public _toKube(): k8s.LabelSelector {
-    if (this.expressions.length === 0 && Object.keys(this.labels).length === 0) {
+    if (this.isEmpty()) {
       return {};
     }
     return {
@@ -490,6 +505,7 @@ export class Pod extends AbstractPod {
   public readonly resourceType = 'pods';
 
   public readonly scheduling: PodScheduling;
+  public readonly connections: PodConnections;
 
   constructor(scope: Construct, id: string, props: PodProps = {}) {
     super(scope, id, props);
@@ -502,7 +518,7 @@ export class Pod extends AbstractPod {
     this.metadata.addLabel(Pod.ADDRESS_LABEL, Names.toLabelValue(this));
 
     this.scheduling = new PodScheduling(this);
-
+    this.connections = new PodConnections(this);
   }
 
   public get podMetadata(): ApiObjectMetadataDefinition {
@@ -1101,9 +1117,23 @@ export class NodeTaintQuery {
 }
 
 /**
+ * Options for `Pods.all`.
+ */
+export interface PodsAllOptions {
+
+  /**
+   * Namespaces the pods are allowed to be in.
+   * Use `Namespaces.all()` to allow all namespaces.
+   *
+   * @default - unset, implies the namespace of the resource this selection is used in.
+   */
+  readonly namespaces?: namespace.Namespaces;
+}
+
+/**
  * Options for `Pods.select`.
  */
-export interface PodSelectOptions {
+export interface PodsSelectOptions {
 
   /**
    * Labels the pods must have.
@@ -1137,8 +1167,15 @@ export class Pods extends Construct implements IPodSelector {
   /**
    * Select pods in the cluster with various selectors.
    */
-  public static select(scope: Construct, id: string, options: PodSelectOptions): Pods {
+  public static select(scope: Construct, id: string, options: PodsSelectOptions): Pods {
     return new Pods(scope, id, options.expressions, options.labels, options.namespaces);
+  }
+
+  /**
+   * Select all pods.
+   */
+  public static all(scope: Construct, id: string, options: PodsAllOptions = {}) {
+    return Pods.select(scope, id, { namespaces: options.namespaces });
   }
 
   constructor(scope: Construct, id: string,
@@ -1148,12 +1185,30 @@ export class Pods extends Construct implements IPodSelector {
     super(scope, id);
   }
 
+  /**
+   * @see IPodSelector.toPodSelectorConfig()
+   */
   public toPodSelectorConfig(): PodSelectorConfig {
     return {
       labelSelector: LabelSelector.of({ expressions: this.expressions, labels: this.labels }),
       namespaces: this.namespaces?.toNamespaceSelectorConfig(),
     };
   }
+
+  /**
+   * @see INetworkPolicyPeer.toNetworkPolicyPeerConfig()
+   */
+  public toNetworkPolicyPeerConfig(): networkpolicy.NetworkPolicyPeerConfig {
+    return { podSelector: this.toPodSelectorConfig() };
+  }
+
+  /**
+   * @see INetworkPolicyPeer.toPodSelector()
+   */
+  public toPodSelector(): IPodSelector | undefined {
+    return this;
+  }
+
 }
 
 /**
@@ -1403,7 +1458,7 @@ export class PodScheduling {
    *
    * - An instance of a `Pod`.
    * - An instance of a `Workload` (e.g `Deployment`, `StatefulSet`).
-   * - An un-managed pod that can be selected via `Pod.select()`.
+   * - An un-managed pod that can be selected via `Pods.select()`.
    *
    * Co-locating with multiple selections ((i.e invoking this method multiple times)) acts as
    * an AND condition. meaning the pod will be assigned to a node that satisfies all
@@ -1433,7 +1488,7 @@ export class PodScheduling {
    *
    * - An instance of a `Pod`.
    * - An instance of a `Workload` (e.g `Deployment`, `StatefulSet`).
-   * - An un-managed pod that can be selected via `Pod.select()`.
+   * - An un-managed pod that can be selected via `Pods.select()`.
    *
    * Seperating from multiple selections acts as an AND condition. meaning the pod
    * will not be assigned to a node that satisfies all selections (i.e runs at least one pod that satisifies each selection).
@@ -1511,5 +1566,225 @@ export class PodScheduling {
       nodeName: this._nodeName,
       tolerations: undefinedIfEmpty(this._tolerations),
     };
+  }
+}
+
+/**
+ * Isolation determines which policies are created
+ * when allowing connections from a a pod / workload to peers.
+ */
+export enum PodConnectionsIsolation {
+
+  /**
+   * Only creates network policies that select the pod.
+   */
+  POD = 'POD',
+
+  /**
+   * Only creates network policies that select the peer.
+   */
+  PEER = 'PEER',
+
+}
+
+/**
+ * Options for `PodConnections.allowTo`.
+ */
+export interface PodConnectionsAllowToOptions {
+
+  /**
+   * Which isolation should be applied to establish the connection.
+   *
+   * @default - unset, isolates both the pod and the peer.
+   */
+  readonly isolation?: PodConnectionsIsolation;
+
+  /**
+   * Ports to allow outgoing traffic to.
+   *
+   * @default - If the peer is a managed pod, take its ports. Otherwise, all ports are allowed.
+   */
+  readonly ports?: networkpolicy.NetworkPolicyPort[];
+
+}
+
+/**
+ * Options for `PodConnections.allowFrom`.
+ */
+export interface PodConnectionsAllowFromOptions {
+
+  /**
+   * Which isolation should be applied to establish the connection.
+   *
+   * @default - unset, isolates both the pod and the peer.
+   */
+  readonly isolation?: PodConnectionsIsolation;
+
+  /**
+   * Ports to allow incoming traffic to.
+   *
+   * @default - The pod ports.
+   */
+  readonly ports?: networkpolicy.NetworkPolicyPort[];
+
+}
+
+/**
+ * Controls network isolation rules for inter-pod communication.
+ */
+export class PodConnections {
+
+  constructor(protected readonly instance: AbstractPod) {}
+
+  /**
+   * Allow network traffic from this pod to the peer.
+   *
+   * By default, this will create an egress network policy for this pod, and an ingress
+   * network policy for the peer. This is required if both sides are already isolated.
+   * Use `options.isolation` to control this behavior.
+   *
+   * @example
+   *
+   * // create only an egress policy that selects the 'web' pod to allow outgoing traffic
+   * // to the 'redis' pod. this requires the 'redis' pod to not be isolated for ingress.
+   * web.connections.allowTo(redis, { isolation: Isolation.POD })
+   *
+   * // create only an ingress policy that selects the 'redis' peer to allow incoming traffic
+   * // from the 'web' pod. this requires the 'web' pod to not be isolated for egress.
+   * web.connections.allowTo(redis, { isolation: Isolation.PEER })
+   *
+   */
+  public allowTo(peer: networkpolicy.INetworkPolicyPeer, options: PodConnectionsAllowToOptions = {}) {
+    return this.allow('Egress', peer, { ports: this.extractPorts(peer), ...options });
+  }
+
+  /**
+   * Allow network traffic from the peer to this pod.
+   *
+   * By default, this will create an ingress network policy for this pod, and an egress
+   * network policy for the peer. This is required if both sides are already isolated.
+   * Use `options.isolation` to control this behavior.
+   *
+   * @example
+   *
+   * // create only an egress policy that selects the 'web' pod to allow outgoing traffic
+   * // to the 'redis' pod. this requires the 'redis' pod to not be isolated for ingress.
+   * redis.connections.allowFrom(web, { isolation: Isolation.PEER })
+   *
+   * // create only an ingress policy that selects the 'redis' peer to allow incoming traffic
+   * // from the 'web' pod. this requires the 'web' pod to not be isolated for egress.
+   * redis.connections.allowFrom(web, { isolation: Isolation.POD })
+   *
+   */
+  public allowFrom(peer: networkpolicy.INetworkPolicyPeer, options: PodConnectionsAllowFromOptions = {}) {
+    return this.allow('Ingress', peer, { ports: this.extractPorts(this.instance), ...options });
+  }
+
+  private allow(direction: 'Ingress' | 'Egress', peer: networkpolicy.INetworkPolicyPeer, options: PodConnectionsAllowToOptions | PodConnectionsAllowFromOptions = {}) {
+
+    const config = peer.toNetworkPolicyPeerConfig();
+    networkpolicy.validatePeerConfig(config);
+
+    const peerAddress = address(peer);
+
+    if (!options.isolation || options.isolation === PodConnectionsIsolation.POD) {
+
+      const src = new networkpolicy.NetworkPolicy(this.instance, `Allow${direction}${peerAddress}`, {
+        selector: this.instance,
+        // the policy must be defined in the namespace of the pod
+        // so it can select it.
+        metadata: { namespace: this.instance.metadata.namespace },
+      });
+
+      switch (direction) {
+        case 'Egress':
+          src.addEgressRule(peer, options.ports);
+          break;
+        case 'Ingress':
+          src.addIngressRule(peer, options.ports);
+      }
+
+    }
+
+    if (!options.isolation || options.isolation === PodConnectionsIsolation.PEER) {
+
+      if (config.ipBlock) {
+        // for an ip block we don't need to create the opposite policies
+        return;
+      }
+
+      const podSelector = peer.toPodSelector();
+      if (!podSelector) {
+        throw new Error(`Unable to create policies for peer '${peer.node.addr}' since its not a pod selector`);
+      }
+
+      const oppositeDirection = direction === 'Egress' ? 'Ingress' : 'Egress';
+
+      const podSelectorConfig = podSelector.toPodSelectorConfig();
+      let namespaces: (string | undefined)[];
+
+      if (!podSelectorConfig.namespaces) {
+
+        // if the peer doesn't specify namespaces, we assume the same namespace.
+        namespaces = [this.instance.metadata.namespace];
+
+      } else {
+
+        // a peer cannot specify namespaces by labels because
+        // we won't be able to extract the names of those namespaces.
+        if (podSelectorConfig.namespaces.labelSelector && !podSelectorConfig.namespaces.labelSelector.isEmpty()) {
+          throw new Error(`Unable to create an ${oppositeDirection} policy for peer '${peer.node.path}' (pod=${this.instance.name}). Peer must specify namespaces only by name`);
+        }
+
+        // a peer must specify namespaces by name.
+        if (!podSelectorConfig.namespaces.names) {
+          throw new Error(`Unable to create an ${oppositeDirection} policy for peer '${peer.node.path}' (pod=${this.instance.name}). Peer must specify namespace names`);
+        }
+
+        namespaces = podSelectorConfig.namespaces.names;
+      }
+
+      for (const name of namespaces) {
+        switch (direction) {
+          case 'Egress':
+            new networkpolicy.NetworkPolicy(this.instance, `AllowIngress${name}${peerAddress}`, {
+              selector: podSelector,
+              metadata: { namespace: name },
+              ingress: { rules: [{ peer: this.instance, ports: options.ports }] },
+            });
+            break;
+          case 'Ingress':
+            new networkpolicy.NetworkPolicy(this.instance, `AllowEgress${name}${peerAddress}`, {
+              selector: podSelector,
+              metadata: { namespace: name },
+              egress: { rules: [{ peer: this.instance, ports: options.ports }] },
+            });
+            break;
+          default:
+            throw new Error(`Unsupported direction: ${direction}`);
+        }
+      }
+
+    }
+  }
+
+  private extractPorts(selector?: networkpolicy.INetworkPolicyPeer): networkpolicy.NetworkPolicyPort[] {
+
+    // empty means all ports
+    if (!selector) { return []; }
+
+    const ports = [];
+
+    // we don't use instanceof intentionally since it can create
+    // cyclic import problems.
+    const containers: container.Container[] = (selector as any).containers;
+
+    for (const con of containers ?? []) {
+      if (con.port) {
+        ports.push(networkpolicy.NetworkPolicyPort.tcp(con.port));
+      }
+    }
+
+    return ports;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { IConstruct } from 'constructs';
+
 export function undefinedIfEmpty<T>(obj: T): T | undefined {
   if (typeof(obj) === 'string' && obj === '') { return undefined; }
   if (Array.isArray(obj) && obj.length === 0) { return undefined; }
@@ -13,4 +15,11 @@ export function filterUndefined(obj: any): any {
     }
   }
   return ret;
+}
+
+export function address(...constructs: IConstruct[]) {
+  const addresses = constructs
+    .map(c => c.node.addr)
+    .sort((a, b) => a.localeCompare(b));
+  return addresses.join('');
 }

--- a/src/workload.ts
+++ b/src/workload.ts
@@ -61,6 +61,7 @@ export abstract class Workload extends pod.AbstractPod {
   public readonly podMetadata: ApiObjectMetadataDefinition;
 
   public readonly scheduling: WorkloadScheduling;
+  public readonly connections: pod.PodConnections;
 
   private readonly _selectors: k8s.LabelSelector[] = [];
 
@@ -69,6 +70,7 @@ export abstract class Workload extends pod.AbstractPod {
 
     this.podMetadata = new ApiObjectMetadataDefinition(props.podMetadata);
     this.scheduling = new WorkloadScheduling(this);
+    this.connections = new pod.PodConnections(this);
 
     const matcher = Names.toLabelValue(this);
     this.podMetadata.addLabel(pod.Pod.ADDRESS_LABEL, matcher);

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -415,9 +415,6 @@ Array [
                         "cdk8s.io/metadata.addr": "test-Redis-c8b1633b",
                       },
                     },
-                    "namespaces": Array [
-                      "default",
-                    ],
                     "topologyKey": "topology.kubernetes.io/zone",
                   },
                   "weight": 1,
@@ -543,9 +540,6 @@ Array [
                       "cdk8s.io/metadata.addr": "test-Redis-c8b1633b",
                     },
                   },
-                  "namespaces": Array [
-                    "default",
-                  ],
                   "topologyKey": "kubernetes.io/hostname",
                 },
               ],
@@ -825,9 +819,6 @@ Array [
                         "cdk8s.io/metadata.addr": "test-Redis-c8b1633b",
                       },
                     },
-                    "namespaces": Array [
-                      "default",
-                    ],
                     "topologyKey": "topology.kubernetes.io/zone",
                   },
                   "weight": 1,
@@ -953,9 +944,6 @@ Array [
                       "cdk8s.io/metadata.addr": "test-Redis-c8b1633b",
                     },
                   },
-                  "namespaces": Array [
-                    "default",
-                  ],
                   "topologyKey": "kubernetes.io/hostname",
                 },
               ],
@@ -1183,9 +1171,6 @@ Array [
                         "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
                       },
                     },
-                    "namespaces": Array [
-                      "default",
-                    ],
                     "topologyKey": "kubernetes.io/hostname",
                   },
                   "weight": 1,
@@ -1259,9 +1244,6 @@ Array [
                       "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
                     },
                   },
-                  "namespaces": Array [
-                    "default",
-                  ],
                   "topologyKey": "kubernetes.io/hostname",
                 },
               ],

--- a/test/__snapshots__/network-policy.test.ts.snap
+++ b/test/__snapshots__/network-policy.test.ts.snap
@@ -1,0 +1,1998 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IpBlock | anyIpv4 1`] = `
+Object {
+  "cidr": "0.0.0.0/0",
+  "except": undefined,
+}
+`;
+
+exports[`IpBlock | anyIpv6 1`] = `
+Object {
+  "cidr": "::/0",
+  "except": undefined,
+}
+`;
+
+exports[`IpBlock | ipv4 1`] = `
+Object {
+  "cidr": "172.17.0.0/16",
+  "except": Array [
+    "172.17.1.0/24",
+  ],
+}
+`;
+
+exports[`IpBlock | ipv6 1`] = `
+Object {
+  "cidr": "2002::1234:abcd:ffff:c0a8:101/64",
+  "except": Array [
+    "2002::1234:abcd:ffff:c0a8:101/24",
+  ],
+}
+`;
+
+exports[`NetworkPolicyPort | allTcp 1`] = `
+Object {
+  "endPort": 65535,
+  "port": IntOrString {
+    "value": 0,
+  },
+  "protocol": "TCP",
+}
+`;
+
+exports[`NetworkPolicyPort | allUcp 1`] = `
+Object {
+  "endPort": 65535,
+  "port": IntOrString {
+    "value": 0,
+  },
+  "protocol": "UDP",
+}
+`;
+
+exports[`NetworkPolicyPort | tcp 1`] = `
+Object {
+  "endPort": undefined,
+  "port": IntOrString {
+    "value": 8080,
+  },
+  "protocol": "TCP",
+}
+`;
+
+exports[`NetworkPolicyPort | tcpRange 1`] = `
+Object {
+  "endPort": 8085,
+  "port": IntOrString {
+    "value": 8080,
+  },
+  "protocol": "TCP",
+}
+`;
+
+exports[`NetworkPolicyPort | udp 1`] = `
+Object {
+  "endPort": undefined,
+  "port": IntOrString {
+    "value": 8080,
+  },
+  "protocol": "UDP",
+}
+`;
+
+exports[`NetworkPolicyPort | udpRange 1`] = `
+Object {
+  "endPort": 8085,
+  "port": IntOrString {
+    "value": 8080,
+  },
+  "protocol": "UDP",
+}
+`;
+
+exports[`NeworkPolicy | can add egress to a managed pod 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to a managed workload resource 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-deployment-c898c72d",
+    },
+    "spec": Object {
+      "minReadySeconds": 0,
+      "progressDeadlineSeconds": 600,
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+        },
+      },
+      "strategy": Object {
+        "rollingUpdate": Object {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%",
+        },
+        "type": "RollingUpdate",
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+          },
+        },
+        "spec": Object {
+          "automountServiceAccountToken": true,
+          "containers": Array [
+            Object {
+              "image": "pod",
+              "imagePullPolicy": "Always",
+              "name": "main",
+              "securityContext": Object {
+                "privileged": false,
+                "readOnlyRootFilesystem": false,
+                "runAsNonRoot": false,
+              },
+            },
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "securityContext": Object {
+            "fsGroupChangePolicy": "Always",
+            "runAsNonRoot": false,
+          },
+          "setHostnameAsFQDN": false,
+        },
+      },
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to all namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {},
+              "podSelector": Object {},
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to all pods 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "podSelector": Object {},
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to an ip block 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "ipBlock": Object {
+                "cidr": "172.17.0.0/16",
+                "except": Array [
+                  "172.17.1.0/24",
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to managed namespace 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "name": "test-namespace-c83f04e1",
+    },
+    "spec": Object {},
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "test-namespace-c83f04e1",
+                },
+              },
+              "podSelector": Object {},
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to pods selected with namespaces selected by labes 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to pods selected with namespaces selected by names 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "selected1",
+                  "type": "selected",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "selected2",
+                  "type": "selected",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to pods selected without namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add egress to selected namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+              "podSelector": Object {},
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from a managed pod 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from a managed workload resource 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-deployment-c898c72d",
+    },
+    "spec": Object {
+      "minReadySeconds": 0,
+      "progressDeadlineSeconds": 600,
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+        },
+      },
+      "strategy": Object {
+        "rollingUpdate": Object {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%",
+        },
+        "type": "RollingUpdate",
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+          },
+        },
+        "spec": Object {
+          "automountServiceAccountToken": true,
+          "containers": Array [
+            Object {
+              "image": "pod",
+              "imagePullPolicy": "Always",
+              "name": "main",
+              "securityContext": Object {
+                "privileged": false,
+                "readOnlyRootFilesystem": false,
+                "runAsNonRoot": false,
+              },
+            },
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "securityContext": Object {
+            "fsGroupChangePolicy": "Always",
+            "runAsNonRoot": false,
+          },
+          "setHostnameAsFQDN": false,
+        },
+      },
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+                },
+              },
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from all namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {},
+              "podSelector": Object {},
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from all pods 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {},
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from an ip block 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "ipBlock": Object {
+                "cidr": "172.17.0.0/16",
+                "except": Array [
+                  "172.17.1.0/24",
+                ],
+              },
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from managed namespace 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "name": "test-namespace-c83f04e1",
+    },
+    "spec": Object {},
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "test-namespace-c83f04e1",
+                },
+              },
+              "podSelector": Object {},
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from pods selected with namespaces selected by labes 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from pods selected with namespaces selected by names 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "selected1",
+                  "type": "selected",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "selected2",
+                  "type": "selected",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from pods selected without namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can add ingress from selected namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+              "podSelector": Object {},
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6379,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can create a policy for a managed pod 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Web-c8b65d84",
+      },
+      "name": "test-web-c854d28f",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "web",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Web-c8b65d84",
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can create a policy for a managed workload resource 1`] = `
+Array [
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-web-c854d28f",
+    },
+    "spec": Object {
+      "minReadySeconds": 0,
+      "progressDeadlineSeconds": 600,
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Web-c8b65d84",
+        },
+      },
+      "strategy": Object {
+        "rollingUpdate": Object {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%",
+        },
+        "type": "RollingUpdate",
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "cdk8s.io/metadata.addr": "test-Web-c8b65d84",
+          },
+        },
+        "spec": Object {
+          "automountServiceAccountToken": true,
+          "containers": Array [
+            Object {
+              "image": "web",
+              "imagePullPolicy": "Always",
+              "name": "main",
+              "securityContext": Object {
+                "privileged": false,
+                "readOnlyRootFilesystem": false,
+                "runAsNonRoot": false,
+              },
+            },
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "securityContext": Object {
+            "fsGroupChangePolicy": "Always",
+            "runAsNonRoot": false,
+          },
+          "setHostnameAsFQDN": false,
+        },
+      },
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Web-c8b65d84",
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can create a policy for all pods 1`] = `
+Array [
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy1-c84bc0a0",
+    },
+    "spec": Object {
+      "podSelector": Object {},
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy2-c822b70e",
+    },
+    "spec": Object {
+      "podSelector": Object {},
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can create a policy for selected pods 1`] = `
+Array [
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "podSelector": Object {
+        "matchLabels": Object {
+          "app": "web",
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can create a policy that allows all egress by default 1`] = `
+Array [
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {},
+      ],
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can create a policy that allows all ingress by default 1`] = `
+Array [
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {},
+      ],
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can create a policy that denies all egress by default 1`] = `
+Array [
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`NeworkPolicy | can create a policy that denies all ingress by default 1`] = `
+Array [
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "test-policy-c89ef47f",
+    },
+    "spec": Object {
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;

--- a/test/__snapshots__/pod.test.ts.snap
+++ b/test/__snapshots__/pod.test.ts.snap
@@ -24,6 +24,3176 @@ Object {
 }
 `;
 
+exports[`connections | allow from defaults to peer container ports 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc82dc44e4f9989eb126eaaba4da220f06-c83d843e",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressundefinedc82dc44e4f9989eb126eaaba4-c8bccb96",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "ports": Array [
+            Object {
+              "containerPort": 6739,
+            },
+          ],
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | allow from with peer isolation creates only ingress policy on peer 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressundefinedc82dc44e4f9989eb126eaaba4-c8bccb96",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | allow from with pod isolation creates only egress policy on pod 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc82dc44e4f9989eb126eaaba4da220f06-c83d843e",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | allow to defaults to peer container ports 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc82dc44e4f9989eb126eaaba4da220f06e-c80adbd2",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 6739,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressundefinedc82dc44e4f9989eb126eaaba-c89ede32",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 6739,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "ports": Array [
+            Object {
+              "containerPort": 6739,
+            },
+          ],
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | allow to with peer isolation creates only ingress policy on peer 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressundefinedc82dc44e4f9989eb126eaaba-c89ede32",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | allow to with pod isolation creates only egress policy on pod 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc82dc44e4f9989eb126eaaba4da220f06e-c80adbd2",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from all pods 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc88991c35987b889bdbc2db5b9892cc87-c8081541",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {},
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressundefinedc88991c35987b889bdbc2db5b-c83614b5",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from ip block 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc87440e54ccd134ddb2b351e4222a2d7d-c8373ce0",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "ipBlock": Object {
+                "cidr": "0.0.0.0/0",
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from managed namespace 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc8490b4294b43dbe5b4c95a59ac983348-c8475de1",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "test-namespace-c83f04e1",
+                },
+              },
+              "podSelector": Object {},
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegresstest-namespace-c83f04e1c8490b4294b-c8979508",
+      "namespace": "test-namespace-c83f04e1",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "name": "test-namespace-c83f04e1",
+    },
+    "spec": Object {},
+  },
+]
+`;
+
+exports[`connections | can allow from managed pod 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc82dc44e4f9989eb126eaaba4da220f06-c83d843e",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressundefinedc82dc44e4f9989eb126eaaba4-c8bccb96",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from managed workload resource 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc83f5e5936a8a190b1ba5aebf19551d14-c8f4f617",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressundefinedc83f5e5936a8a190b1ba5aebf-c8123fe4",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-deployment-c898c72d",
+    },
+    "spec": Object {
+      "minReadySeconds": 0,
+      "progressDeadlineSeconds": 600,
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+        },
+      },
+      "strategy": Object {
+        "rollingUpdate": Object {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%",
+        },
+        "type": "RollingUpdate",
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+          },
+        },
+        "spec": Object {
+          "automountServiceAccountToken": true,
+          "containers": Array [
+            Object {
+              "image": "pod",
+              "imagePullPolicy": "Always",
+              "name": "main",
+              "securityContext": Object {
+                "privileged": false,
+                "readOnlyRootFilesystem": false,
+                "runAsNonRoot": false,
+              },
+            },
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "securityContext": Object {
+            "fsGroupChangePolicy": "Always",
+            "runAsNonRoot": false,
+          },
+          "setHostnameAsFQDN": false,
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from multiple peers 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc82dc44e4f9989eb126eaaba4da220f06-c83d843e",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressundefinedc82dc44e4f9989eb126eaaba4-c8bccb96",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc8b86857d7ce2958c4fd0ab7a90aca46d-c8e59af0",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod3-c8b86857",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressundefinedc8b86857d7ce2958c4fd0ab7a-c8a631d9",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod3-c8b86857",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod3-c8b86857",
+      },
+      "name": "test-pod3-c81af0d3",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from namespaces selected by name 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc880996af92c38a237394619e07db1dc7-c88d7612",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "n1",
+                },
+              },
+              "podSelector": Object {},
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressn1c880996af92c38a237394619e07db1dc-c81060da",
+      "namespace": "n1",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from peer across namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+      "namespace": "n1",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc82dc44e4f9989eb126eaaba4da220f06-c83d843e",
+      "namespace": "n1",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "n2",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressn2c82dc44e4f9989eb126eaaba4da220f0-c8989f9d",
+      "namespace": "n2",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "n1",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+      "namespace": "n2",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from pods selected with namespaces selected by names 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc87532153cca98350206df142ec1520c0-c8f26607",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "selected1",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "selected2",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressselected1c87532153cca98350206df142-c82f906b",
+      "namespace": "selected1",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "type": "selected",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressselected2c87532153cca98350206df142-c85120c3",
+      "namespace": "selected2",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "type": "selected",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow from pods selected without namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressc87532153cca98350206df142ec1520c0-c8f26607",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressundefinedc87532153cca98350206df142-c808190b",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "type": "selected",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to all pods 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc88991c35987b889bdbc2db5b9892cc872-c8bb5ff9",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {},
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressundefinedc88991c35987b889bdbc2db5-c84459ec",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to ip block 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc87440e54ccd134ddb2b351e4222a2d7d7-c860cc50",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "ipBlock": Object {
+                "cidr": "0.0.0.0/0",
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to managed namespace 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc8490b4294b43dbe5b4c95a59ac9833484-c80ece9b",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "test-namespace-c83f04e1",
+                },
+              },
+              "podSelector": Object {},
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingresstest-namespace-c83f04e1c8490b4294-c8b90d22",
+      "namespace": "test-namespace-c83f04e1",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": Object {
+      "name": "test-namespace-c83f04e1",
+    },
+    "spec": Object {},
+  },
+]
+`;
+
+exports[`connections | can allow to managed pod 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc82dc44e4f9989eb126eaaba4da220f06e-c80adbd2",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [
+            Object {
+              "port": 4444,
+              "protocol": "TCP",
+            },
+          ],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressundefinedc82dc44e4f9989eb126eaaba-c89ede32",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+          "ports": Array [
+            Object {
+              "port": 4444,
+              "protocol": "TCP",
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to managed workload resource 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc83f5e5936a8a190b1ba5aebf19551d145-c8a91658",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressundefinedc83f5e5936a8a190b1ba5aeb-c805c250",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": Object {
+      "name": "test-deployment-c898c72d",
+    },
+    "spec": Object {
+      "minReadySeconds": 0,
+      "progressDeadlineSeconds": 600,
+      "replicas": 1,
+      "selector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+        },
+      },
+      "strategy": Object {
+        "rollingUpdate": Object {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%",
+        },
+        "type": "RollingUpdate",
+      },
+      "template": Object {
+        "metadata": Object {
+          "labels": Object {
+            "cdk8s.io/metadata.addr": "test-Deployment-c83f5e59",
+          },
+        },
+        "spec": Object {
+          "automountServiceAccountToken": true,
+          "containers": Array [
+            Object {
+              "image": "pod",
+              "imagePullPolicy": "Always",
+              "name": "main",
+              "securityContext": Object {
+                "privileged": false,
+                "readOnlyRootFilesystem": false,
+                "runAsNonRoot": false,
+              },
+            },
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "securityContext": Object {
+            "fsGroupChangePolicy": "Always",
+            "runAsNonRoot": false,
+          },
+          "setHostnameAsFQDN": false,
+        },
+      },
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to multiple peers 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc82dc44e4f9989eb126eaaba4da220f06e-c80adbd2",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressundefinedc82dc44e4f9989eb126eaaba-c89ede32",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc8b86857d7ce2958c4fd0ab7a90aca46d9-c8c2771b",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod3-c8b86857",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressundefinedc8b86857d7ce2958c4fd0ab7-c80c4c6c",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod3-c8b86857",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod3-c8b86857",
+      },
+      "name": "test-pod3-c81af0d3",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to namespaces selected by name 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc880996af92c38a237394619e07db1dc75-c863bace",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "n1",
+                },
+              },
+              "podSelector": Object {},
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressn1c880996af92c38a237394619e07db1d-c80a6fce",
+      "namespace": "n1",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {},
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to peer across namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+      },
+      "name": "test-pod1-c8153666",
+      "namespace": "n1",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc82dc44e4f9989eb126eaaba4da220f06e-c80adbd2",
+      "namespace": "n1",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "n2",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressn2c82dc44e4f9989eb126eaaba4da220f-c841c6b9",
+      "namespace": "n2",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "n1",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod1-c8591188",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod2-c82dc44e",
+      },
+      "name": "test-pod2-c895d79d",
+      "namespace": "n2",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to pods selected with namespaces selected by names 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc87532153cca98350206df142ec1520c00-c812a038",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "selected1",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+            Object {
+              "namespaceSelector": Object {
+                "matchLabels": Object {
+                  "kubernetes.io/metadata.name": "selected2",
+                },
+              },
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressselected1c87532153cca98350206df14-c8e4e2a7",
+      "namespace": "selected1",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "type": "selected",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressselected2c87532153cca98350206df14-c8899c50",
+      "namespace": "selected2",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "type": "selected",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
+exports[`connections | can allow to pods selected without namespaces 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "pod",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsNonRoot": false,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowegressc87532153cca98350206df142ec1520c00-c812a038",
+    },
+    "spec": Object {
+      "egress": Array [
+        Object {
+          "ports": Array [],
+          "to": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "type": "selected",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+        },
+      },
+      "policyTypes": Array [
+        "Egress",
+      ],
+    },
+  },
+  Object {
+    "apiVersion": "networking.k8s.io/v1",
+    "kind": "NetworkPolicy",
+    "metadata": Object {
+      "name": "allowingressundefinedc87532153cca98350206df14-c8728faf",
+    },
+    "spec": Object {
+      "ingress": Array [
+        Object {
+          "from": Array [
+            Object {
+              "podSelector": Object {
+                "matchLabels": Object {
+                  "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+                },
+              },
+            },
+          ],
+          "ports": Array [],
+        },
+      ],
+      "podSelector": Object {
+        "matchLabels": Object {
+          "type": "selected",
+        },
+      },
+      "policyTypes": Array [
+        "Ingress",
+      ],
+    },
+  },
+]
+`;
+
 exports[`defaults 1`] = `
 Array [
   Object {
@@ -261,9 +3431,6 @@ Array [
                     "cdk8s.io/metadata.addr": "test-Redis-c8b1633b",
                   },
                 },
-                "namespaces": Array [
-                  "default",
-                ],
                 "topologyKey": "topology.kubernetes.io/zone",
               },
               "weight": 1,
@@ -347,9 +3514,6 @@ Array [
                   "cdk8s.io/metadata.addr": "test-Redis-c8b1633b",
                 },
               },
-              "namespaces": Array [
-                "default",
-              ],
               "topologyKey": "kubernetes.io/hostname",
             },
           ],
@@ -536,9 +3700,6 @@ Array [
                     "cdk8s.io/metadata.addr": "test-Redis-c8b1633b",
                   },
                 },
-                "namespaces": Array [
-                  "default",
-                ],
                 "topologyKey": "topology.kubernetes.io/zone",
               },
               "weight": 1,
@@ -622,9 +3783,6 @@ Array [
                   "cdk8s.io/metadata.addr": "test-Redis-c8b1633b",
                 },
               },
-              "namespaces": Array [
-                "default",
-              ],
               "topologyKey": "kubernetes.io/hostname",
             },
           ],

--- a/test/network-policy.test.ts
+++ b/test/network-policy.test.ts
@@ -1,0 +1,527 @@
+import { Testing } from 'cdk8s';
+import * as kplus from '../src';
+
+describe('IpBlock |', () => {
+
+  test('ipv4', () => {
+    const chart = Testing.chart();
+    expect(kplus.NetworkPolicyIpBlock.ipv4(chart, 'Block', '172.17.0.0/16', ['172.17.1.0/24'])._toKube()).toMatchSnapshot();
+  });
+
+  test('throws on invalid ipv4 cidr', () => {
+    const chart = Testing.chart();
+    expect(() => kplus.NetworkPolicyIpBlock.ipv4(chart, 'Block', '1234')).toThrow(/Invalid IPv4 CIDR:/);
+  });
+
+  test('ipv6', () => {
+    const chart = Testing.chart();
+    expect(kplus.NetworkPolicyIpBlock.ipv6(chart, 'Block', '2002::1234:abcd:ffff:c0a8:101/64', ['2002::1234:abcd:ffff:c0a8:101/24'])._toKube()).toMatchSnapshot();
+  });
+
+  test('throws on invalid ipv6 cidr', () => {
+    const chart = Testing.chart();
+    expect(() => kplus.NetworkPolicyIpBlock.ipv6(chart, 'Block', '1234')).toThrow(/Invalid IPv6 CIDR:/);
+  });
+
+  test('anyIpv4', () => {
+    const chart = Testing.chart();
+    expect(kplus.NetworkPolicyIpBlock.anyIpv4(chart, 'Block')._toKube()).toMatchSnapshot();
+  });
+
+  test('anyIpv6', () => {
+    const chart = Testing.chart();
+    expect(kplus.NetworkPolicyIpBlock.anyIpv6(chart, 'Block')._toKube()).toMatchSnapshot();
+  });
+
+});
+
+describe('NetworkPolicyPort |', () => {
+
+  test('tcp', () => {
+    expect(kplus.NetworkPolicyPort.tcp(8080)._toKube()).toMatchSnapshot();
+  });
+
+  test('tcpRange', () => {
+    expect(kplus.NetworkPolicyPort.tcpRange(8080, 8085)._toKube()).toMatchSnapshot();
+  });
+
+  test('allTcp', () => {
+    expect(kplus.NetworkPolicyPort.allTcp()._toKube()).toMatchSnapshot();
+  });
+
+  test('udp', () => {
+    expect(kplus.NetworkPolicyPort.udp(8080)._toKube()).toMatchSnapshot();
+  });
+
+  test('udpRange', () => {
+    expect(kplus.NetworkPolicyPort.udpRange(8080, 8085)._toKube()).toMatchSnapshot();
+  });
+
+  test('allUcp', () => {
+    expect(kplus.NetworkPolicyPort.allUdp()._toKube()).toMatchSnapshot();
+  });
+
+  test('of', () => {
+    expect(kplus.NetworkPolicyPort.of({ port: 5050, endPort: 5500, protocol: kplus.NetworkProtocol.SCTP }));
+  });
+
+});
+
+describe('NeworkPolicy |', () => {
+
+  test('can create a policy for a managed pod', () => {
+
+    const chart = Testing.chart();
+    const web = new kplus.Pod(chart, 'Web', {
+      containers: [{ image: 'web' }],
+    });
+
+    new kplus.NetworkPolicy(chart, 'Policy', { selector: web });
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can create a policy for a managed workload resource', () => {
+
+    const chart = Testing.chart();
+    const web = new kplus.Deployment(chart, 'Web', {
+      containers: [{ image: 'web' }],
+    });
+
+    new kplus.NetworkPolicy(chart, 'Policy', { selector: web });
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can create a policy for selected pods', () => {
+
+    const chart = Testing.chart();
+    const web = kplus.Pods.select(chart, 'Pods', { labels: { app: 'web' } });
+
+    new kplus.NetworkPolicy(chart, 'Policy', { selector: web });
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+  });
+
+  test('can create a policy for all pods', () => {
+
+    const chart = Testing.chart();
+
+    new kplus.NetworkPolicy(chart, 'Policy1');
+    new kplus.NetworkPolicy(chart, 'Policy2', { selector: kplus.Pods.all(chart, 'AllPods') });
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+  });
+
+  test('can create a policy that allows all ingress by default', () => {
+
+    const chart = Testing.chart();
+
+    new kplus.NetworkPolicy(chart, 'Policy', {
+      ingress: { default: kplus.NetworkPolicyTrafficDefault.ALLOW },
+    });
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can create a policy that denies all ingress by default', () => {
+
+    const chart = Testing.chart();
+
+    new kplus.NetworkPolicy(chart, 'Policy', {
+      ingress: { default: kplus.NetworkPolicyTrafficDefault.DENY },
+    });
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can create a policy that allows all egress by default', () => {
+
+    const chart = Testing.chart();
+
+    new kplus.NetworkPolicy(chart, 'Policy', {
+      egress: { default: kplus.NetworkPolicyTrafficDefault.ALLOW },
+    });
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can create a policy that denies all egress by default', () => {
+
+    const chart = Testing.chart();
+
+    new kplus.NetworkPolicy(chart, 'Policy', {
+      egress: { default: kplus.NetworkPolicyTrafficDefault.DENY },
+    });
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('cannot create a policy for a selector that selects pods in multiple namespaces', () => {
+
+    const chart = Testing.chart();
+    const web = kplus.Pods.select(chart, 'Pods', {
+      namespaces: kplus.Namespaces.select(chart, 'Namespaces', {
+        names: ['n1', 'n2'],
+      }),
+    });
+
+    expect(() => new kplus.NetworkPolicy(chart, 'Policy', {
+      selector: web,
+    })).toThrow('Unable to create a network policy for a selector (test/Pods) that selects pods in multiple namespaces');
+
+  });
+
+  test('cannot create a policy for a selector that selects pods in namespaces based on labels', () => {
+
+    const chart = Testing.chart();
+    const web = kplus.Pods.select(chart, 'Pods', {
+      labels: { app: 'web' },
+      namespaces: kplus.Namespaces.select(chart, 'Namespaces', {
+        labels: { tier: 'web' },
+      }),
+    });
+
+    expect(() => new kplus.NetworkPolicy(chart, 'Policy', {
+      selector: web,
+    })).toThrow('Unable to create a network policy for a selector (test/Pods) that selects pods in namespaces based on labels');
+
+  });
+
+  test('policy namespace defaults to selector namespace', () => {
+
+    const chart = Testing.chart();
+    const web = new kplus.Pod(chart, 'Web', {
+      containers: [{ image: 'web' }],
+      metadata: { namespace: 'n1' },
+    });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: web });
+
+    expect(policy.metadata.namespace).toEqual('n1');
+
+  });
+
+  test('can add ingress from an ip block', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const ipBlock = kplus.NetworkPolicyIpBlock.ipv4(chart, 'Block', '172.17.0.0/16', ['172.17.1.0/24']);
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(ipBlock, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from a managed pod', () => {
+
+    const chart = Testing.chart();
+    const pod1 = new kplus.Pod(chart, 'Pod1', { containers: [{ image: 'pod' }] });
+    const pod2 = new kplus.Pod(chart, 'Pod2', { containers: [{ image: 'pod' }] });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod1 });
+
+    policy.addIngressRule(pod2, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from a managed workload resource', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+    const deployment = new kplus.Deployment(chart, 'Deployment', { containers: [{ image: 'pod' }] });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(deployment, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from pods selected without namespaces', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const selected = kplus.Pods.select(chart, 'Pods', { labels: { type: 'selected' } });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(selected, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from pods selected with namespaces selected by labes', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const selected = kplus.Pods.select(chart, 'Pods', {
+      labels: { type: 'selected' },
+      namespaces: kplus.Namespaces.select(chart, 'Namespaces', { labels: { type: 'selected' } }),
+    });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(selected, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from pods selected with namespaces selected by names', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const selected = kplus.Pods.select(chart, 'Pods', {
+      labels: { type: 'selected' },
+      namespaces: kplus.Namespaces.select(chart, 'Namespaces', {
+        labels: { type: 'selected' },
+        names: ['selected1', 'selected2'],
+      }),
+    });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(selected, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from all pods', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const all = kplus.Pods.all(chart, 'AllPods');
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(all, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from managed namespace', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const namespace = new kplus.Namespace(chart, 'Namespace');
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(namespace, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from selected namespaces', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const namespace = kplus.Namespaces.select(chart, 'Namespaces', { labels: { type: 'selected' } });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(namespace, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add ingress from all namespaces', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const namespaces = kplus.Namespaces.all(chart, 'AllPods');
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addIngressRule(namespaces, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+
+  test('can add egress to an ip block', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const ipBlock = kplus.NetworkPolicyIpBlock.ipv4(chart, 'Block', '172.17.0.0/16', ['172.17.1.0/24']);
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(ipBlock, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to a managed pod', () => {
+
+    const chart = Testing.chart();
+    const pod1 = new kplus.Pod(chart, 'Pod1', { containers: [{ image: 'pod' }] });
+    const pod2 = new kplus.Pod(chart, 'Pod2', { containers: [{ image: 'pod' }] });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod1 });
+
+    policy.addEgressRule(pod2, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to a managed workload resource', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+    const deployment = new kplus.Deployment(chart, 'Deployment', { containers: [{ image: 'pod' }] });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(deployment, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to pods selected without namespaces', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const selected = kplus.Pods.select(chart, 'Pods', { labels: { type: 'selected' } });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(selected, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to pods selected with namespaces selected by labes', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const selected = kplus.Pods.select(chart, 'Pods', {
+      labels: { type: 'selected' },
+      namespaces: kplus.Namespaces.select(chart, 'Namespaces', { labels: { type: 'selected' } }),
+    });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(selected, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to pods selected with namespaces selected by names', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const selected = kplus.Pods.select(chart, 'Pods', {
+      labels: { type: 'selected' },
+      namespaces: kplus.Namespaces.select(chart, 'Namespaces', {
+        labels: { type: 'selected' },
+        names: ['selected1', 'selected2'],
+      }),
+    });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(selected, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to all pods', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const all = kplus.Pods.all(chart, 'AllPods');
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(all, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to managed namespace', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const namespace = new kplus.Namespace(chart, 'Namespace');
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(namespace, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to selected namespaces', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const namespace = kplus.Namespaces.select(chart, 'Namespaces', { labels: { type: 'selected' } });
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(namespace, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+  test('can add egress to all namespaces', () => {
+
+    const chart = Testing.chart();
+    const pod = new kplus.Pod(chart, 'Pod', { containers: [{ image: 'pod' }] });
+
+    const namespaces = kplus.Namespaces.all(chart, 'AllPods');
+
+    const policy = new kplus.NetworkPolicy(chart, 'Policy', { selector: pod });
+
+    policy.addEgressRule(namespaces, [kplus.NetworkPolicyPort.tcp(6379)]);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
+
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-24/main` to `k8s-23/main`:
 - [feat: network policies (#737)](https://github.com/cdk8s-team/cdk8s-plus/pull/737)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)