### PR TITLE
feat(workload): default `restartPolicy` to `ALWAYS`

### DIFF
--- a/src/pod.ts
+++ b/src/pod.ts
@@ -30,7 +30,7 @@ export abstract class AbstractPod extends base.Resource implements IPodSelector,
   constructor(scope: Construct, id: string, props: AbstractPodProps = {}) {
     super(scope, id);
 
-    this.restartPolicy = props.restartPolicy;
+    this.restartPolicy = props.restartPolicy ?? RestartPolicy.ALWAYS;
     this.serviceAccount = props.serviceAccount;
     this.securityContext = new PodSecurityContext(props.securityContext);
     this.dns = new PodDns(props.dns);

--- a/test/__snapshots__/container.test.ts.snap
+++ b/test/__snapshots__/container.test.ts.snap
@@ -49,6 +49,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -97,6 +98,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -166,6 +168,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -220,6 +223,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,

--- a/test/__snapshots__/daemon-set.test.ts.snap
+++ b/test/__snapshots__/daemon-set.test.ts.snap
@@ -48,6 +48,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -108,6 +109,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,

--- a/test/__snapshots__/deployment.test.ts.snap
+++ b/test/__snapshots__/deployment.test.ts.snap
@@ -68,6 +68,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -194,6 +195,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -299,6 +301,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -390,6 +393,7 @@ Array [
           ],
           "dnsPolicy": "ClusterFirst",
           "nodeName": "node1",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -479,6 +483,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -567,6 +572,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -636,6 +642,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -717,6 +724,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -786,6 +794,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -864,6 +873,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -955,6 +965,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1043,6 +1054,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1112,6 +1124,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1193,6 +1206,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1262,6 +1276,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1340,6 +1355,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1431,6 +1447,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1519,6 +1536,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1605,6 +1623,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1688,6 +1707,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1738,6 +1758,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,

--- a/test/__snapshots__/network-policy.test.ts.snap
+++ b/test/__snapshots__/network-policy.test.ts.snap
@@ -130,6 +130,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -173,6 +174,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -257,6 +259,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -319,6 +322,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -405,6 +409,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -486,6 +491,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -566,6 +572,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -651,6 +658,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -744,6 +752,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -833,6 +842,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -936,6 +946,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1020,6 +1031,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1105,6 +1117,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1148,6 +1161,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1232,6 +1246,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1294,6 +1309,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1380,6 +1396,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1461,6 +1478,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1541,6 +1559,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1626,6 +1645,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1719,6 +1739,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1808,6 +1829,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1911,6 +1933,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1995,6 +2018,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2080,6 +2104,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2161,6 +2186,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,

--- a/test/__snapshots__/pod.test.ts.snap
+++ b/test/__snapshots__/pod.test.ts.snap
@@ -62,6 +62,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -178,6 +179,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -226,6 +228,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -300,6 +303,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -348,6 +352,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -422,6 +427,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -470,6 +476,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -596,6 +603,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -644,6 +652,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -718,6 +727,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -766,6 +776,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -840,6 +851,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -888,6 +900,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -990,6 +1003,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1067,6 +1081,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1183,6 +1198,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1288,6 +1304,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1336,6 +1353,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1460,6 +1478,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -1510,6 +1529,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1677,6 +1697,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1720,6 +1741,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1768,6 +1790,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1877,6 +1900,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -1995,6 +2019,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2043,6 +2068,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2203,6 +2229,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2313,6 +2340,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2415,6 +2443,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2492,6 +2521,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2608,6 +2638,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2723,6 +2754,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2771,6 +2803,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -2895,6 +2928,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -2945,6 +2979,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3112,6 +3147,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3155,6 +3191,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3203,6 +3240,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3312,6 +3350,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3430,6 +3469,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3478,6 +3518,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3638,6 +3679,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3748,6 +3790,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3796,6 +3839,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3888,6 +3932,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -3988,6 +4033,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4080,6 +4126,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4167,6 +4214,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4215,6 +4263,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4321,6 +4370,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,
@@ -4482,6 +4532,7 @@ Array [
       ],
       "dnsPolicy": "ClusterFirst",
       "nodeName": "node1",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4550,6 +4601,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4617,6 +4669,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4665,6 +4718,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4725,6 +4779,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4773,6 +4828,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4830,6 +4886,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4895,6 +4952,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -4958,6 +5016,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -5006,6 +5065,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -5066,6 +5126,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -5114,6 +5175,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -5171,6 +5233,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -5236,6 +5299,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -5306,6 +5370,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,
@@ -5354,6 +5419,7 @@ Array [
         },
       ],
       "dnsPolicy": "ClusterFirst",
+      "restartPolicy": "Always",
       "securityContext": Object {
         "fsGroupChangePolicy": "Always",
         "runAsNonRoot": false,

--- a/test/__snapshots__/service.test.ts.snap
+++ b/test/__snapshots__/service.test.ts.snap
@@ -89,6 +89,7 @@ Array [
             },
           ],
           "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
           "securityContext": Object {
             "fsGroupChangePolicy": "Always",
             "runAsNonRoot": false,

--- a/test/pod.test.ts
+++ b/test/pod.test.ts
@@ -1,7 +1,7 @@
 import { Testing, ApiObject, Duration } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
-import { DockerConfigSecret, FsGroupChangePolicy, Probe, k8s } from '../src';
+import { DockerConfigSecret, FsGroupChangePolicy, Probe, k8s, RestartPolicy } from '../src';
 
 test('defaults', () => {
 
@@ -10,8 +10,12 @@ test('defaults', () => {
     containers: [{ image: 'image' }],
   });
 
-  expect(Testing.synth(chart)).toMatchSnapshot();
+  const manifest = Testing.synth(chart);
+  const spec = manifest[0].spec;
 
+  expect(manifest).toMatchSnapshot();
+  expect(spec.restartPolicy).toEqual(RestartPolicy.ALWAYS);
+  expect(spec.automountServiceAccountToken).toBeTruthy();
 });
 
 test('fails with two volumes with the same name', () => {


### PR DESCRIPTION
As per Kubernetes documentation,
```
"Only a .spec.template.spec.restartPolicy equal to Always is allowed, which is the default if not specified."
```
So, other values of restart policy would not apply to resources like Deployment / Pod / DaemonSet / ReplicaSet / ReplicationController.

Signed-off-by: Vinayak Kukreja <vinakuk@amazon.com>

Resolves https://github.com/cdk8s-team/cdk8s-plus/issues/811