### PR TITLE
fix(config-map): update examples in documentation (#1334)

### DIFF
--- a/docs/plus/config-map.md
+++ b/docs/plus/config-map.md
@@ -13,12 +13,24 @@ and will therefore not be included in the resulting manifest.
 
 ```typescript
 import * as kplus from 'cdk8s-plus-23';
+import { Construct } from 'constructs';
+import { App, Chart, ChartProps } from 'cdk8s';
 
-const config: kplus.IConfigMap = kplus.ConfigMap.fromConfigMapName('config');
+export class MyChart extends Chart {
+  constructor(scope: Construct, id: string, props?: ChartProps) {
+    super(scope, id, props);
 
-// the 'config' constant can later be used by API's that require an IConfigMap.
-// for example when creating a volume.
-const volume = kplus.Volume.fromConfigMap(config);
+    const config: kplus.IConfigMap = kplus.ConfigMap.fromConfigMapName(this, 'ConfigMap', 'config');
+
+    // the 'config' constant can later be used by API's that require an IConfigMap.
+    // for example when creating a volume.
+    kplus.Volume.fromConfigMap(this, 'Volume', config);
+  }
+}
+
+const app = new App();
+new MyChart(app, 'VolumeFromConfigMap');
+app.synth();
 ```
 
 ## Adding data
@@ -27,13 +39,21 @@ You can create config maps and add some data to them like so:
 
 ```typescript
 import * as kplus from 'cdk8s-plus-23';
-import * as k from 'cdk8s';
+import { Construct } from 'constructs';
+import { App, Chart, ChartProps } from 'cdk8s';
 
-const app = new k.App();
-const chart = new k.Chart(app, 'Chart');
+export class MyChart extends Chart {
+  constructor(scope: Construct, id: string, props?: ChartProps) {
+    super(scope, id, props);
+    
+    const config = new kplus.ConfigMap(this, 'Config');
+    config.addData('url', 'https://my-endpoint:8080');
+  }
+}
 
-const config = new kplus.ConfigMap(chart, 'Config');
-config.addData('url', 'https://my-endpoint:8080');
+const app = new App();
+new MyChart(app, 'ConfigMap');
+app.synth();
 ```
 
 ## Creating a volume from a directory
@@ -42,29 +62,37 @@ Here is a nifty little trick you can use to create a volume that contains a dire
 
 ```typescript
 import * as kplus from 'cdk8s-plus-23';
-import * as k from 'cdk8s';
 import * as path from 'path';
+import { Construct } from 'constructs';
+import { App, Chart, ChartProps } from 'cdk8s';
 
-const app = new k.App();
-const chart = new k.Chart(app, 'Chart');
+export class MyChart extends Chart {
+  constructor(scope: Construct, id: string, props?: ChartProps) {
+    super(scope, id, props);
+    const appMap = new kplus.ConfigMap(this, 'Config');
 
-const appMap = new kplus.ConfigMap(chart, 'Config');
+    // add the files in the directory to the config map.
+    // this will create a key for each file.
+    // note: this directory needs to exist
+    // note: that only top level files will be included, sub-directories are not yet supported.
+    appMap.addDirectory(path.join(__dirname, 'app'));
 
-// add the files in the directory to the config map.
-// this will create a key for each file.
-// note that only top level files will be included, sub-directories are not yet supported.
-appMap.addDirectory(path.join(__dirname, 'app'));
+    const appVolume = kplus.Volume.fromConfigMap(this, 'ConfigMap', appMap);
 
-const appVolume = kplus.Volume.fromConfigMap(appMap);
+    const mountPath = '/var/app';
+    const pod = new kplus.Pod(this, 'Pod');
+    const container = pod.addContainer({
+      image: 'node',
+      command: [ 'node', 'app.js' ],
+      workingDir: mountPath,
+    });
 
-const mountPath = '/var/app';
-const pod = new kplus.Pod(chart, 'Pod');
-const container = pod.addContainer({
-  image: 'node',
-  command: [ 'node', 'app.js' ],
-  workingDir: mountPath,
-});
+    // from here, just mount the volume to a container, and run your app!
+    container.mount(mountPath, appVolume);
+  }
+}
 
-// from here, just mount the volume to a container, and run your app!
-container.mount(mountPath, appVolume);
+const app = new App();
+new MyChart(app, 'AppWithDir');
+app.synth();
 ```


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-25/main` to `k8s-23/main`:
 - [fix(config-map): update examples in documentation (#1334)](https://github.com/cdk8s-team/cdk8s-plus/pull/1334)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)