### PR TITLE
feat: expose L1 constructs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,3 +23,4 @@ export * from './network-policy';
 export * from './namespace';
 
 export * from './api-resource.generated';
+export * as k8s from './imports/k8s';

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -1,7 +1,6 @@
 import { Testing, ApiObject } from 'cdk8s';
 import { Construct } from 'constructs';
-import { Resource, ResourceProps } from '../src/base';
-import { KubeConfigMap } from '../src/imports/k8s';
+import { Resource, ResourceProps, k8s } from '../src';
 
 test('Can mutate metadata', () => {
 
@@ -18,7 +17,7 @@ test('Can mutate metadata', () => {
     constructor(scope: Construct, id: string, props: CustomProps) {
       super(scope, id);
 
-      this.apiObject = new KubeConfigMap(this, 'ConfigMap', {
+      this.apiObject = new k8s.KubeConfigMap(this, 'ConfigMap', {
         metadata: props.metadata,
       });
     }

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -1,8 +1,7 @@
 import * as cdk8s from 'cdk8s';
 import { Size, Testing } from 'cdk8s';
 import * as kplus from '../src';
-import { Container, Cpu, Handler, ConnectionScheme, Probe } from '../src';
-import * as k8s from '../src/imports/k8s';
+import { Container, Cpu, Handler, ConnectionScheme, Probe, k8s } from '../src';
 
 describe('EnvValue', () => {
 

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -1,8 +1,7 @@
 import { Testing, ApiObject, Duration } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
-import { DeploymentStrategy, PercentOrAbsolute } from '../src';
-import * as k8s from '../src/imports/k8s';
+import { DeploymentStrategy, PercentOrAbsolute, k8s } from '../src';
 
 test('defaultChild', () => {
 

--- a/test/handler.test.ts
+++ b/test/handler.test.ts
@@ -1,5 +1,4 @@
-import { Container, Handler } from '../src';
-import { IntOrString } from '../src/imports/k8s';
+import { Container, Handler, k8s } from '../src';
 
 test('fromCommand', () => {
   const container = new Container({ image: 'image' });
@@ -10,11 +9,11 @@ test('fromCommand', () => {
 test('fromHttpGet', () => {
   const container = new Container({ image: 'image' });
   const handler = Handler.fromHttpGet('/path');
-  expect(handler._toKube(container).httpGet).toEqual({ path: '/path', port: IntOrString.fromNumber(80), scheme: 'HTTP' });
+  expect(handler._toKube(container).httpGet).toEqual({ path: '/path', port: k8s.IntOrString.fromNumber(80), scheme: 'HTTP' });
 });
 
 test('fromTcpSocket', () => {
   const container = new Container({ image: 'image' });
   const handler = Handler.fromTcpSocket({ port: 8888 });
-  expect(handler._toKube(container).tcpSocket).toEqual({ port: IntOrString.fromNumber(8888) });
+  expect(handler._toKube(container).tcpSocket).toEqual({ port: k8s.IntOrString.fromNumber(8888) });
 });

--- a/test/pod.test.ts
+++ b/test/pod.test.ts
@@ -1,8 +1,7 @@
 import { Testing, ApiObject, Duration } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
-import { DockerConfigSecret, FsGroupChangePolicy, Probe } from '../src';
-import * as k8s from '../src/imports/k8s';
+import { DockerConfigSecret, FsGroupChangePolicy, Probe, k8s } from '../src';
 
 test('defaults', () => {
 

--- a/test/probe.test.ts
+++ b/test/probe.test.ts
@@ -1,6 +1,5 @@
 import { Duration } from 'cdk8s';
-import { Container, Probe } from '../src';
-import { IntOrString } from '../src/imports/k8s';
+import { Container, Probe, k8s } from '../src';
 
 describe('fromHttpGet()', () => {
   test('defaults to the container port', () => {
@@ -15,7 +14,7 @@ describe('fromHttpGet()', () => {
       failureThreshold: 3,
       httpGet: {
         path: '/hello',
-        port: IntOrString.fromNumber(5555),
+        port: k8s.IntOrString.fromNumber(5555),
         scheme: 'HTTP',
       },
       initialDelaySeconds: undefined,
@@ -37,7 +36,7 @@ describe('fromHttpGet()', () => {
       failureThreshold: 3,
       httpGet: {
         path: '/hello',
-        port: IntOrString.fromNumber(1234),
+        port: k8s.IntOrString.fromNumber(1234),
         scheme: 'HTTP',
       },
       initialDelaySeconds: undefined,
@@ -64,7 +63,7 @@ describe('fromHttpGet()', () => {
     expect(min._toKube(container)).toEqual({
       httpGet: {
         path: '/hello',
-        port: IntOrString.fromNumber(5555),
+        port: k8s.IntOrString.fromNumber(5555),
         scheme: 'HTTP',
       },
       failureThreshold: 11,
@@ -135,7 +134,7 @@ describe('fromTcpSocket()', () => {
     // THEN
     expect(min._toKube(container)).toEqual({
       tcpSocket: {
-        port: IntOrString.fromNumber(5555),
+        port: k8s.IntOrString.fromNumber(5555),
         host: undefined,
       },
       failureThreshold: 3,
@@ -159,7 +158,7 @@ describe('fromTcpSocket()', () => {
     // THEN
     expect(min._toKube(container)).toEqual({
       tcpSocket: {
-        port: IntOrString.fromNumber(8080),
+        port: k8s.IntOrString.fromNumber(8080),
         host: 'hostname',
       },
       failureThreshold: 3,
@@ -186,7 +185,7 @@ describe('fromTcpSocket()', () => {
     // THEN
     expect(min._toKube(container)).toEqual({
       tcpSocket: {
-        port: IntOrString.fromNumber(5555),
+        port: k8s.IntOrString.fromNumber(5555),
         host: undefined,
       },
       failureThreshold: 11,

--- a/test/statefulset.test.ts
+++ b/test/statefulset.test.ts
@@ -1,8 +1,7 @@
 import { Testing, ApiObject, Duration } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
-import { StatefulSetUpdateStrategy } from '../src';
-import * as k8s from '../src/imports/k8s';
+import { StatefulSetUpdateStrategy, k8s } from '../src';
 
 test('defaultChild', () => {
 


### PR DESCRIPTION
Instead of vending them as separate libraries, lets just expose them from `cdk8s-plus`, as it already vends them.

Resolves https://github.com/cdk8s-team/cdk8s/issues/937