### PR TITLE
chore(deployment): separator causing api ref docs corruption

### DIFF
--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -95,7 +95,6 @@ export interface ExposeDeploymentViaIngressOptions extends DeploymentExposeViaSe
 * > Note: Do not manage ReplicaSets owned by a Deployment. Consider opening an issue in the main Kubernetes repository if your use case is not covered below.
 *
 * Use Case
-* ---------
 *
 * The following are typical use cases for Deployments:
 *


### PR DESCRIPTION
There's a separator that cause some corruption when rendering the markdown sidebar. Remove it.

![Screen Shot 2022-08-18 at 11 32 27 AM](https://user-images.githubusercontent.com/1428812/185349398-c1068cd6-81b0-4e78-b964-c0d35ee10ed6.png)
