### PR TITLE
feat(role): imported resources can be granted permissions on

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -16,7 +16,7 @@ export interface ResourceProps {
 /**
  * Represents a resource.
  */
-export interface IResource extends IConstruct {
+export interface IResource extends IConstruct, IApiResource {
   /**
    * The Kubernetes name of this resource.
    */
@@ -26,11 +26,6 @@ export interface IResource extends IConstruct {
    * The object's API version (e.g. "authorization.k8s.io/v1")
    */
   readonly apiVersion: string;
-
-  /**
-   * The group portion of the API version (e.g. "authorization.k8s.io")
-   */
-  readonly apiGroup: string;
 
   /**
    * The object kind (e.g. "Deployment").

--- a/src/config-map.ts
+++ b/src/config-map.ts
@@ -56,6 +56,8 @@ class ImportedConfigMap extends Construct implements IConfigMap {
 
   private readonly _name: string;
 
+  public readonly resourceType = 'configmaps';
+
   constructor(scope: Construct, id: string, name: string) {
     super(scope, id);
     this._name = name;
@@ -75,6 +77,10 @@ class ImportedConfigMap extends Construct implements IConfigMap {
 
   public get kind(): string {
     return k8s.KubeConfigMap.GVK.kind;
+  }
+
+  public get resourceName(): string {
+    return this.name;
   }
 
 }

--- a/src/pv.ts
+++ b/src/pv.ts
@@ -79,6 +79,8 @@ class ImportedPersistentVolume extends Construct implements IPersistentVolume {
 
   private readonly _name: string;
 
+  public readonly resourceType = 'persistentvolumes';
+
   constructor(scope: Construct, id: string, name: string) {
     super(scope, id);
     this._name = name;
@@ -98,6 +100,10 @@ class ImportedPersistentVolume extends Construct implements IPersistentVolume {
 
   public get kind(): string {
     return k8s.KubePersistentVolume.GVK.kind;
+  }
+
+  public get resourceName(): string {
+    return this.name;
   }
 
 }

--- a/src/pvc.ts
+++ b/src/pvc.ts
@@ -75,6 +75,8 @@ class ImportedPersistentVolumeClaim extends Construct implements IPersistentVolu
 
   private readonly _name: string;
 
+  public readonly resourceType = 'persistentvolumeclaims';
+
   constructor(scope: Construct, id: string, name: string) {
     super(scope, id);
     this._name = name;
@@ -94,6 +96,10 @@ class ImportedPersistentVolumeClaim extends Construct implements IPersistentVolu
 
   public get kind(): string {
     return k8s.KubePersistentVolumeClaim.GVK.kind;
+  }
+
+  public get resourceName(): string {
+    return this.name;
   }
 
 }

--- a/src/role.ts
+++ b/src/role.ts
@@ -45,6 +45,9 @@ export interface RolePolicyRule {
 class ImportedRole extends Construct implements IRole {
 
   private readonly _name: string;
+
+  public readonly resourceType = 'roles';
+
   constructor(scope: Construct, id: string, name: string) {
     super(scope, id);
     this._name = name;
@@ -65,6 +68,11 @@ class ImportedRole extends Construct implements IRole {
   public get kind(): string {
     return k8s.KubeRole.GVK.kind;
   }
+
+  public get resourceName(): string {
+    return this.name;
+  }
+
 }
 
 /**
@@ -279,6 +287,8 @@ class ImportedClusterRole extends Construct implements IClusterRole {
 
   private readonly _name: string;
 
+  public readonly resourceType: string = 'clusterroles';
+
   constructor(scope: Construct, id: string, name: string) {
     super(scope, id);
     this._name = name;
@@ -298,6 +308,10 @@ class ImportedClusterRole extends Construct implements IClusterRole {
 
   public get kind(): string {
     return k8s.KubeClusterRole.GVK.kind;
+  }
+
+  public get resourceName(): string {
+    return this.name;
   }
 
 }

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -64,6 +64,8 @@ class ImportedSecret extends Construct implements ISecret {
 
   private readonly _name: string;
 
+  public readonly resourceType = 'secrets';
+
   constructor(scope: Construct, id: string, name: string) {
     super(scope, id);
     this._name = name;
@@ -83,6 +85,10 @@ class ImportedSecret extends Construct implements ISecret {
 
   public get kind(): string {
     return k8s.KubeSecret.GVK.kind;
+  }
+
+  public get resourceName(): string {
+    return this.name;
   }
 
 }

--- a/src/service-account.ts
+++ b/src/service-account.ts
@@ -37,6 +37,8 @@ class ImportedServiceAccount extends Construct implements IServiceAccount {
 
   private readonly _name: string;
 
+  public readonly resourceType = 'serviceaccounts';
+
   constructor(scope: Construct, id: string, name: string) {
     super(scope, id);
     this._name = name;
@@ -56,6 +58,10 @@ class ImportedServiceAccount extends Construct implements IServiceAccount {
 
   public get kind(): string {
     return k8s.KubeServiceAccount.GVK.kind;
+  }
+
+  public get resourceName(): string {
+    return this.name;
   }
 
 }

--- a/test/__snapshots__/config-map.test.ts.snap
+++ b/test/__snapshots__/config-map.test.ts.snap
@@ -82,3 +82,33 @@ Array [
   },
 ]
 `;
+
+exports[`can grant permissions on imported 1`] = `
+Array [
+  Object {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": Object {
+      "name": "test-role-c8eba390",
+    },
+    "rules": Array [
+      Object {
+        "apiGroups": Array [
+          "",
+        ],
+        "resourceNames": Array [
+          "name",
+        ],
+        "resources": Array [
+          "configmaps",
+        ],
+        "verbs": Array [
+          "get",
+          "list",
+          "watch",
+        ],
+      },
+    ],
+  },
+]
+`;

--- a/test/__snapshots__/pv.test.ts.snap
+++ b/test/__snapshots__/pv.test.ts.snap
@@ -254,6 +254,36 @@ Array [
 ]
 `;
 
+exports[`PersistentVolume can grant permissions on imported 1`] = `
+Array [
+  Object {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": Object {
+      "name": "test-role-c8eba390",
+    },
+    "rules": Array [
+      Object {
+        "apiGroups": Array [
+          "",
+        ],
+        "resourceNames": Array [
+          "vol",
+        ],
+        "resources": Array [
+          "persistentvolumes",
+        ],
+        "verbs": Array [
+          "get",
+          "list",
+          "watch",
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`PersistentVolume custom 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/pvc.test.ts.snap
+++ b/test/__snapshots__/pvc.test.ts.snap
@@ -32,6 +32,36 @@ Array [
 ]
 `;
 
+exports[`can grant permissions on imported 1`] = `
+Array [
+  Object {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": Object {
+      "name": "test-role-c8eba390",
+    },
+    "rules": Array [
+      Object {
+        "apiGroups": Array [
+          "",
+        ],
+        "resourceNames": Array [
+          "claim",
+        ],
+        "resources": Array [
+          "persistentvolumeclaims",
+        ],
+        "verbs": Array [
+          "get",
+          "list",
+          "watch",
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`custom 1`] = `
 Array [
   Object {

--- a/test/__snapshots__/role.test.ts.snap
+++ b/test/__snapshots__/role.test.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClusterRole can grant permissions on imported 1`] = `
+Array [
+  Object {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": Object {
+      "name": "test-role-c8eba390",
+    },
+    "rules": Array [
+      Object {
+        "apiGroups": Array [
+          "rbac.authorization.k8s.io",
+        ],
+        "resourceNames": Array [
+          "r2",
+        ],
+        "resources": Array [
+          "clusterroles",
+        ],
+        "verbs": Array [
+          "get",
+          "list",
+          "watch",
+        ],
+      },
+    ],
+  },
+]
+`;
+
+exports[`Role can grant permissions on imported 1`] = `
+Array [
+  Object {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": Object {
+      "name": "test-role-c8eba390",
+    },
+    "rules": Array [
+      Object {
+        "apiGroups": Array [
+          "rbac.authorization.k8s.io",
+        ],
+        "resourceNames": Array [
+          "r2",
+        ],
+        "resources": Array [
+          "roles",
+        ],
+        "verbs": Array [
+          "get",
+          "list",
+          "watch",
+        ],
+      },
+    ],
+  },
+]
+`;

--- a/test/__snapshots__/secret.test.ts.snap
+++ b/test/__snapshots__/secret.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can grant permissions on imported 1`] = `
+Array [
+  Object {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": Object {
+      "name": "test-role-c8eba390",
+    },
+    "rules": Array [
+      Object {
+        "apiGroups": Array [
+          "",
+        ],
+        "resourceNames": Array [
+          "secret",
+        ],
+        "resources": Array [
+          "secrets",
+        ],
+        "verbs": Array [
+          "get",
+          "list",
+          "watch",
+        ],
+      },
+    ],
+  },
+]
+`;

--- a/test/__snapshots__/service-account.test.ts.snap
+++ b/test/__snapshots__/service-account.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can grant permissions on imported 1`] = `
+Array [
+  Object {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": Object {
+      "name": "test-role-c8eba390",
+    },
+    "rules": Array [
+      Object {
+        "apiGroups": Array [
+          "",
+        ],
+        "resourceNames": Array [
+          "service-account",
+        ],
+        "resources": Array [
+          "serviceaccounts",
+        ],
+        "verbs": Array [
+          "get",
+          "list",
+          "watch",
+        ],
+      },
+    ],
+  },
+]
+`;

--- a/test/config-map.test.ts
+++ b/test/config-map.test.ts
@@ -1,6 +1,18 @@
 import { Testing, ApiObject } from 'cdk8s';
 import { Node } from 'constructs';
-import { ConfigMap } from '../src';
+import { ConfigMap, Role } from '../src';
+
+test('can grant permissions on imported', () => {
+
+  const chart = Testing.chart();
+  const cm = ConfigMap.fromConfigMapName(chart, 'ConfigMap', 'name');
+
+  const role = new Role(chart, 'Role');
+  role.allowRead(cm);
+
+  expect(Testing.synth(chart)).toMatchSnapshot();
+
+});
 
 test('defaultChild', () => {
 

--- a/test/pv.test.ts
+++ b/test/pv.test.ts
@@ -4,6 +4,18 @@ import * as kplus from '../src';
 
 describe('PersistentVolume', () => {
 
+  test('can grant permissions on imported', () => {
+
+    const chart = Testing.chart();
+    const pv = kplus.PersistentVolume.fromPersistentVolumeName(chart, 'Vol', 'vol');
+
+    const role = new kplus.Role(chart, 'Role');
+    role.allowRead(pv);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
   test('defaults', () => {
 
     const chart = cdk8s.Testing.chart();

--- a/test/pvc.test.ts
+++ b/test/pvc.test.ts
@@ -2,6 +2,18 @@ import * as cdk8s from 'cdk8s';
 import { Testing } from 'cdk8s';
 import * as kplus from '../src';
 
+test('can grant permissions on imported', () => {
+
+  const chart = Testing.chart();
+  const claim = kplus.PersistentVolumeClaim.fromClaimName(chart, 'Claim', 'claim');
+
+  const role = new kplus.Role(chart, 'Role');
+  role.allowRead(claim);
+
+  expect(Testing.synth(chart)).toMatchSnapshot();
+
+});
+
 test('defaults', () => {
 
   const chart = cdk8s.Testing.chart();

--- a/test/role.test.ts
+++ b/test/role.test.ts
@@ -4,6 +4,19 @@ import * as kplus from '../src';
 import { ApiResource } from '../src';
 
 describe('Role', () => {
+
+  test('can grant permissions on imported', () => {
+
+    const chart = Testing.chart();
+    const r2 = kplus.Role.fromRoleName(chart, 'R2', 'r2');
+
+    const role = new kplus.Role(chart, 'Role');
+    role.allowRead(r2);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
+
   test('defaultChild', () => {
 
     // GIVEN
@@ -247,6 +260,18 @@ Array [
 });
 
 describe('ClusterRole', () => {
+
+  test('can grant permissions on imported', () => {
+
+    const chart = Testing.chart();
+    const r2 = kplus.ClusterRole.fromClusterRoleName(chart, 'R2', 'r2');
+
+    const role = new kplus.Role(chart, 'Role');
+    role.allowRead(r2);
+
+    expect(Testing.synth(chart)).toMatchSnapshot();
+
+  });
 
   test('defaultChild', () => {
 

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -2,6 +2,18 @@ import { Testing, ApiObject } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
 
+test('can grant permissions on imported', () => {
+
+  const chart = Testing.chart();
+  const secret = kplus.Secret.fromSecretName(chart, 'Secret', 'secret');
+
+  const role = new kplus.Role(chart, 'Role');
+  role.allowRead(secret);
+
+  expect(Testing.synth(chart)).toMatchSnapshot();
+
+});
+
 test('defaultChild', () => {
   const chart = Testing.chart();
 

--- a/test/service-account.test.ts
+++ b/test/service-account.test.ts
@@ -2,6 +2,18 @@ import { Testing, ApiObject } from 'cdk8s';
 import { Node } from 'constructs';
 import * as kplus from '../src';
 
+test('can grant permissions on imported', () => {
+
+  const chart = Testing.chart();
+  const sa = kplus.ServiceAccount.fromServiceAccountName(chart, 'ServiceAccount', 'service-account');
+
+  const role = new kplus.Role(chart, 'Role');
+  role.allowRead(sa);
+
+  expect(Testing.synth(chart)).toMatchSnapshot();
+
+});
+
 test('defaultChild', () => {
   const chart = Testing.chart();
 


### PR DESCRIPTION
Imported resources could not be used in the `role.allowXXX` methods because they didn't implement the `IApiResource` interface. 

They can easily implement this interface because imports are always done using the resource name, which is what this interface needs. 

Resolves https://github.com/cdk8s-team/cdk8s-plus/issues/1516