### PR TITLE
feat: `cdk8s-plus` is now a release-candidate (#761)

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -367,7 +367,7 @@
       "env": {
         "RELEASE": "true",
         "MAJOR": "2",
-        "PRERELEASE": "beta",
+        "PRERELEASE": "rc",
         "RELEASE_TAG_PREFIX": "cdk8s-plus-23/"
       },
       "steps": [

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -29,7 +29,7 @@ const project = new cdk.JsiiProject({
   ],
 
   projenCredentials: github.GithubCredentials.fromPersonalAccessToken(),
-  prerelease: 'beta',
+  prerelease: 'rc',
 
   peerDeps: [
     'cdk8s',


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-24/main` to `k8s-23/main`:
 - [feat: `cdk8s-plus` is now a release-candidate (#761)](https://github.com/cdk8s-team/cdk8s-plus/pull/761)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)