### PR TITLE
fix(container): enhance Capability enum with ALL cap

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -12,6 +12,10 @@ import * as volume from './volume';
  */
 export enum Capability {
   /**
+   * ALL
+   */
+  ALL = 'ALL',
+  /**
    * CAP_AUDIT_CONTROL
    */
   AUDIT_CONTROL = 'CAP_AUDIT_CONTROL',


### PR DESCRIPTION
Fixes #3817 by enhancing Capability enum.

It is possible to drop/add all capabilities by using `ALL` instead of explicitly giving all caps:

```yaml
securityContext:
  capabilities:
    drop:
      - ALL
    add: [“NET_ADMIN”]
```