### PR TITLE
feat(pod): allow passing an existing secret to `dockerRegistryAuth`

### DIFF
--- a/src/pod.ts
+++ b/src/pod.ts
@@ -17,7 +17,7 @@ export abstract class AbstractPod extends base.Resource implements IPodSelector,
   public readonly serviceAccount?: serviceaccount.IServiceAccount;
   public readonly securityContext: PodSecurityContext;
   public readonly dns: PodDns;
-  public readonly dockerRegistryAuth?: secret.DockerConfigSecret;
+  public readonly dockerRegistryAuth?: secret.ISecret;
   public readonly automountServiceAccountToken: boolean;
 
   protected readonly isolate: boolean;
@@ -410,7 +410,7 @@ export interface AbstractPodProps extends base.ResourceProps {
    *
    * @default - No auth. Images are assumed to be publicly available.
    */
-  readonly dockerRegistryAuth?: secret.DockerConfigSecret;
+  readonly dockerRegistryAuth?: secret.ISecret;
 
   /**
    * Indicates whether a service account token should be automatically mounted.

--- a/test/__snapshots__/pod.test.ts.snap
+++ b/test/__snapshots__/pod.test.ts.snap
@@ -1,5 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`can pass an existing secret as the docker auth 1`] = `
+Array [
+  Object {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": Object {
+      "labels": Object {
+        "cdk8s.io/metadata.addr": "test-Pod-c815bc91",
+      },
+      "name": "test-pod-c890e1b8",
+    },
+    "spec": Object {
+      "automountServiceAccountToken": false,
+      "containers": Array [
+        Object {
+          "image": "image",
+          "imagePullPolicy": "Always",
+          "name": "main",
+          "resources": Object {
+            "limits": Object {
+              "cpu": "1500m",
+              "memory": "2048Mi",
+            },
+            "requests": Object {
+              "cpu": "1000m",
+              "memory": "512Mi",
+            },
+          },
+          "securityContext": Object {
+            "allowPrivilegeEscalation": false,
+            "privileged": false,
+            "readOnlyRootFilesystem": true,
+            "runAsNonRoot": true,
+          },
+        },
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "imagePullSecrets": Array [
+        Object {
+          "name": "scw-registry-secret",
+        },
+      ],
+      "restartPolicy": "Always",
+      "securityContext": Object {
+        "fsGroupChangePolicy": "Always",
+        "runAsNonRoot": true,
+      },
+      "setHostnameAsFQDN": false,
+    },
+  },
+]
+`;
+
 exports[`can select pods 1`] = `
 Object {
   "matchExpressions": Array [

--- a/test/pod.test.ts
+++ b/test/pod.test.ts
@@ -1478,3 +1478,18 @@ describe('permissions', () => {
   });
 
 });
+
+test('can pass an existing secret as the docker auth', () => {
+
+  const chart = Testing.chart();
+
+  const registrySecret = kplus.Secret.fromSecretName(chart, 'RegistrySecret', 'scw-registry-secret');
+
+  new kplus.Pod(chart, 'Pod', {
+    containers: [{ image: 'image' }],
+    dockerRegistryAuth: registrySecret,
+  });
+
+  expect(Testing.synth(chart)).toMatchSnapshot();
+
+});


### PR DESCRIPTION
Fixes https://github.com/cdk8s-team/cdk8s-plus/issues/1784