### PR TITLE
fix: revert jsii-docgen to produce smaller docs (#4594)

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -79,7 +79,7 @@
     },
     {
       "name": "jsii-docgen",
-      "version": "^10.5.0",
+      "version": "^3.8.31",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -82,6 +82,7 @@ const importTask = project.addTask('import', {
 });
 project.compileTask.prependSpawn(importTask);
 
+project.addDevDeps('jsii-docgen@^3.8.31');
 const docgenTask = project.tasks.tryFind('docgen')!;
 docgenTask.reset();
 for (const lang of ['typescript', 'python', 'java']) {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "jest-junit": "^15",
     "jsii": "1.x",
     "jsii-diff": "^1.103.0",
-    "jsii-docgen": "^10.5.0",
+    "jsii-docgen": "^3.8.31",
     "jsii-pacmak": "^1.103.0",
     "jsii-rosetta": "1.x",
     "projen": "^0.86.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,7 +627,7 @@
     chalk "^4.1.2"
     semver "^7.6.3"
 
-"@jsii/spec@1.103.0", "@jsii/spec@^1.102.0", "@jsii/spec@^1.103.0":
+"@jsii/spec@1.103.0", "@jsii/spec@^1.102.0", "@jsii/spec@^1.103.0", "@jsii/spec@^1.44.0":
   version "1.103.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.103.0.tgz#a0cfe50d03b773eaa3c57b23e501599ebaf6444e"
   integrity sha512-SLKkITTr6d2wSMCC/HITBNLwBcwz6PStV83oZpM98SDtyNHDbpLNlkwS5m8DpmP+ufMqgI6IvgF7iiyrwz8DRg==
@@ -900,6 +900,14 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/glob@*":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.1.0.tgz#b63e70155391b0584dce44e7ea25190bbc38f2fc"
+  integrity sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==
+  dependencies:
+    "@types/minimatch" "^5.1.2"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
@@ -943,6 +951,11 @@
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
+"@types/minimatch@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimist@^1.2.0":
   version "1.2.5"
@@ -2979,7 +2992,7 @@ forwarded-parse@^2.1.0:
   resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz#08511eddaaa2ddfd56ba11138eee7df117a09325"
   integrity sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==
 
-fs-extra@^10.1.0:
+fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -3133,10 +3146,12 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-promise@^6.0.7:
-  version "6.0.7"
-  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-6.0.7.tgz#6d894212c63a42e1b86d1cbb04f4582b658308e4"
-  integrity sha512-DEAe6br1w8ZF+y6KM2pzgdfhpreladtNvyNNVgSkxxkFWzXTJFXxQrJQQbAnc7kL0EUd7w5cR8u4K0P4+/q+Gw==
+glob-promise@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-3.4.0.tgz#b6b8f084504216f702dc2ce8c9bc9ac8866fdb20"
+  integrity sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==
+  dependencies:
+    "@types/glob" "*"
 
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
   version "7.2.3"
@@ -3150,7 +3165,7 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8, glob@^8.1.0:
+glob@^8:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -4283,18 +4298,19 @@ jsii-diff@^1.103.0:
     log4js "^6.9.1"
     yargs "^16.2.0"
 
-jsii-docgen@^10.5.0:
-  version "10.5.1"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-10.5.1.tgz#b96a49bd8a317dfbe75ed5acc648083f44b10f53"
-  integrity sha512-NTDejLbHOAMHvK7WZFSI8QMyPNZ0/fwsK9RW8Hdvb0KtZZ2ol54rIcE9Y+0J5KaNRdgYsoiHCMr04c48dnFGNA==
+jsii-docgen@^3.8.31:
+  version "3.8.31"
+  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-3.8.31.tgz#f04bbabbb008763151e498687454266e4cbb3c4e"
+  integrity sha512-Tkx7PNEIXc1/g6BZXGkhTp4LNvx5+IcQZpjsn7Y2qTDS79ikvjIB+yNFdgPpMQ/dq2sWXQjmQSuGBwkFoRZfiw==
   dependencies:
-    "@jsii/spec" "^1.102.0"
+    "@jsii/spec" "^1.44.0"
     case "^1.6.3"
-    fs-extra "^10.1.0"
-    glob "^8.1.0"
-    glob-promise "^6.0.7"
-    jsii-reflect "^1.102.0"
-    semver "^7.6.3"
+    fs-extra "^10.0.0"
+    glob "^7.2.0"
+    glob-promise "^3.4.0"
+    jsii-reflect "^1.44.0"
+    jsii-rosetta "^1.44.0"
+    semver "^7.3.5"
     yargs "^16.2.0"
 
 jsii-pacmak@^1.103.0:
@@ -4315,7 +4331,7 @@ jsii-pacmak@^1.103.0:
     xmlbuilder "^15.1.1"
     yargs "^16.2.0"
 
-jsii-reflect@^1.102.0, jsii-reflect@^1.103.0:
+jsii-reflect@^1.103.0, jsii-reflect@^1.44.0:
   version "1.103.0"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.103.0.tgz#4390b3d6d3ac1ab79f58f8663f4e083b56099b8f"
   integrity sha512-L6sV0zVWDvlMbNY6vFmtfZsmMHHtd+TlefP+R/8y6puZf2eA+rh5W9SpmX+q1xHwZ7ohRsXt9S7nONiEgv7F3g==
@@ -4327,7 +4343,7 @@ jsii-reflect@^1.102.0, jsii-reflect@^1.103.0:
     oo-ascii-tree "^1.103.0"
     yargs "^16.2.0"
 
-jsii-rosetta@1.x:
+jsii-rosetta@1.x, jsii-rosetta@^1.44.0:
   version "1.103.0"
   resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.103.0.tgz#2bfb7f5e135493710db133a1a68e5847cbd2420e"
   integrity sha512-+sTS43/oMvwHKTX8kXks3Tb5xbGkndBCmI5toR5Ad/QYC6SvHZQplUTRbp0EX2sHnCoBt+q/TRfq0wODkdYZmA==
@@ -5647,7 +5663,7 @@ semver-intersect@^1.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.x, semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.5.3, semver@^7.6.0, semver@^7.6.3:
+semver@7.x, semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.5.3, semver@^7.6.0, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==


### PR DESCRIPTION
# Backport

This will backport the following commits from `k8s-30/main` to `k8s-29/main`:
 - [fix: revert jsii-docgen to produce smaller docs (#4594)](https://github.com/cdk8s-team/cdk8s-plus/pull/4594)

<!--- Backport version: 8.9.9 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)