### PR TITLE
feat(container): default container resource requirements

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -623,7 +623,7 @@ export class Container {
         limit: Cpu.millis(1500),
       },
       memory: {
-        request: Size.mebibytes(1769),
+        request: Size.mebibytes(512),
         limit: Size.mebibytes(2048),
       },
     };

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,4 +1,4 @@
-import { Size as container } from 'cdk8s';
+import { Size as container, Size } from 'cdk8s';
 import * as configmap from './config-map';
 import * as handler from './handler';
 import * as k8s from './imports/k8s';
@@ -609,6 +609,17 @@ export class Container {
       throw new Error('Attempted to construct a container from a Container object.');
     }
 
+    const defaultResourceSpec: ContainerResources = {
+      cpu: {
+        request: Cpu.millis(1000),
+        limit: Cpu.millis(1500),
+      },
+      memory: {
+        request: Size.mebibytes(1769),
+        limit: Size.mebibytes(2048),
+      },
+    };
+
     this.name = props.name ?? 'main';
     this.image = props.image;
     this.port = props.port;
@@ -618,7 +629,7 @@ export class Container {
     this._liveness = props.liveness;
     this._startup = props.startup;
     this._lifecycle = props.lifecycle;
-    this.resources = props.resources;
+    this.resources = props.resources ?? defaultResourceSpec;
     this.workingDir = props.workingDir;
     this.mounts = props.volumeMounts ?? [];
     this.imagePullPolicy = props.imagePullPolicy ?? ImagePullPolicy.ALWAYS;

--- a/src/container.ts
+++ b/src/container.ts
@@ -535,7 +535,7 @@ export interface ContainerProps {
    *      request: 1000 millis
    *      limit: 1500 millis
    *    memory:
-   *      request: 1769 mebibytes
+   *      request: 512 mebibytes
    *      limit: 2048 mebibytes
    */
   readonly resources?: ContainerResources;

--- a/src/container.ts
+++ b/src/container.ts
@@ -529,6 +529,14 @@ export interface ContainerProps {
   /**
    * Compute resources (CPU and memory requests and limits) required by the container
    * @see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+   *
+   * @default
+   *    cpu:
+   *      request: 1000 millis
+   *      limit: 1500 millis
+   *    memory:
+   *      request: 1769 mebibytes
+   *      limit: 2048 mebibytes
    */
   readonly resources?: ContainerResources;
 
@@ -909,8 +917,8 @@ export interface MemoryResources {
  * Emphemeral storage request and limit
  */
 export interface EphemeralStorageResources {
-  readonly request?: container;
-  readonly limit?: container;
+  readonly request?: Size;
+  readonly limit?: Size;
 }
 
 /**

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,4 +1,4 @@
-import { Size as container, Size } from 'cdk8s';
+import { Size } from 'cdk8s';
 import * as configmap from './config-map';
 import * as handler from './handler';
 import * as k8s from './imports/k8s';
@@ -892,8 +892,8 @@ export class Cpu {
  * Memory request and limit
  */
 export interface MemoryResources {
-  readonly request?: container;
-  readonly limit?: container;
+  readonly request?: Size;
+  readonly limit?: Size;
 }
 
 /**

--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -25,7 +25,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {

--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -18,6 +18,16 @@ Array [
           "image": "image",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,

--- a/test/__snapshots__/daemon-set.test.ts.snap
+++ b/test/__snapshots__/daemon-set.test.ts.snap
@@ -35,7 +35,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -93,7 +93,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {

--- a/test/__snapshots__/daemon-set.test.ts.snap
+++ b/test/__snapshots__/daemon-set.test.ts.snap
@@ -28,6 +28,16 @@ Array [
               "image": "image",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -76,6 +86,16 @@ Array [
               "image": "image",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -42,6 +42,16 @@ Array [
                   "containerPort": 9300,
                 },
               ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -154,6 +164,16 @@ Array [
                   "containerPort": 9300,
                 },
               ],
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -232,6 +252,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -310,6 +340,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -386,6 +426,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -443,6 +493,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -512,6 +572,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -569,6 +639,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -635,6 +715,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -714,6 +804,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -790,6 +890,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -847,6 +957,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -916,6 +1036,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -973,6 +1103,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -1039,6 +1179,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -1118,6 +1268,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -1194,6 +1354,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -1268,6 +1438,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -1339,6 +1519,16 @@ Array [
               "image": "redis",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -1377,6 +1567,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -49,7 +49,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -171,7 +171,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -259,7 +259,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -347,7 +347,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -433,7 +433,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -500,7 +500,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -579,7 +579,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -646,7 +646,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -722,7 +722,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -811,7 +811,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -897,7 +897,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -964,7 +964,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1043,7 +1043,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1110,7 +1110,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1186,7 +1186,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1275,7 +1275,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1361,7 +1361,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1445,7 +1445,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1526,7 +1526,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1574,7 +1574,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {

--- a/test/__snapshots__/network-policy.test.ts.snap
+++ b/test/__snapshots__/network-policy.test.ts.snap
@@ -117,7 +117,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -158,7 +158,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -240,7 +240,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -300,7 +300,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -384,7 +384,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -463,7 +463,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -541,7 +541,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -624,7 +624,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -715,7 +715,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -802,7 +802,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -903,7 +903,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -985,7 +985,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1068,7 +1068,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1109,7 +1109,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1191,7 +1191,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1251,7 +1251,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1335,7 +1335,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1414,7 +1414,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1492,7 +1492,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1575,7 +1575,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1666,7 +1666,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1753,7 +1753,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1854,7 +1854,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1936,7 +1936,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2019,7 +2019,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2098,7 +2098,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {

--- a/test/__snapshots__/network-policy.test.ts.snap
+++ b/test/__snapshots__/network-policy.test.ts.snap
@@ -110,6 +110,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -141,6 +151,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -213,6 +233,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -263,6 +293,16 @@ Array [
               "image": "pod",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -337,6 +377,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -406,6 +456,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -474,6 +534,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -547,6 +617,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -628,6 +708,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -705,6 +795,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -796,6 +896,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -868,6 +978,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -941,6 +1061,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -972,6 +1102,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1044,6 +1184,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1094,6 +1244,16 @@ Array [
               "image": "pod",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -1168,6 +1328,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1237,6 +1407,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1305,6 +1485,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1378,6 +1568,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1459,6 +1659,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1536,6 +1746,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1627,6 +1847,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1699,6 +1929,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1772,6 +2012,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1841,6 +2091,16 @@ Array [
               "image": "web",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,

--- a/test/__snapshots__/pod.test.ts.snap
+++ b/test/__snapshots__/pod.test.ts.snap
@@ -42,6 +42,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -140,6 +150,16 @@ Array [
               "containerPort": 6739,
             },
           ],
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -176,6 +196,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -238,6 +268,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -274,6 +314,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -336,6 +386,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -372,6 +432,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -480,6 +550,16 @@ Array [
               "containerPort": 6739,
             },
           ],
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -516,6 +596,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -578,6 +668,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -614,6 +714,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -676,6 +786,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -712,6 +832,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -802,6 +932,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -867,6 +1007,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -971,6 +1121,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1064,6 +1224,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1100,6 +1270,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1212,6 +1392,16 @@ Array [
               "image": "pod",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -1250,6 +1440,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1405,6 +1605,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1436,6 +1646,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1472,6 +1692,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1569,6 +1799,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1675,6 +1915,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1711,6 +1961,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1859,6 +2119,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -1957,6 +2227,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2047,6 +2327,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2112,6 +2402,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2216,6 +2516,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2319,6 +2629,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2355,6 +2675,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2467,6 +2797,16 @@ Array [
               "image": "pod",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -2505,6 +2845,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2660,6 +3010,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2691,6 +3051,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2727,6 +3097,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2824,6 +3204,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2930,6 +3320,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -2966,6 +3366,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3114,6 +3524,16 @@ Array [
           "image": "pod",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3212,6 +3632,16 @@ Array [
           "image": "image",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3248,6 +3678,16 @@ Array [
           "image": "image",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3328,6 +3768,16 @@ Array [
           "image": "image",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3416,6 +3866,16 @@ Array [
           "image": "image",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3496,6 +3956,16 @@ Array [
           "image": "image",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3571,6 +4041,16 @@ Array [
           "image": "scraper",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3607,6 +4087,16 @@ Array [
           "image": "image",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3701,6 +4191,16 @@ Array [
               "image": "scraper",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
@@ -3849,6 +4349,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3906,6 +4416,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3961,6 +4481,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -3997,6 +4527,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4045,6 +4585,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4081,6 +4631,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4126,6 +4686,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4179,6 +4749,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4230,6 +4810,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4266,6 +4856,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4314,6 +4914,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4350,6 +4960,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4395,6 +5015,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4448,6 +5078,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4506,6 +5146,16 @@ Array [
           "image": "web",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
@@ -4542,6 +5192,16 @@ Array [
           "image": "redis",
           "imagePullPolicy": "Always",
           "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "1769Mi",
+            },
+          },
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,

--- a/test/__snapshots__/pod.test.ts.snap
+++ b/test/__snapshots__/pod.test.ts.snap
@@ -49,7 +49,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -157,7 +157,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -203,7 +203,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -275,7 +275,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -321,7 +321,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -393,7 +393,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -439,7 +439,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -557,7 +557,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -603,7 +603,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -675,7 +675,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -721,7 +721,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -793,7 +793,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -839,7 +839,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -939,7 +939,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1014,7 +1014,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1128,7 +1128,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1231,7 +1231,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1277,7 +1277,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1399,7 +1399,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -1447,7 +1447,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1612,7 +1612,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1653,7 +1653,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1699,7 +1699,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1806,7 +1806,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1922,7 +1922,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -1968,7 +1968,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2126,7 +2126,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2234,7 +2234,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2334,7 +2334,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2409,7 +2409,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2523,7 +2523,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2636,7 +2636,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2682,7 +2682,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -2804,7 +2804,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -2852,7 +2852,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3017,7 +3017,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3058,7 +3058,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3104,7 +3104,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3211,7 +3211,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3327,7 +3327,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3373,7 +3373,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3531,7 +3531,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3639,7 +3639,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3685,7 +3685,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3775,7 +3775,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3873,7 +3873,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -3963,7 +3963,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4048,7 +4048,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4094,7 +4094,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4198,7 +4198,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {
@@ -4356,7 +4356,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4423,7 +4423,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4488,7 +4488,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4534,7 +4534,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4592,7 +4592,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4638,7 +4638,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4693,7 +4693,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4756,7 +4756,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4817,7 +4817,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4863,7 +4863,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4921,7 +4921,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -4967,7 +4967,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -5022,7 +5022,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -5085,7 +5085,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -5153,7 +5153,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {
@@ -5199,7 +5199,7 @@ Array [
             },
             "requests": Object {
               "cpu": "1000m",
-              "memory": "1769Mi",
+              "memory": "512Mi",
             },
           },
           "securityContext": Object {

--- a/test/__snapshots__/service.test.ts.snap
+++ b/test/__snapshots__/service.test.ts.snap
@@ -69,6 +69,16 @@ Array [
               "image": "image",
               "imagePullPolicy": "Always",
               "name": "main",
+              "resources": Object {
+                "limits": Object {
+                  "cpu": "1500m",
+                  "memory": "2048Mi",
+                },
+                "requests": Object {
+                  "cpu": "1000m",
+                  "memory": "1769Mi",
+                },
+              },
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,

--- a/test/__snapshots__/service.test.ts.snap
+++ b/test/__snapshots__/service.test.ts.snap
@@ -76,7 +76,7 @@ Array [
                 },
                 "requests": Object {
                   "cpu": "1000m",
-                  "memory": "1769Mi",
+                  "memory": "512Mi",
                 },
               },
               "securityContext": Object {

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -182,7 +182,7 @@ describe('Container', () => {
         },
         requests: {
           cpu: k8s.Quantity.fromString('1000m'),
-          memory: k8s.Quantity.fromString('1769Mi'),
+          memory: k8s.Quantity.fromString('512Mi'),
         },
       },
       command: ['command'],

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -175,6 +175,16 @@ describe('Container', () => {
       ports: [{
         containerPort: 9000,
       }],
+      resources: {
+        limits: {
+          cpu: k8s.Quantity.fromString('1500m'),
+          memory: k8s.Quantity.fromString('2048Mi'),
+        },
+        requests: {
+          cpu: k8s.Quantity.fromString('1000m'),
+          memory: k8s.Quantity.fromString('1769Mi'),
+        },
+      },
       command: ['command'],
       env: [{
         name: 'key',


### PR DESCRIPTION
As we will allow customers to integrate with manifest validation plugins soon, we see that one of the recommendation for K8s manifest is to have defined container resource limits. This would safeguard the containers to not have undefined limits which could end up in Out Of Memory crashes or performance degradation due to CPU over utilization.

Picking up these defaults from what Lambda follows [here](https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html), let me know if you believe these can be updated. 

Resolves https://github.com/cdk8s-team/cdk8s-plus/issues/807