### PR TITLE
fix: `import` task running un-necessary during build

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -89,9 +89,6 @@
       "description": "Only compile",
       "steps": [
         {
-          "spawn": "import"
-        },
-        {
           "exec": "jsii --silence-warnings=reserved-word"
         }
       ]

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -80,11 +80,10 @@ project.gitignore.exclude('.vscode/');
 
 const importdir = path.join('src', 'imports');
 
-const importTask = project.addTask('import', {
+project.addTask('import', {
   exec: `cdk8s -l typescript -o ${importdir} import k8s@${K8S_VERSION}`,
   description: 'Updates imports based on latest version of cdk8s-cli.',
 });
-project.compileTask.prependSpawn(importTask);
 
 project.addDevDeps('jsii-docgen@^3.8.31');
 // because jsii-docgen is so outdated, it accidentally introduces a transitive dependency on the broken @types/glob@9

--- a/rotate.md
+++ b/rotate.md
@@ -47,8 +47,9 @@ The new branch should be named `k8s-XX/main` (e.g. `k8s-25/main` for K8s v1.25.0
      2. ([`README.md`](./README.md)): In the table of supported versions, add a new row and remove the oldest one.
      3. `yarn projen`
      4. `yarn rotate` # updates all version references in documenation
-     5. `yarn build`
-     6. Create a PR to the `k8s-XX/main` branch. (See [example](https://github.com/cdk8s-team/cdk8s-plus/pull/4260)).
+     5. `yarn run import` # codegen the k8s imports file based on the new schema.
+     6. `yarn build`
+     7. Create a PR to the `k8s-XX/main` branch. (See [example](https://github.com/cdk8s-team/cdk8s-plus/pull/4260)).
 
 8. Wait for the PR above to be merged and verify that automation builds/tags/releases the new version successfully.
 


### PR DESCRIPTION
The `import` task generates TypeScript code based on the corresponding k8s schema, that code is generated once whenever we release a new flavor of the library. We then push it to source control in [k8s.ts](https://github.com/cdk8s-team/cdk8s-plus/blob/k8s-33/main/src/imports/k8s.ts) so there is no need to regenerate it on every build. 

Doing so actually introduces a chance that our published artifact differs than the one we store in source control.

The `import` task still remains if devs need to proactively updates the imports to grab a hold of new schema updates.