### PR TITLE
fix: npm releases failing to generate provenance

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -72,6 +72,8 @@ const project = new Cdk8sTeamJsiiProject({
 // Used in K8s upgrade tests to control publishing of new branches
 project.package.addField('private', false);
 
+// not using `npmAccess` property because projen omits values that are
+// identical to npm defaults.
 project.package.addField('publishConfig', { access: 'public' });
 
 project.gitignore.exclude('.vscode/');

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -72,6 +72,8 @@ const project = new Cdk8sTeamJsiiProject({
 // Used in K8s upgrade tests to control publishing of new branches
 project.package.addField('private', false);
 
+project.package.addField('publishConfig', { access: 'public' });
+
 project.gitignore.exclude('.vscode/');
 
 const importdir = path.join('src', 'imports');

--- a/package.json
+++ b/package.json
@@ -107,6 +107,9 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [


### PR DESCRIPTION
We are [seeing](https://github.com/cdk8s-team/cdk8s-plus/actions/runs/8081657712/job/22080844284) the following error in NPM releases: 

```console
npm ERR! Can't generate provenance for new or private package, you must set `access` to public.
```

As of Feb 14, projen [has started](https://github.com/projen/projen/pull/3330) [generating provenance statements](https://docs.npmjs.com/generating-provenance-statements) for NPM releases (on by default for public packages). 
It is not clear why we are seeing the failure above because `access` should be `public` by default for public packages.
My suspicion is that for the very first version of a package, `access` must be explicitly set. Trying this out. 