### PR TITLE
fix(pod): unable to use `LabelSelector` class in python

### DIFF
--- a/src/pod.ts
+++ b/src/pod.ts
@@ -423,7 +423,7 @@ export interface PodProps extends AbstractPodProps {}
 /**
  * Options for `LabelSelector.of`.
  */
-export class LabelSelectorOptions {
+export interface LabelSelectorOptions {
 
   /**
    * Strict label matchers.


### PR DESCRIPTION
Fixes #745 

Hi, cdk8s-team! Thanks for maintaining such a awesome project.
Recently, I'm testing `cdk8s-plus` based on python at work. but, As with #745, currently specifying a selector for deployment in python does not work.

Because `LabelsSelectorOption` is `class`, I could not assign values to `labels` and `expressions` properties (readonly).
Perhaps there is a problem after converting to python code by `jsii`. 