### PR TITLE
feat(secret): convert a secret to an `EnvValue`

### DIFF
--- a/src/imports/k8s.ts
+++ b/src/imports/k8s.ts
@@ -14,7 +14,7 @@ export class KubeMutatingWebhookConfiguration extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'admissionregistration.k8s.io/v1',
     kind: 'MutatingWebhookConfiguration',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration".
@@ -68,7 +68,7 @@ export class KubeMutatingWebhookConfigurationList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'admissionregistration.k8s.io/v1',
     kind: 'MutatingWebhookConfigurationList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.admissionregistration.v1.MutatingWebhookConfigurationList".
@@ -122,7 +122,7 @@ export class KubeValidatingWebhookConfiguration extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'admissionregistration.k8s.io/v1',
     kind: 'ValidatingWebhookConfiguration',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration".
@@ -176,7 +176,7 @@ export class KubeValidatingWebhookConfigurationList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'admissionregistration.k8s.io/v1',
     kind: 'ValidatingWebhookConfigurationList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfigurationList".
@@ -230,7 +230,7 @@ export class KubeStorageVersionV1Alpha1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'internal.apiserver.k8s.io/v1alpha1',
     kind: 'StorageVersion',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion".
@@ -284,7 +284,7 @@ export class KubeStorageVersionListV1Alpha1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'internal.apiserver.k8s.io/v1alpha1',
     kind: 'StorageVersionList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionList".
@@ -338,7 +338,7 @@ export class KubeControllerRevision extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'ControllerRevision',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.ControllerRevision".
@@ -392,7 +392,7 @@ export class KubeControllerRevisionList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'ControllerRevisionList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.ControllerRevisionList".
@@ -446,7 +446,7 @@ export class KubeDaemonSet extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'DaemonSet',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.DaemonSet".
@@ -500,7 +500,7 @@ export class KubeDaemonSetList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'DaemonSetList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.DaemonSetList".
@@ -554,7 +554,7 @@ export class KubeDeployment extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'Deployment',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.Deployment".
@@ -608,7 +608,7 @@ export class KubeDeploymentList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'DeploymentList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.DeploymentList".
@@ -662,7 +662,7 @@ export class KubeReplicaSet extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'ReplicaSet',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.ReplicaSet".
@@ -716,7 +716,7 @@ export class KubeReplicaSetList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'ReplicaSetList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.ReplicaSetList".
@@ -774,7 +774,7 @@ export class KubeStatefulSet extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'StatefulSet',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.StatefulSet".
@@ -828,7 +828,7 @@ export class KubeStatefulSetList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'StatefulSetList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.StatefulSetList".
@@ -882,7 +882,7 @@ export class KubeTokenRequest extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authentication.k8s.io/v1',
     kind: 'TokenRequest',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authentication.v1.TokenRequest".
@@ -936,7 +936,7 @@ export class KubeTokenReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authentication.k8s.io/v1',
     kind: 'TokenReview',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authentication.v1.TokenReview".
@@ -990,7 +990,7 @@ export class KubeLocalSubjectAccessReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'LocalSubjectAccessReview',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authorization.v1.LocalSubjectAccessReview".
@@ -1044,7 +1044,7 @@ export class KubeSelfSubjectAccessReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'SelfSubjectAccessReview',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authorization.v1.SelfSubjectAccessReview".
@@ -1098,7 +1098,7 @@ export class KubeSelfSubjectRulesReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'SelfSubjectRulesReview',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authorization.v1.SelfSubjectRulesReview".
@@ -1152,7 +1152,7 @@ export class KubeSubjectAccessReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'SubjectAccessReview',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authorization.v1.SubjectAccessReview".
@@ -1206,7 +1206,7 @@ export class KubeHorizontalPodAutoscaler extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v1',
     kind: 'HorizontalPodAutoscaler',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler".
@@ -1260,7 +1260,7 @@ export class KubeHorizontalPodAutoscalerList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v1',
     kind: 'HorizontalPodAutoscalerList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList".
@@ -1314,7 +1314,7 @@ export class KubeScale extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v1',
     kind: 'Scale',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v1.Scale".
@@ -1368,7 +1368,7 @@ export class KubeHorizontalPodAutoscalerV2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v2',
     kind: 'HorizontalPodAutoscaler',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler".
@@ -1422,7 +1422,7 @@ export class KubeHorizontalPodAutoscalerListV2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v2',
     kind: 'HorizontalPodAutoscalerList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList".
@@ -1476,7 +1476,7 @@ export class KubeHorizontalPodAutoscalerV2Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v2beta2',
     kind: 'HorizontalPodAutoscaler',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler".
@@ -1530,7 +1530,7 @@ export class KubeHorizontalPodAutoscalerListV2Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v2beta2',
     kind: 'HorizontalPodAutoscalerList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList".
@@ -1584,7 +1584,7 @@ export class KubeCronJob extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'batch/v1',
     kind: 'CronJob',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.batch.v1.CronJob".
@@ -1638,7 +1638,7 @@ export class KubeCronJobList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'batch/v1',
     kind: 'CronJobList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.batch.v1.CronJobList".
@@ -1692,7 +1692,7 @@ export class KubeJob extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'batch/v1',
     kind: 'Job',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.batch.v1.Job".
@@ -1746,7 +1746,7 @@ export class KubeJobList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'batch/v1',
     kind: 'JobList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.batch.v1.JobList".
@@ -1806,7 +1806,7 @@ export class KubeCertificateSigningRequest extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'certificates.k8s.io/v1',
     kind: 'CertificateSigningRequest',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.certificates.v1.CertificateSigningRequest".
@@ -1860,7 +1860,7 @@ export class KubeCertificateSigningRequestList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'certificates.k8s.io/v1',
     kind: 'CertificateSigningRequestList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.certificates.v1.CertificateSigningRequestList".
@@ -1914,7 +1914,7 @@ export class KubeLease extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'coordination.k8s.io/v1',
     kind: 'Lease',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.coordination.v1.Lease".
@@ -1968,7 +1968,7 @@ export class KubeLeaseList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'coordination.k8s.io/v1',
     kind: 'LeaseList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.coordination.v1.LeaseList".
@@ -2022,7 +2022,7 @@ export class KubeBinding extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Binding',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Binding".
@@ -2076,7 +2076,7 @@ export class KubeComponentStatus extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ComponentStatus',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ComponentStatus".
@@ -2130,7 +2130,7 @@ export class KubeComponentStatusList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ComponentStatusList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ComponentStatusList".
@@ -2184,7 +2184,7 @@ export class KubeConfigMap extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ConfigMap',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ConfigMap".
@@ -2238,7 +2238,7 @@ export class KubeConfigMapList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ConfigMapList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ConfigMapList".
@@ -2304,7 +2304,7 @@ export class KubeEndpoints extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Endpoints',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Endpoints".
@@ -2358,7 +2358,7 @@ export class KubeEndpointsList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'EndpointsList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.EndpointsList".
@@ -2412,7 +2412,7 @@ export class KubeEvent extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'events.k8s.io/v1',
     kind: 'Event',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.events.v1.Event".
@@ -2466,7 +2466,7 @@ export class KubeEventList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'events.k8s.io/v1',
     kind: 'EventList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.events.v1.EventList".
@@ -2520,7 +2520,7 @@ export class KubeLimitRange extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'LimitRange',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.LimitRange".
@@ -2574,7 +2574,7 @@ export class KubeLimitRangeList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'LimitRangeList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.LimitRangeList".
@@ -2628,7 +2628,7 @@ export class KubeNamespace extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Namespace',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Namespace".
@@ -2682,7 +2682,7 @@ export class KubeNamespaceList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'NamespaceList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.NamespaceList".
@@ -2736,7 +2736,7 @@ export class KubeNode extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Node',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Node".
@@ -2790,7 +2790,7 @@ export class KubeNodeList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'NodeList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.NodeList".
@@ -2844,7 +2844,7 @@ export class KubePersistentVolume extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PersistentVolume',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PersistentVolume".
@@ -2898,7 +2898,7 @@ export class KubePersistentVolumeClaim extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PersistentVolumeClaim',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PersistentVolumeClaim".
@@ -2952,7 +2952,7 @@ export class KubePersistentVolumeClaimList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PersistentVolumeClaimList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PersistentVolumeClaimList".
@@ -3006,7 +3006,7 @@ export class KubePersistentVolumeList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PersistentVolumeList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PersistentVolumeList".
@@ -3060,7 +3060,7 @@ export class KubePod extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Pod',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Pod".
@@ -3114,7 +3114,7 @@ export class KubePodList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PodList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PodList".
@@ -3168,7 +3168,7 @@ export class KubePodTemplate extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PodTemplate',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PodTemplate".
@@ -3222,7 +3222,7 @@ export class KubePodTemplateList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PodTemplateList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PodTemplateList".
@@ -3276,7 +3276,7 @@ export class KubeReplicationController extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ReplicationController',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ReplicationController".
@@ -3330,7 +3330,7 @@ export class KubeReplicationControllerList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ReplicationControllerList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ReplicationControllerList".
@@ -3384,7 +3384,7 @@ export class KubeResourceQuota extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ResourceQuota',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ResourceQuota".
@@ -3438,7 +3438,7 @@ export class KubeResourceQuotaList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ResourceQuotaList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ResourceQuotaList".
@@ -3492,7 +3492,7 @@ export class KubeSecret extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Secret',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Secret".
@@ -3546,7 +3546,7 @@ export class KubeSecretList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'SecretList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.SecretList".
@@ -3600,7 +3600,7 @@ export class KubeService extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Service',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Service".
@@ -3654,7 +3654,7 @@ export class KubeServiceAccount extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ServiceAccount".
@@ -3708,7 +3708,7 @@ export class KubeServiceAccountList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ServiceAccountList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ServiceAccountList".
@@ -3762,7 +3762,7 @@ export class KubeServiceList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ServiceList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ServiceList".
@@ -3816,7 +3816,7 @@ export class KubeEndpointSlice extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'discovery.k8s.io/v1',
     kind: 'EndpointSlice',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.discovery.v1.EndpointSlice".
@@ -3870,7 +3870,7 @@ export class KubeEndpointSliceList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'discovery.k8s.io/v1',
     kind: 'EndpointSliceList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.discovery.v1.EndpointSliceList".
@@ -3924,7 +3924,7 @@ export class KubeFlowSchemaV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta1',
     kind: 'FlowSchema',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta1.FlowSchema".
@@ -3978,7 +3978,7 @@ export class KubeFlowSchemaListV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta1',
     kind: 'FlowSchemaList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta1.FlowSchemaList".
@@ -4032,7 +4032,7 @@ export class KubePriorityLevelConfigurationV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta1',
     kind: 'PriorityLevelConfiguration',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration".
@@ -4086,7 +4086,7 @@ export class KubePriorityLevelConfigurationListV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta1',
     kind: 'PriorityLevelConfigurationList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationList".
@@ -4140,7 +4140,7 @@ export class KubeFlowSchemaV1Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
     kind: 'FlowSchema',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.FlowSchema".
@@ -4194,7 +4194,7 @@ export class KubeFlowSchemaListV1Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
     kind: 'FlowSchemaList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList".
@@ -4248,7 +4248,7 @@ export class KubePriorityLevelConfigurationV1Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
     kind: 'PriorityLevelConfiguration',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration".
@@ -4302,7 +4302,7 @@ export class KubePriorityLevelConfigurationListV1Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
     kind: 'PriorityLevelConfigurationList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList".
@@ -4356,7 +4356,7 @@ export class KubeIngress extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'Ingress',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.Ingress".
@@ -4410,7 +4410,7 @@ export class KubeIngressClass extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'IngressClass',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.IngressClass".
@@ -4464,7 +4464,7 @@ export class KubeIngressClassList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'IngressClassList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.IngressClassList".
@@ -4518,7 +4518,7 @@ export class KubeIngressList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'IngressList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.IngressList".
@@ -4572,7 +4572,7 @@ export class KubeNetworkPolicy extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'NetworkPolicy',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.NetworkPolicy".
@@ -4626,7 +4626,7 @@ export class KubeNetworkPolicyList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'NetworkPolicyList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.NetworkPolicyList".
@@ -4680,7 +4680,7 @@ export class KubeClusterCidrv1Alpha1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1alpha1',
     kind: 'ClusterCIDR',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1alpha1.ClusterCIDR".
@@ -4734,7 +4734,7 @@ export class KubeClusterCidrListV1Alpha1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1alpha1',
     kind: 'ClusterCIDRList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1alpha1.ClusterCIDRList".
@@ -4788,7 +4788,7 @@ export class KubeRuntimeClass extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'node.k8s.io/v1',
     kind: 'RuntimeClass',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.node.v1.RuntimeClass".
@@ -4842,7 +4842,7 @@ export class KubeRuntimeClassList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'node.k8s.io/v1',
     kind: 'RuntimeClassList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.node.v1.RuntimeClassList".
@@ -4896,7 +4896,7 @@ export class KubeEviction extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'policy/v1',
     kind: 'Eviction',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.policy.v1.Eviction".
@@ -4950,7 +4950,7 @@ export class KubePodDisruptionBudget extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'policy/v1',
     kind: 'PodDisruptionBudget',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.policy.v1.PodDisruptionBudget".
@@ -5004,7 +5004,7 @@ export class KubePodDisruptionBudgetList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'policy/v1',
     kind: 'PodDisruptionBudgetList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.policy.v1.PodDisruptionBudgetList".
@@ -5058,7 +5058,7 @@ export class KubeClusterRole extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.ClusterRole".
@@ -5112,7 +5112,7 @@ export class KubeClusterRoleBinding extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.ClusterRoleBinding".
@@ -5166,7 +5166,7 @@ export class KubeClusterRoleBindingList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBindingList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.ClusterRoleBindingList".
@@ -5220,7 +5220,7 @@ export class KubeClusterRoleList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.ClusterRoleList".
@@ -5274,7 +5274,7 @@ export class KubeRole extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'Role',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.Role".
@@ -5328,7 +5328,7 @@ export class KubeRoleBinding extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBinding',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.RoleBinding".
@@ -5382,7 +5382,7 @@ export class KubeRoleBindingList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBindingList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.RoleBindingList".
@@ -5436,7 +5436,7 @@ export class KubeRoleList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.RoleList".
@@ -5490,7 +5490,7 @@ export class KubePriorityClass extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'scheduling.k8s.io/v1',
     kind: 'PriorityClass',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.scheduling.v1.PriorityClass".
@@ -5544,7 +5544,7 @@ export class KubePriorityClassList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'scheduling.k8s.io/v1',
     kind: 'PriorityClassList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.scheduling.v1.PriorityClassList".
@@ -5598,7 +5598,7 @@ export class KubeCsiDriver extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSIDriver',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSIDriver".
@@ -5652,7 +5652,7 @@ export class KubeCsiDriverList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSIDriverList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSIDriverList".
@@ -5706,7 +5706,7 @@ export class KubeCsiNode extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSINode',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSINode".
@@ -5760,7 +5760,7 @@ export class KubeCsiNodeList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSINodeList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSINodeList".
@@ -5822,7 +5822,7 @@ export class KubeCsiStorageCapacity extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSIStorageCapacity',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSIStorageCapacity".
@@ -5876,7 +5876,7 @@ export class KubeCsiStorageCapacityList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSIStorageCapacityList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSIStorageCapacityList".
@@ -5932,7 +5932,7 @@ export class KubeStorageClass extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'StorageClass',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.StorageClass".
@@ -5986,7 +5986,7 @@ export class KubeStorageClassList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'StorageClassList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.StorageClassList".
@@ -6042,7 +6042,7 @@ export class KubeVolumeAttachment extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'VolumeAttachment',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.VolumeAttachment".
@@ -6096,7 +6096,7 @@ export class KubeVolumeAttachmentList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'VolumeAttachmentList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.VolumeAttachmentList".
@@ -6158,7 +6158,7 @@ export class KubeCsiStorageCapacityV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1beta1',
     kind: 'CSIStorageCapacity',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1beta1.CSIStorageCapacity".
@@ -6212,7 +6212,7 @@ export class KubeCsiStorageCapacityListV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1beta1',
     kind: 'CSIStorageCapacityList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1beta1.CSIStorageCapacityList".
@@ -6266,7 +6266,7 @@ export class KubeCustomResourceDefinition extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apiextensions.k8s.io/v1',
     kind: 'CustomResourceDefinition',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition".
@@ -6320,7 +6320,7 @@ export class KubeCustomResourceDefinitionList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apiextensions.k8s.io/v1',
     kind: 'CustomResourceDefinitionList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList".
@@ -6374,7 +6374,7 @@ export class KubeStatus extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Status',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.apimachinery.pkg.apis.meta.v1.Status".
@@ -6428,7 +6428,7 @@ export class KubeApiService extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apiregistration.k8s.io/v1',
     kind: 'APIService',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService".
@@ -6482,7 +6482,7 @@ export class KubeApiServiceList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apiregistration.k8s.io/v1',
     kind: 'APIServiceList',
-  };
+  }
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceList".

--- a/src/imports/k8s.ts
+++ b/src/imports/k8s.ts
@@ -14,7 +14,7 @@ export class KubeMutatingWebhookConfiguration extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'admissionregistration.k8s.io/v1',
     kind: 'MutatingWebhookConfiguration',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.admissionregistration.v1.MutatingWebhookConfiguration".
@@ -68,7 +68,7 @@ export class KubeMutatingWebhookConfigurationList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'admissionregistration.k8s.io/v1',
     kind: 'MutatingWebhookConfigurationList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.admissionregistration.v1.MutatingWebhookConfigurationList".
@@ -122,7 +122,7 @@ export class KubeValidatingWebhookConfiguration extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'admissionregistration.k8s.io/v1',
     kind: 'ValidatingWebhookConfiguration',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfiguration".
@@ -176,7 +176,7 @@ export class KubeValidatingWebhookConfigurationList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'admissionregistration.k8s.io/v1',
     kind: 'ValidatingWebhookConfigurationList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.admissionregistration.v1.ValidatingWebhookConfigurationList".
@@ -230,7 +230,7 @@ export class KubeStorageVersionV1Alpha1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'internal.apiserver.k8s.io/v1alpha1',
     kind: 'StorageVersion',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apiserverinternal.v1alpha1.StorageVersion".
@@ -284,7 +284,7 @@ export class KubeStorageVersionListV1Alpha1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'internal.apiserver.k8s.io/v1alpha1',
     kind: 'StorageVersionList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apiserverinternal.v1alpha1.StorageVersionList".
@@ -338,7 +338,7 @@ export class KubeControllerRevision extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'ControllerRevision',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.ControllerRevision".
@@ -392,7 +392,7 @@ export class KubeControllerRevisionList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'ControllerRevisionList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.ControllerRevisionList".
@@ -446,7 +446,7 @@ export class KubeDaemonSet extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'DaemonSet',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.DaemonSet".
@@ -500,7 +500,7 @@ export class KubeDaemonSetList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'DaemonSetList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.DaemonSetList".
@@ -554,7 +554,7 @@ export class KubeDeployment extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'Deployment',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.Deployment".
@@ -608,7 +608,7 @@ export class KubeDeploymentList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'DeploymentList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.DeploymentList".
@@ -662,7 +662,7 @@ export class KubeReplicaSet extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'ReplicaSet',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.ReplicaSet".
@@ -716,7 +716,7 @@ export class KubeReplicaSetList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'ReplicaSetList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.ReplicaSetList".
@@ -774,7 +774,7 @@ export class KubeStatefulSet extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'StatefulSet',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.StatefulSet".
@@ -828,7 +828,7 @@ export class KubeStatefulSetList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apps/v1',
     kind: 'StatefulSetList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.apps.v1.StatefulSetList".
@@ -882,7 +882,7 @@ export class KubeTokenRequest extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authentication.k8s.io/v1',
     kind: 'TokenRequest',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authentication.v1.TokenRequest".
@@ -936,7 +936,7 @@ export class KubeTokenReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authentication.k8s.io/v1',
     kind: 'TokenReview',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authentication.v1.TokenReview".
@@ -990,7 +990,7 @@ export class KubeLocalSubjectAccessReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'LocalSubjectAccessReview',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authorization.v1.LocalSubjectAccessReview".
@@ -1044,7 +1044,7 @@ export class KubeSelfSubjectAccessReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'SelfSubjectAccessReview',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authorization.v1.SelfSubjectAccessReview".
@@ -1098,7 +1098,7 @@ export class KubeSelfSubjectRulesReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'SelfSubjectRulesReview',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authorization.v1.SelfSubjectRulesReview".
@@ -1152,7 +1152,7 @@ export class KubeSubjectAccessReview extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'authorization.k8s.io/v1',
     kind: 'SubjectAccessReview',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.authorization.v1.SubjectAccessReview".
@@ -1206,7 +1206,7 @@ export class KubeHorizontalPodAutoscaler extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v1',
     kind: 'HorizontalPodAutoscaler',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler".
@@ -1260,7 +1260,7 @@ export class KubeHorizontalPodAutoscalerList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v1',
     kind: 'HorizontalPodAutoscalerList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList".
@@ -1314,7 +1314,7 @@ export class KubeScale extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v1',
     kind: 'Scale',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v1.Scale".
@@ -1368,7 +1368,7 @@ export class KubeHorizontalPodAutoscalerV2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v2',
     kind: 'HorizontalPodAutoscaler',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2.HorizontalPodAutoscaler".
@@ -1422,7 +1422,7 @@ export class KubeHorizontalPodAutoscalerListV2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v2',
     kind: 'HorizontalPodAutoscalerList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerList".
@@ -1476,7 +1476,7 @@ export class KubeHorizontalPodAutoscalerV2Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v2beta2',
     kind: 'HorizontalPodAutoscaler',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscaler".
@@ -1530,7 +1530,7 @@ export class KubeHorizontalPodAutoscalerListV2Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'autoscaling/v2beta2',
     kind: 'HorizontalPodAutoscalerList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.autoscaling.v2beta2.HorizontalPodAutoscalerList".
@@ -1584,7 +1584,7 @@ export class KubeCronJob extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'batch/v1',
     kind: 'CronJob',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.batch.v1.CronJob".
@@ -1638,7 +1638,7 @@ export class KubeCronJobList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'batch/v1',
     kind: 'CronJobList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.batch.v1.CronJobList".
@@ -1692,7 +1692,7 @@ export class KubeJob extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'batch/v1',
     kind: 'Job',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.batch.v1.Job".
@@ -1746,7 +1746,7 @@ export class KubeJobList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'batch/v1',
     kind: 'JobList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.batch.v1.JobList".
@@ -1806,7 +1806,7 @@ export class KubeCertificateSigningRequest extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'certificates.k8s.io/v1',
     kind: 'CertificateSigningRequest',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.certificates.v1.CertificateSigningRequest".
@@ -1860,7 +1860,7 @@ export class KubeCertificateSigningRequestList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'certificates.k8s.io/v1',
     kind: 'CertificateSigningRequestList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.certificates.v1.CertificateSigningRequestList".
@@ -1914,7 +1914,7 @@ export class KubeLease extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'coordination.k8s.io/v1',
     kind: 'Lease',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.coordination.v1.Lease".
@@ -1968,7 +1968,7 @@ export class KubeLeaseList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'coordination.k8s.io/v1',
     kind: 'LeaseList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.coordination.v1.LeaseList".
@@ -2022,7 +2022,7 @@ export class KubeBinding extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Binding',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Binding".
@@ -2076,7 +2076,7 @@ export class KubeComponentStatus extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ComponentStatus',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ComponentStatus".
@@ -2130,7 +2130,7 @@ export class KubeComponentStatusList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ComponentStatusList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ComponentStatusList".
@@ -2184,7 +2184,7 @@ export class KubeConfigMap extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ConfigMap',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ConfigMap".
@@ -2238,7 +2238,7 @@ export class KubeConfigMapList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ConfigMapList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ConfigMapList".
@@ -2304,7 +2304,7 @@ export class KubeEndpoints extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Endpoints',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Endpoints".
@@ -2358,7 +2358,7 @@ export class KubeEndpointsList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'EndpointsList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.EndpointsList".
@@ -2412,7 +2412,7 @@ export class KubeEvent extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'events.k8s.io/v1',
     kind: 'Event',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.events.v1.Event".
@@ -2466,7 +2466,7 @@ export class KubeEventList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'events.k8s.io/v1',
     kind: 'EventList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.events.v1.EventList".
@@ -2520,7 +2520,7 @@ export class KubeLimitRange extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'LimitRange',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.LimitRange".
@@ -2574,7 +2574,7 @@ export class KubeLimitRangeList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'LimitRangeList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.LimitRangeList".
@@ -2628,7 +2628,7 @@ export class KubeNamespace extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Namespace',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Namespace".
@@ -2682,7 +2682,7 @@ export class KubeNamespaceList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'NamespaceList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.NamespaceList".
@@ -2736,7 +2736,7 @@ export class KubeNode extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Node',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Node".
@@ -2790,7 +2790,7 @@ export class KubeNodeList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'NodeList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.NodeList".
@@ -2844,7 +2844,7 @@ export class KubePersistentVolume extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PersistentVolume',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PersistentVolume".
@@ -2898,7 +2898,7 @@ export class KubePersistentVolumeClaim extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PersistentVolumeClaim',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PersistentVolumeClaim".
@@ -2952,7 +2952,7 @@ export class KubePersistentVolumeClaimList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PersistentVolumeClaimList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PersistentVolumeClaimList".
@@ -3006,7 +3006,7 @@ export class KubePersistentVolumeList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PersistentVolumeList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PersistentVolumeList".
@@ -3060,7 +3060,7 @@ export class KubePod extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Pod',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Pod".
@@ -3114,7 +3114,7 @@ export class KubePodList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PodList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PodList".
@@ -3168,7 +3168,7 @@ export class KubePodTemplate extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PodTemplate',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PodTemplate".
@@ -3222,7 +3222,7 @@ export class KubePodTemplateList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'PodTemplateList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.PodTemplateList".
@@ -3276,7 +3276,7 @@ export class KubeReplicationController extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ReplicationController',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ReplicationController".
@@ -3330,7 +3330,7 @@ export class KubeReplicationControllerList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ReplicationControllerList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ReplicationControllerList".
@@ -3384,7 +3384,7 @@ export class KubeResourceQuota extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ResourceQuota',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ResourceQuota".
@@ -3438,7 +3438,7 @@ export class KubeResourceQuotaList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ResourceQuotaList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ResourceQuotaList".
@@ -3492,7 +3492,7 @@ export class KubeSecret extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Secret',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Secret".
@@ -3546,7 +3546,7 @@ export class KubeSecretList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'SecretList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.SecretList".
@@ -3600,7 +3600,7 @@ export class KubeService extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Service',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.Service".
@@ -3654,7 +3654,7 @@ export class KubeServiceAccount extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ServiceAccount".
@@ -3708,7 +3708,7 @@ export class KubeServiceAccountList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ServiceAccountList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ServiceAccountList".
@@ -3762,7 +3762,7 @@ export class KubeServiceList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'ServiceList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.core.v1.ServiceList".
@@ -3816,7 +3816,7 @@ export class KubeEndpointSlice extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'discovery.k8s.io/v1',
     kind: 'EndpointSlice',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.discovery.v1.EndpointSlice".
@@ -3870,7 +3870,7 @@ export class KubeEndpointSliceList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'discovery.k8s.io/v1',
     kind: 'EndpointSliceList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.discovery.v1.EndpointSliceList".
@@ -3924,7 +3924,7 @@ export class KubeFlowSchemaV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta1',
     kind: 'FlowSchema',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta1.FlowSchema".
@@ -3978,7 +3978,7 @@ export class KubeFlowSchemaListV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta1',
     kind: 'FlowSchemaList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta1.FlowSchemaList".
@@ -4032,7 +4032,7 @@ export class KubePriorityLevelConfigurationV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta1',
     kind: 'PriorityLevelConfiguration',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfiguration".
@@ -4086,7 +4086,7 @@ export class KubePriorityLevelConfigurationListV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta1',
     kind: 'PriorityLevelConfigurationList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta1.PriorityLevelConfigurationList".
@@ -4140,7 +4140,7 @@ export class KubeFlowSchemaV1Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
     kind: 'FlowSchema',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.FlowSchema".
@@ -4194,7 +4194,7 @@ export class KubeFlowSchemaListV1Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
     kind: 'FlowSchemaList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.FlowSchemaList".
@@ -4248,7 +4248,7 @@ export class KubePriorityLevelConfigurationV1Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
     kind: 'PriorityLevelConfiguration',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfiguration".
@@ -4302,7 +4302,7 @@ export class KubePriorityLevelConfigurationListV1Beta2 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'flowcontrol.apiserver.k8s.io/v1beta2',
     kind: 'PriorityLevelConfigurationList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.flowcontrol.v1beta2.PriorityLevelConfigurationList".
@@ -4356,7 +4356,7 @@ export class KubeIngress extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'Ingress',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.Ingress".
@@ -4410,7 +4410,7 @@ export class KubeIngressClass extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'IngressClass',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.IngressClass".
@@ -4464,7 +4464,7 @@ export class KubeIngressClassList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'IngressClassList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.IngressClassList".
@@ -4518,7 +4518,7 @@ export class KubeIngressList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'IngressList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.IngressList".
@@ -4572,7 +4572,7 @@ export class KubeNetworkPolicy extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'NetworkPolicy',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.NetworkPolicy".
@@ -4626,7 +4626,7 @@ export class KubeNetworkPolicyList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1',
     kind: 'NetworkPolicyList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1.NetworkPolicyList".
@@ -4680,7 +4680,7 @@ export class KubeClusterCidrv1Alpha1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1alpha1',
     kind: 'ClusterCIDR',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1alpha1.ClusterCIDR".
@@ -4734,7 +4734,7 @@ export class KubeClusterCidrListV1Alpha1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'networking.k8s.io/v1alpha1',
     kind: 'ClusterCIDRList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.networking.v1alpha1.ClusterCIDRList".
@@ -4788,7 +4788,7 @@ export class KubeRuntimeClass extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'node.k8s.io/v1',
     kind: 'RuntimeClass',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.node.v1.RuntimeClass".
@@ -4842,7 +4842,7 @@ export class KubeRuntimeClassList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'node.k8s.io/v1',
     kind: 'RuntimeClassList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.node.v1.RuntimeClassList".
@@ -4896,7 +4896,7 @@ export class KubeEviction extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'policy/v1',
     kind: 'Eviction',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.policy.v1.Eviction".
@@ -4950,7 +4950,7 @@ export class KubePodDisruptionBudget extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'policy/v1',
     kind: 'PodDisruptionBudget',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.policy.v1.PodDisruptionBudget".
@@ -5004,7 +5004,7 @@ export class KubePodDisruptionBudgetList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'policy/v1',
     kind: 'PodDisruptionBudgetList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.policy.v1.PodDisruptionBudgetList".
@@ -5058,7 +5058,7 @@ export class KubeClusterRole extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.ClusterRole".
@@ -5112,7 +5112,7 @@ export class KubeClusterRoleBinding extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.ClusterRoleBinding".
@@ -5166,7 +5166,7 @@ export class KubeClusterRoleBindingList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBindingList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.ClusterRoleBindingList".
@@ -5220,7 +5220,7 @@ export class KubeClusterRoleList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.ClusterRoleList".
@@ -5274,7 +5274,7 @@ export class KubeRole extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'Role',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.Role".
@@ -5328,7 +5328,7 @@ export class KubeRoleBinding extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBinding',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.RoleBinding".
@@ -5382,7 +5382,7 @@ export class KubeRoleBindingList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBindingList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.RoleBindingList".
@@ -5436,7 +5436,7 @@ export class KubeRoleList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.rbac.v1.RoleList".
@@ -5490,7 +5490,7 @@ export class KubePriorityClass extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'scheduling.k8s.io/v1',
     kind: 'PriorityClass',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.scheduling.v1.PriorityClass".
@@ -5544,7 +5544,7 @@ export class KubePriorityClassList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'scheduling.k8s.io/v1',
     kind: 'PriorityClassList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.scheduling.v1.PriorityClassList".
@@ -5598,7 +5598,7 @@ export class KubeCsiDriver extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSIDriver',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSIDriver".
@@ -5652,7 +5652,7 @@ export class KubeCsiDriverList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSIDriverList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSIDriverList".
@@ -5706,7 +5706,7 @@ export class KubeCsiNode extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSINode',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSINode".
@@ -5760,7 +5760,7 @@ export class KubeCsiNodeList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSINodeList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSINodeList".
@@ -5822,7 +5822,7 @@ export class KubeCsiStorageCapacity extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSIStorageCapacity',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSIStorageCapacity".
@@ -5876,7 +5876,7 @@ export class KubeCsiStorageCapacityList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'CSIStorageCapacityList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.CSIStorageCapacityList".
@@ -5932,7 +5932,7 @@ export class KubeStorageClass extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'StorageClass',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.StorageClass".
@@ -5986,7 +5986,7 @@ export class KubeStorageClassList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'StorageClassList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.StorageClassList".
@@ -6042,7 +6042,7 @@ export class KubeVolumeAttachment extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'VolumeAttachment',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.VolumeAttachment".
@@ -6096,7 +6096,7 @@ export class KubeVolumeAttachmentList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1',
     kind: 'VolumeAttachmentList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1.VolumeAttachmentList".
@@ -6158,7 +6158,7 @@ export class KubeCsiStorageCapacityV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1beta1',
     kind: 'CSIStorageCapacity',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1beta1.CSIStorageCapacity".
@@ -6212,7 +6212,7 @@ export class KubeCsiStorageCapacityListV1Beta1 extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'storage.k8s.io/v1beta1',
     kind: 'CSIStorageCapacityList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.api.storage.v1beta1.CSIStorageCapacityList".
@@ -6266,7 +6266,7 @@ export class KubeCustomResourceDefinition extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apiextensions.k8s.io/v1',
     kind: 'CustomResourceDefinition',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinition".
@@ -6320,7 +6320,7 @@ export class KubeCustomResourceDefinitionList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apiextensions.k8s.io/v1',
     kind: 'CustomResourceDefinitionList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionList".
@@ -6374,7 +6374,7 @@ export class KubeStatus extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'v1',
     kind: 'Status',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.apimachinery.pkg.apis.meta.v1.Status".
@@ -6428,7 +6428,7 @@ export class KubeApiService extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apiregistration.k8s.io/v1',
     kind: 'APIService',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService".
@@ -6482,7 +6482,7 @@ export class KubeApiServiceList extends ApiObject {
   public static readonly GVK: GroupVersionKind = {
     apiVersion: 'apiregistration.k8s.io/v1',
     kind: 'APIServiceList',
-  }
+  };
 
   /**
    * Renders a Kubernetes manifest for "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceList".

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -1,6 +1,7 @@
 import { ApiObject } from 'cdk8s';
 import { Construct } from 'constructs';
 import * as base from './base';
+import { EnvValue, EnvValueFromSecretOptions } from './container';
 import * as k8s from './imports/k8s';
 import * as serviceaccount from './service-account';
 
@@ -42,7 +43,7 @@ export interface SecretProps extends CommonSecretProps {
 }
 
 export interface ISecret extends base.IResource {
-
+  envValue(key: string, options?: EnvValueFromSecretOptions): EnvValue;
 }
 
 /**
@@ -83,6 +84,10 @@ class ImportedSecret extends Construct implements ISecret {
 
   public get kind(): string {
     return k8s.KubeSecret.GVK.kind;
+  }
+
+  envValue(key: string, options?: EnvValueFromSecretOptions): EnvValue {
+    return EnvValue.fromSecretValue({ secret: this, key }, options);
   }
 
 }
@@ -147,6 +152,10 @@ export class Secret extends base.Resource implements ISecret {
    */
   public getStringData(key: string): string | undefined {
     return this.stringData[key];
+  }
+
+  envValue(key: string, options?: EnvValueFromSecretOptions): EnvValue {
+    return EnvValue.fromSecretValue({ secret: this, key }, options);
   }
 }
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -43,6 +43,11 @@ export interface SecretProps extends CommonSecretProps {
 }
 
 export interface ISecret extends base.IResource {
+  /**
+   * Returns EnvValue object from a secret's key.
+   * @param key Secret's key
+   * @param options Additional EnvValue options
+   */
   envValue(key: string, options?: EnvValueFromSecretOptions): EnvValue;
 }
 

--- a/src/secret.ts
+++ b/src/secret.ts
@@ -97,7 +97,7 @@ class ImportedSecret extends Construct implements ISecret {
     return this.name;
   }
 
-  envValue(key: string, options?: EnvValueFromSecretOptions): EnvValue {
+  public envValue(key: string, options?: EnvValueFromSecretOptions): EnvValue {
     return EnvValue.fromSecretValue({ secret: this, key }, options);
   }
 
@@ -165,7 +165,7 @@ export class Secret extends base.Resource implements ISecret {
     return this.stringData[key];
   }
 
-  envValue(key: string, options?: EnvValueFromSecretOptions): EnvValue {
+  public envValue(key: string, options?: EnvValueFromSecretOptions): EnvValue {
     return EnvValue.fromSecretValue({ secret: this, key }, options);
   }
 }

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -47,7 +47,7 @@ describe('EnvValue', () => {
     });
   });
 
-  test('Can be created from secret.envValue', () => {
+  test('Can be created from ISecret.envValue', () => {
     const chart = Testing.chart();
 
     const actual = kplus.Secret.fromSecretName(chart, 'Secret', 'Secret').envValue('my-key', { optional: false });
@@ -58,6 +58,21 @@ describe('EnvValue', () => {
         key: 'my-key',
         name: 'Secret',
         optional: false,
+      },
+    });
+  });
+
+  test('Can be created from new secret.envValue', () => {
+    const chart = Testing.chart();
+
+    const actual = new kplus.Secret(chart, 'Secret', { stringData: { 'my-key': 'my-value' } }).envValue('my-key', { optional: true });
+
+    expect(actual.value).toBeUndefined();
+    expect(actual.valueFrom).toEqual({
+      secretKeyRef: {
+        key: 'my-key',
+        name: 'test-secret-c837fa76',
+        optional: true,
       },
     });
   });

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -47,6 +47,21 @@ describe('EnvValue', () => {
     });
   });
 
+  test('Can be created from secret.envValue', () => {
+    const chart = Testing.chart();
+
+    const actual = kplus.Secret.fromSecretName(chart, 'Secret', 'Secret').envValue('my-key', { optional: false });
+
+    expect(actual.value).toBeUndefined();
+    expect(actual.valueFrom).toEqual({
+      secretKeyRef: {
+        key: 'my-key',
+        name: 'Secret',
+        optional: false,
+      },
+    });
+  });
+
   test('Cannot be created from missing required process env', () => {
 
     const key = 'cdk8s-plus.tests.container.env.fromProcess';


### PR DESCRIPTION
Signed-off-by: Yair Fried <5310525+yfried@users.noreply.github.com>

Add a shorter and more OO way to extract secret value as env

```typescript
env={"VARNAME": kplus.EnvValue.fromSecretValue({secret: mysecret, key: "mykey"}), ...}
```
```python
env={"VARNAME": kplus.EnvValue.from_secret_value(
                                       secret_value=kplus.SecretValue(secret=mysecret,
                                                                      key="mykey")), ...}
```

do 

```typescript
env={"VARNAME": mysecret.envValue("mykey"), ...}
```

```python
env={"VARNAME": mysecret.env_value(key="mykey"), ...}
```
