### PR TITLE
chore: decouple optional and required properties for a container

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -494,13 +494,18 @@ export interface ContainerLifecycle {
 /**
  * Properties for creating a container.
  */
-export interface ContainerProps {
+export interface ContainerProps extends ContainerOpts {
 
   /**
    * Docker image name.
    */
   readonly image: string;
+}
 
+/**
+ * Optional properties of a container.
+ */
+export interface ContainerOpts {
   /**
    * Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
    *


### PR DESCRIPTION
This simple PR decouples the optional properties of a container from the required ones.

Rationale:

We use this library in combination with CDK's capabilities to handle compiling, bundling and uploading images to ECR. In which case we expect our users to provide all other properties of a container but the `image` property which is abstracted away.