### PR TITLE
feat(container): default container UID and GID

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -15,7 +15,7 @@ export interface ContainerSecurityContextProps {
   /**
     * The UID to run the entrypoint of the container process.
     *
-    * @default - 25000. An arbitrary number larger than 9999 is selected here.
+    * @default - 25000. An arbitrary number bigger than 9999 is selected here.
     * This is so that the container is blocked to access host files even if
     * somehow it manages to get access to host file system.
     */
@@ -24,7 +24,7 @@ export interface ContainerSecurityContextProps {
   /**
     * The GID to run the entrypoint of the container process.
     *
-    * @default - 26000. An arbitrary number larger than 9999 is selected here.
+    * @default - 26000. An arbitrary number bigger than 9999 is selected here.
     * This is so that the container is blocked to access host files even if
     * somehow it manages to get access to host file system.
     */

--- a/src/container.ts
+++ b/src/container.ts
@@ -15,14 +15,18 @@ export interface ContainerSecurityContextProps {
   /**
     * The UID to run the entrypoint of the container process.
     *
-    * @default - User specified in image metadata
+    * @default - 25000. An arbitrary number larger than 9999 is selected here.
+    * This is so that the container is blocked to access host files even if
+    * somehow it manages to get access to host file system.
     */
   readonly user?: number;
 
   /**
     * The GID to run the entrypoint of the container process.
     *
-    * @default - Group configured by container runtime
+    * @default - 26000. An arbitrary number larger than 9999 is selected here.
+    * This is so that the container is blocked to access host files even if
+    * somehow it manages to get access to host file system.
     */
   readonly group?: number;
 
@@ -66,8 +70,8 @@ export class ContainerSecurityContext {
     this.ensureNonRoot = props.ensureNonRoot ?? false;
     this.privileged = props.privileged ?? false;
     this.readOnlyRootFilesystem = props.readOnlyRootFilesystem ?? false;
-    this.user = props.user;
-    this.group = props.group;
+    this.user = props.user ?? 25000;
+    this.group = props.group ?? 26000;
   }
 
   /**

--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -21,7 +21,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
           "volumeMounts": Array [
             Object {

--- a/test/__snapshots__/daemon-set.test.ts.snap
+++ b/test/__snapshots__/daemon-set.test.ts.snap
@@ -31,7 +31,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -79,7 +81,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -45,7 +45,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -157,7 +159,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -235,7 +239,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -313,7 +319,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -389,7 +397,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -446,7 +456,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -515,7 +527,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -572,7 +586,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -638,7 +654,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -717,7 +735,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -793,7 +813,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -850,7 +872,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -919,7 +943,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -976,7 +1002,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -1042,7 +1070,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -1121,7 +1151,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -1197,7 +1229,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -1271,7 +1305,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -1342,7 +1378,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -1380,7 +1418,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],

--- a/test/__snapshots__/network-policy.test.ts.snap
+++ b/test/__snapshots__/network-policy.test.ts.snap
@@ -113,7 +113,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -144,7 +146,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -216,7 +220,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -266,7 +272,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -340,7 +348,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -409,7 +419,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -477,7 +489,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -550,7 +564,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -631,7 +647,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -708,7 +726,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -799,7 +819,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -871,7 +893,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -944,7 +968,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -975,7 +1001,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1047,7 +1075,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1097,7 +1127,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -1171,7 +1203,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1240,7 +1274,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1308,7 +1344,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1381,7 +1419,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1462,7 +1502,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1539,7 +1581,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1630,7 +1674,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1702,7 +1748,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1775,7 +1823,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1844,7 +1894,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],

--- a/test/__snapshots__/pod.test.ts.snap
+++ b/test/__snapshots__/pod.test.ts.snap
@@ -45,7 +45,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -143,7 +145,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -179,7 +183,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -241,7 +247,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -277,7 +285,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -339,7 +349,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -375,7 +387,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -483,7 +497,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -519,7 +535,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -581,7 +599,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -617,7 +637,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -679,7 +701,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -715,7 +739,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -805,7 +831,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -870,7 +898,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -974,7 +1004,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1067,7 +1099,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1103,7 +1137,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1215,7 +1251,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -1253,7 +1291,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1408,7 +1448,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1439,7 +1481,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1475,7 +1519,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1572,7 +1618,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1678,7 +1726,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1714,7 +1764,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1862,7 +1914,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -1960,7 +2014,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2050,7 +2106,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2115,7 +2173,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2219,7 +2279,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2322,7 +2384,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2358,7 +2422,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2470,7 +2536,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -2508,7 +2576,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2663,7 +2733,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2694,7 +2766,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2730,7 +2804,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2827,7 +2903,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2933,7 +3011,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -2969,7 +3049,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3117,7 +3199,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3215,7 +3299,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3251,7 +3337,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3331,7 +3419,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3419,7 +3509,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3499,7 +3591,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3574,7 +3668,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3610,7 +3706,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3704,7 +3802,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],
@@ -3852,7 +3952,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3909,7 +4011,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -3964,7 +4068,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4000,7 +4106,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4048,7 +4156,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4084,7 +4194,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4129,7 +4241,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4182,7 +4296,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4233,7 +4349,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4269,7 +4387,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4317,7 +4437,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4353,7 +4475,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4398,7 +4522,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4451,7 +4577,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4509,7 +4637,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],
@@ -4545,7 +4675,9 @@ Array [
           "securityContext": Object {
             "privileged": false,
             "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
             "runAsNonRoot": false,
+            "runAsUser": 25000,
           },
         },
       ],

--- a/test/__snapshots__/service.test.ts.snap
+++ b/test/__snapshots__/service.test.ts.snap
@@ -72,7 +72,9 @@ Array [
               "securityContext": Object {
                 "privileged": false,
                 "readOnlyRootFilesystem": false,
+                "runAsGroup": 26000,
                 "runAsNonRoot": false,
+                "runAsUser": 25000,
               },
             },
           ],

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -184,6 +184,8 @@ describe('Container', () => {
         privileged: false,
         readOnlyRootFilesystem: false,
         runAsNonRoot: false,
+        runAsUser: 25000,
+        runAsGroup: 26000,
       },
     };
 
@@ -535,8 +537,6 @@ test('default security context', () => {
   expect(container.securityContext.ensureNonRoot).toBeFalsy();
   expect(container.securityContext.privileged).toBeFalsy();
   expect(container.securityContext.readOnlyRootFilesystem).toBeFalsy();
-  expect(container.securityContext.user).toBeUndefined();
-  expect(container.securityContext.group).toBeUndefined();
 
   expect(container._toKube().securityContext).toEqual(container.securityContext._toKube());
   expect(container.securityContext._toKube()).toStrictEqual({


### PR DESCRIPTION
We need to set a number bigger than 9999 for UID and GID of the container. This helps preventing the container to get access to host files even if it somehow gets access to the host's file system. 

Resolves https://github.com/cdk8s-team/cdk8s-plus/issues/810

Signed-off-by: Vinayak Kukreja <vinakuk@amazon.com>