### PR TITLE
fix(docs): incorrect API reference link in HPA overview

### DIFF
--- a/docs/plus/horizontal-pod-autoscaler.md
+++ b/docs/plus/horizontal-pod-autoscaler.md
@@ -3,7 +3,7 @@
 HorizontalPodAutoscaler allows your services to scale up when demand is high and scale down when they are no longer needed.
 
 !!! tip ""
-    [API Reference](../reference/cdk8s-plus-25/typescript.md#horizontalpodautoscaler)
+    [API Reference](../../reference/cdk8s-plus-25/typescript.md#horizontalpodautoscaler)
 
 ## Using a HorizontalPodAutoscaler
 


### PR DESCRIPTION
## Summary

This PR fixes an incorrect link in the HPA overview doc page. 