### PR TITLE
chore: remove v1.22.0 (#1294)

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -84,6 +84,7 @@ const project = new cdk.JsiiProject({
   depsUpgradeOptions: {
     workflowOptions: {
       branches: [
+        // Support the 3 latest major versions
         `k8s-${LATEST_SUPPORTED_K8S_VERSION}/main`,
         `k8s-${LATEST_SUPPORTED_K8S_VERSION - 1}/main`,
         `k8s-${LATEST_SUPPORTED_K8S_VERSION - 2}/main`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,26 +135,26 @@ apply the feature or bug fix to all the appropriate libraries.
 
 We currently track each version on a separate branch:
 
-- k8s-25/main
 - k8s-24/main
 - k8s-23/main
+- k8s-22/main
 
 In most cases, all you need to do is make a change to the library corresponding
-to latest version of kubernetes (i.e to the `k8s-25/main` branch). To do this,
+to latest version of kubernetes (i.e to the `k8s-24/main` branch). To do this,
 you can just follow the standard process for making a pull request: fork the
 repository, create your own branch, and add your changes. When you are finished,
 you should run "npx projen build" to make sure all tests pass and documentation
 is automatically updated.
 
 When you clone the repo, it will check out the branch corresponding to the
-latest version (`k8s-25/main`), and when you create the pull request on GitHub, it
+latest version (`k8s-24/main`), and when you create the pull request on GitHub, it
 should automatically target this branch. We will take care of backporting your
 change to the other branches corresponding to cdk8s-plus-23 and cdk8s-plus-24
-once the changes are merged to cdk8s-plus-25.
+once the changes are merged to cdk8s-plus-24.
 
 > Note: In some situations, you might only want to make a change to a library
 targeting an older kubernetes version. For example, `IngressV1Beta` is not
-available in cdk8s-plus-25, so changing it would require making a change to
+available in cdk8s-plus-24, so changing it would require making a change to
 cdk8s-plus-24 and cdk8s-plus-23. If you need to make a pull request to a version
 of cdk8s-plus that isn't the latest version, create your branch from the corresponding
 `k8s-XX/main` branch, and when you submit the pull request on GitHub, make sure the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,32 +135,32 @@ apply the feature or bug fix to all the appropriate libraries.
 
 We currently track each version on a separate branch:
 
-- k8s-22/main
-- k8s-21/main
-- k8s-20/main
+- k8s-25/main
+- k8s-24/main
+- k8s-23/main
 
 In most cases, all you need to do is make a change to the library corresponding
-to latest version of kubernetes (i.e to the `k8s-22/main` branch). To do this,
+to latest version of kubernetes (i.e to the `k8s-25/main` branch). To do this,
 you can just follow the standard process for making a pull request: fork the
 repository, create your own branch, and add your changes. When you are finished,
 you should run "npx projen build" to make sure all tests pass and documentation
 is automatically updated.
 
 When you clone the repo, it will check out the branch corresponding to the
-latest version (`k8s-22/main`), and when you create the pull request on GitHub, it
+latest version (`k8s-25/main`), and when you create the pull request on GitHub, it
 should automatically target this branch. We will take care of backporting your
-change to the other branches corresponding to cdk8s-plus-21 and cdk8s-plus-20
-once the changes are merged to cdk8s-plus-22.
+change to the other branches corresponding to cdk8s-plus-23 and cdk8s-plus-24
+once the changes are merged to cdk8s-plus-25.
 
 > Note: In some situations, you might only want to make a change to a library
 targeting an older kubernetes version. For example, `IngressV1Beta` is not
-available in cdk8s-plus-22, so changing it would require making a change to
-cdk8s-plus-21 and cdk8s-plus-20. If you need to make a pull request to a version
+available in cdk8s-plus-25, so changing it would require making a change to
+cdk8s-plus-24 and cdk8s-plus-23. If you need to make a pull request to a version
 of cdk8s-plus that isn't the latest version, create your branch from the corresponding
 `k8s-XX/main` branch, and when you submit the pull request on GitHub, make sure the
 target branch matches your base branch. The pull request should target the latest branch that your fix
-applies for - so in the example above, only a PR to `k8s-21/main` is required,
-and we will backport it to `k8s-20/main`.
+applies for - so in the example above, only a PR to `k8s-24/main` is required,
+and we will backport it to `k8s-23/main`.
 
 ### Developer Certificate Of Origin (DCO)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ### High level constructs for Kubernetes
 
 ![Stability:Beta](https://img.shields.io/badge/stability-beta-orange)
-[![cdk8s-plus-22](https://img.shields.io/github/workflow/status/cdk8s-team/cdk8s-plus/release-k8s.22?label=cdk8s-plus-22&logo=GitHub)](https://github.com/cdk8s-team/cdk8s-plus/actions/workflows/release-k8s.22.yml)
 [![cdk8s-plus-23](https://img.shields.io/github/workflow/status/cdk8s-team/cdk8s-plus/release-k8s.23?label=cdk8s-plus-23&logo=GitHub)](https://github.com/cdk8s-team/cdk8s-plus/actions/workflows/release-k8s.23.yml)
 [![cdk8s-plus-24](https://img.shields.io/github/workflow/status/cdk8s-team/cdk8s-plus/release-k8s.24?label=cdk8s-plus-24&logo=GitHub)](https://github.com/cdk8s-team/cdk8s-plus/actions/workflows/release-k8s.24.yml)
 

--- a/docs/plus/horizontal-pod-autoscaler.md
+++ b/docs/plus/horizontal-pod-autoscaler.md
@@ -3,7 +3,7 @@
 HorizontalPodAutoscaler allows your services to scale up when demand is high and scale down when they are no longer needed.
 
 !!! tip ""
-    [API Reference](../reference/cdk8s-plus-25/typescript.md#horizontalpodautoscaler)
+    [API Reference](../reference/cdk8s-plus-24/typescript.md#horizontalpodautoscaler)
 
 ## Using a HorizontalPodAutoscaler
 
@@ -11,7 +11,7 @@ The example below creates a HorizontalPodAutoscaler that scales the number of re
 
 ```typescript
 import * as k from 'cdk8s';
-import * as kplus from 'cdk8s-plus-25';
+import * as kplus from 'cdk8s-plus-24';
 
 const app = new k.App();
 const chart = new k.Chart(app, 'Chart');
@@ -71,7 +71,7 @@ Resource metrics are used to scale on a resource like CPU or memory.
 
 
 ```typescript
-import * as kplus from 'cdk8s-plus-25';
+import * as kplus from 'cdk8s-plus-24';
 
 
 const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
@@ -88,7 +88,7 @@ const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
 Pods metrics are used to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second).
 
 ```typescript
-import * as kplus from 'cdk8s-plus-25';
+import * as kplus from 'cdk8s-plus-24';
 
 
 const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
@@ -110,7 +110,7 @@ const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
 Container metrics are used to scale on one of the scaling target's container metrics.
 
 ```typescript
-import * as kplus from 'cdk8s-plus-25';
+import * as kplus from 'cdk8s-plus-24';
 
 
 const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
@@ -127,7 +127,7 @@ const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
 Object metrics are used to scale on a metric describing a single kubernetes object (for example, requests-per-second on an Ingress object).
 
 ```typescript
-import * as kplus from 'cdk8s-plus-25';
+import * as kplus from 'cdk8s-plus-24';
 
 
 const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
@@ -148,7 +148,7 @@ const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
 External metrics are used to scale on a metric not associated with any Kubernetes object (for example, an SQS queue).
 
 ```typescript
-import * as kplus from 'cdk8s-plus-25';
+import * as kplus from 'cdk8s-plus-24';
 
 
 const hpa = new kplus.HorizontalPodAutoscaler(chart, 'BookstoreWebsiteHpa', {
@@ -223,4 +223,4 @@ This means that if we currently have 3 web server pods, and the CPU utilization 
 
 This will result in a total of 9 web server pods. If after 60 seconds the CPU utilization is still at 72% the autoscaler will only be allowed to add one more replica because `maxReplicas` has been configured to 10.
 
-For more information on HorizontalPodAutoscaler check out the [API Reference](../reference/cdk8s-plus-25/typescript.md#horizontalpodautoscaler).
+For more information on HorizontalPodAutoscaler check out the [API Reference](../reference/cdk8s-plus-24/typescript.md#horizontalpodautoscaler).


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-25/main` to `k8s-24/main`:
 - [chore: remove v1.22.0 (#1294)](https://github.com/cdk8s-team/cdk8s-plus/pull/1294)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)