### PR TITLE
feat(container): default container startup probe (#1093)

### DIFF
--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -1,5 +1,181 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Container "startupProbe" property has defaults if port is provided 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "foo",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "ports": Array [
+            Object {
+              "containerPort": 8080,
+            },
+          ],
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "512Mi",
+            },
+          },
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
+            "runAsNonRoot": false,
+            "runAsUser": 25000,
+          },
+          "startupProbe": Object {
+            "failureThreshold": 3,
+            "tcpSocket": Object {
+              "port": 8080,
+            },
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`Container "startupProbe" property is undefined if port is not provided 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "image": "foo",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "512Mi",
+            },
+          },
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
+            "runAsNonRoot": false,
+            "runAsUser": 25000,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
+exports[`Container Instantiation properties are all respected 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": true,
+      "containers": Array [
+        Object {
+          "command": Array [
+            "command",
+          ],
+          "env": Array [
+            Object {
+              "name": "key",
+              "value": "value",
+            },
+          ],
+          "image": "image",
+          "imagePullPolicy": "Never",
+          "name": "name",
+          "ports": Array [
+            Object {
+              "containerPort": 9000,
+            },
+          ],
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "512Mi",
+            },
+          },
+          "securityContext": Object {
+            "privileged": false,
+            "readOnlyRootFilesystem": false,
+            "runAsGroup": 26000,
+            "runAsNonRoot": false,
+            "runAsUser": 25000,
+          },
+          "startupProbe": Object {
+            "failureThreshold": 3,
+            "tcpSocket": Object {
+              "port": 9000,
+            },
+          },
+          "workingDir": "workingDir",
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": false,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
 exports[`Container can mount container to a pv 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -59,6 +59,12 @@ Array [
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
               },
+              "startupProbe": Object {
+                "failureThreshold": 3,
+                "tcpSocket": Object {
+                  "port": 9300,
+                },
+              },
             },
           ],
           "dnsPolicy": "ClusterFirst",
@@ -283,6 +289,12 @@ Array [
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
+              },
+              "startupProbe": Object {
+                "failureThreshold": 3,
+                "tcpSocket": Object {
+                  "port": 9300,
+                },
               },
             },
           ],

--- a/test/__snapshots__/pod.test.ts.snap
+++ b/test/__snapshots__/pod.test.ts.snap
@@ -169,6 +169,12 @@ Array [
             "runAsNonRoot": false,
             "runAsUser": 25000,
           },
+          "startupProbe": Object {
+            "failureThreshold": 3,
+            "tcpSocket": Object {
+              "port": 6739,
+            },
+          },
         },
       ],
       "dnsPolicy": "ClusterFirst",
@@ -580,6 +586,12 @@ Array [
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
+          },
+          "startupProbe": Object {
+            "failureThreshold": 3,
+            "tcpSocket": Object {
+              "port": 6739,
+            },
           },
         },
       ],


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-24/main` to `k8s-22/main`:
 - [feat(container): default container startup probe (#1093)](https://github.com/cdk8s-team/cdk8s-plus/pull/1093)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)