### PR TITLE
feat(container): default `readOnlyRootFilesystem` to true

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -49,7 +49,7 @@ export interface ContainerSecurityContextProps {
   /**
    * Whether this container has a read-only root filesystem.
    *
-   * @default false
+   * @default true
    */
   readonly readOnlyRootFilesystem?: boolean;
 
@@ -134,7 +134,7 @@ export class ContainerSecurityContext {
   constructor(props: ContainerSecurityContextProps = {}) {
     this.ensureNonRoot = props.ensureNonRoot ?? false;
     this.privileged = props.privileged ?? false;
-    this.readOnlyRootFilesystem = props.readOnlyRootFilesystem ?? false;
+    this.readOnlyRootFilesystem = props.readOnlyRootFilesystem ?? true;
     this.user = props.user ?? 25000;
     this.group = props.group ?? 26000;
   }
@@ -638,7 +638,7 @@ export interface ContainerProps {
    *
    *   ensureNonRoot: false
    *   privileged: false
-   *   readOnlyRootFilesystem: false
+   *   readOnlyRootFilesystem: true
    */
   readonly securityContext?: ContainerSecurityContextProps;
 }

--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -35,7 +35,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -89,7 +89,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -151,7 +151,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -206,7 +206,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,

--- a/test/__snapshots__/cron-job.test.ts.snap
+++ b/test/__snapshots__/cron-job.test.ts.snap
@@ -40,7 +40,7 @@ Array [
                   },
                   "securityContext": Object {
                     "privileged": false,
-                    "readOnlyRootFilesystem": false,
+                    "readOnlyRootFilesystem": true,
                     "runAsGroup": 26000,
                     "runAsNonRoot": false,
                     "runAsUser": 25000,
@@ -106,7 +106,7 @@ Array [
                   },
                   "securityContext": Object {
                     "privileged": false,
-                    "readOnlyRootFilesystem": false,
+                    "readOnlyRootFilesystem": true,
                     "runAsGroup": 26000,
                     "runAsNonRoot": false,
                     "runAsUser": 25000,

--- a/test/__snapshots__/daemon-set.test.ts.snap
+++ b/test/__snapshots__/daemon-set.test.ts.snap
@@ -40,7 +40,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -100,7 +100,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -54,7 +54,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -186,7 +186,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -285,7 +285,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -381,7 +381,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -471,7 +471,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -559,7 +559,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -628,7 +628,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -709,7 +709,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -778,7 +778,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -856,7 +856,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -947,7 +947,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1035,7 +1035,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1104,7 +1104,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1185,7 +1185,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1254,7 +1254,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1332,7 +1332,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1423,7 +1423,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1511,7 +1511,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1597,7 +1597,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1680,7 +1680,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1730,7 +1730,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,

--- a/test/__snapshots__/network-policy.test.ts.snap
+++ b/test/__snapshots__/network-policy.test.ts.snap
@@ -122,7 +122,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -165,7 +165,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -249,7 +249,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -311,7 +311,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -397,7 +397,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -478,7 +478,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -558,7 +558,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -643,7 +643,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -736,7 +736,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -825,7 +825,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -928,7 +928,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1012,7 +1012,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1097,7 +1097,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1140,7 +1140,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1224,7 +1224,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1286,7 +1286,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1372,7 +1372,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1453,7 +1453,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1533,7 +1533,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1618,7 +1618,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1711,7 +1711,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1800,7 +1800,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1903,7 +1903,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1987,7 +1987,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2072,7 +2072,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2153,7 +2153,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,

--- a/test/__snapshots__/pod.test.ts.snap
+++ b/test/__snapshots__/pod.test.ts.snap
@@ -54,7 +54,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -164,7 +164,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -218,7 +218,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -292,7 +292,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -340,7 +340,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -414,7 +414,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -462,7 +462,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -582,7 +582,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -636,7 +636,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -710,7 +710,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -758,7 +758,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -832,7 +832,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -880,7 +880,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -982,7 +982,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1059,7 +1059,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1175,7 +1175,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1280,7 +1280,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1328,7 +1328,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1452,7 +1452,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -1502,7 +1502,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1669,7 +1669,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1712,7 +1712,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1760,7 +1760,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1869,7 +1869,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -1987,7 +1987,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2035,7 +2035,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2195,7 +2195,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2305,7 +2305,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2407,7 +2407,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2484,7 +2484,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2600,7 +2600,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2715,7 +2715,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2763,7 +2763,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -2887,7 +2887,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -2937,7 +2937,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3104,7 +3104,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3147,7 +3147,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3195,7 +3195,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3304,7 +3304,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3422,7 +3422,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3470,7 +3470,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3630,7 +3630,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3740,7 +3740,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3788,7 +3788,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3880,7 +3880,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -3980,7 +3980,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4072,7 +4072,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4159,7 +4159,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4207,7 +4207,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4313,7 +4313,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,
@@ -4473,7 +4473,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4542,7 +4542,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4609,7 +4609,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4657,7 +4657,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4717,7 +4717,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4765,7 +4765,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4822,7 +4822,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4887,7 +4887,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4950,7 +4950,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -4998,7 +4998,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -5058,7 +5058,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -5106,7 +5106,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -5163,7 +5163,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -5228,7 +5228,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -5298,7 +5298,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,
@@ -5346,7 +5346,7 @@ Array [
           },
           "securityContext": Object {
             "privileged": false,
-            "readOnlyRootFilesystem": false,
+            "readOnlyRootFilesystem": true,
             "runAsGroup": 26000,
             "runAsNonRoot": false,
             "runAsUser": 25000,

--- a/test/__snapshots__/service.test.ts.snap
+++ b/test/__snapshots__/service.test.ts.snap
@@ -81,7 +81,7 @@ Array [
               },
               "securityContext": Object {
                 "privileged": false,
-                "readOnlyRootFilesystem": false,
+                "readOnlyRootFilesystem": true,
                 "runAsGroup": 26000,
                 "runAsNonRoot": false,
                 "runAsUser": 25000,

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -263,7 +263,7 @@ describe('Container', () => {
     expect(container.env[0].name).toEqual('key');
     expect(container.env[0].value).toEqual('value');
     expect(container.securityContext.privileged).toEqual(false);
-    expect(container.securityContext.readOnlyRootFilesystem).toEqual(false);
+    expect(container.securityContext.readOnlyRootFilesystem).toEqual(true);
     expect(container.securityContext.runAsNonRoot).toEqual(false);
     expect(container.startupProbe.failureThreshold).toEqual(3);
     expect(container.startupProbe.tcpSocket.port).toEqual(9000);
@@ -651,7 +651,7 @@ test('default security context', () => {
 
   expect(container.securityContext.ensureNonRoot).toBeFalsy();
   expect(container.securityContext.privileged).toBeFalsy();
-  expect(container.securityContext.readOnlyRootFilesystem).toBeFalsy();
+  expect(container.securityContext.readOnlyRootFilesystem).toBeTruthy();
 
   expect(container._toKube().securityContext).toEqual(container.securityContext._toKube());
   expect(container.securityContext._toKube()).toStrictEqual({


### PR DESCRIPTION
Setting `readOnlyRootFilesystem` property to `true` in a container denies access to any malicious actor to tamper with the local disk. 

Signed-off-by: Vinayak Kukreja <vinakuk@amazon.com>

Resolves https://github.com/cdk8s-team/cdk8s-plus/issues/815