### PR TITLE
chore(backport): action failing due to upstream bug (#1446)

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -17,7 +17,7 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
-          "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --non-interactive",
+          "exec": "npx backport@8.5.0 --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --non-interactive",
           "cwd": "/tmp/.backport/"
         }
       ]
@@ -39,7 +39,7 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
-          "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-22/main",
+          "exec": "npx backport@8.5.0 --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-22/main",
           "cwd": "/tmp/.backport/"
         }
       ]
@@ -61,7 +61,7 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
-          "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-23/main",
+          "exec": "npx backport@8.5.0 --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-23/main",
           "cwd": "/tmp/.backport/"
         }
       ]
@@ -83,7 +83,7 @@
           "exec": "cp .backportrc.json /tmp/.backport/"
         },
         {
-          "exec": "npx backport --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-24/main",
+          "exec": "npx backport@8.5.0 --accesstoken ${GITHUB_TOKEN} --pr ${BACKPORT_PR_NUMBER} --branch k8s-24/main",
           "cwd": "/tmp/.backport/"
         }
       ]

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -199,7 +199,10 @@ function createBackportTask(branch?: Number): Task {
   task.exec(`mkdir -p ${backportHome}`);
   task.exec(`cp ${backportConfig.path} ${backportHome}`);
 
-  const backport = ['npx', 'backport', '--accesstoken', '${GITHUB_TOKEN}', '--pr', '${BACKPORT_PR_NUMBER}'];
+  // pinning because of https://github.com/sqren/backport/issues/451
+  const backportVersion = '8.5.0';
+
+  const backport = ['npx', `backport@${backportVersion}`, '--accesstoken', '${GITHUB_TOKEN}', '--pr', '${BACKPORT_PR_NUMBER}'];
   if (branch) {
     backport.push(...['--branch', `k8s-${branch}/main`]);
   } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-25/main` to `k8s-24/main`:
 - [chore(backport): action failing due to upstream bug (#1446)](https://github.com/cdk8s-team/cdk8s-plus/pull/1446)

<!--- Backport version: 8.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)