### PR TITLE
chore: backport action is failing due to node version

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
       - closed
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -127,7 +127,7 @@ for (const spec of [LATEST_SUPPORTED_K8S_VERSION - 1, LATEST_SUPPORTED_K8S_VERSI
 const backportWorkflow = project.github!.addWorkflow('backport');
 backportWorkflow.on({ pullRequestTarget: { types: ['closed'] } });
 backportWorkflow.addJob('backport', {
-  runsOn: ['ubuntu-18.04'],
+  runsOn: ['ubuntu-latest'],
   permissions: {
     contents: JobPermission.WRITE,
   },


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/6002