### PR TITLE
fix(service): Allow specifying a string in `targetPort`

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -394,7 +394,7 @@ export interface ServiceBindOptions {
    *
    * @default - The value of `port` will be used.
    */
-  readonly targetPort?: number;
+  readonly targetPort?: number | string;
 }
 
 /**


### PR DESCRIPTION
`ServicePort` did not allow users to specify a string in `targetPort` to reference a named port in the target pod's container ports.

- https://kubernetes.io/docs/reference/kubernetes-api/core/service-v1/#ServicePort
- https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports