### PR TITLE
fix(container): EnvFrom with multiple refs renders as separate envFrom entries

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -1376,16 +1376,27 @@ export class EnvFrom {
   /**
    * @internal
    */
-  public _toKube(): k8s.EnvFromSource {
-    return {
-      configMapRef: this.configMap ? {
-        name: this.configMap.name,
-      } : undefined,
-      secretRef: this.sec ? {
-        name: this.sec.name,
-      } : undefined,
-      prefix: this.prefix,
-    };
+  public _toKube(): k8s.EnvFromSource[] {
+    // a single `k8s.EnvFromSource` may only specify one of `configMapRef` / `secretRef`.
+    // if both a config map and a secret are configured on this instance, they must be
+    // rendered as separate entries, otherwise the resulting manifest is invalid.
+    const sources = new Array<k8s.EnvFromSource>();
+
+    if (this.configMap) {
+      sources.push({
+        configMapRef: { name: this.configMap.name },
+        prefix: this.prefix,
+      });
+    }
+
+    if (this.sec) {
+      sources.push({
+        secretRef: { name: this.sec.name },
+        prefix: this.prefix,
+      });
+    }
+
+    return sources;
   }
 
 }
@@ -1484,7 +1495,7 @@ export class Env {
    */
   public _toKube(): { variables?: k8s.EnvVar[]; from?: k8s.EnvFromSource[] } {
     return {
-      from: undefinedIfEmpty(this._sources.map(s => s._toKube())),
+      from: undefinedIfEmpty(this._sources.flatMap(s => s._toKube())),
       variables: undefinedIfEmpty(this.renderEnv(this._variables)),
     };
   }

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -421,6 +421,29 @@ describe('Container', () => {
 
   test('can add environment variables from a secret', () => {});
 
+  test('a single EnvFrom source with both a config map and a secret is split into separate envFrom entries', () => {
+
+    const chart = Testing.chart();
+
+    const cm = new kplus.ConfigMap(chart, 'ConfigMap');
+    const secret = new kplus.Secret(chart, 'Secret');
+
+    const envFrom = new kplus.EnvFrom(cm, 'pref', secret);
+
+    const container = new kplus.Container({
+      image: 'image',
+      envFrom: [envFrom],
+    });
+
+    const spec: k8s.Container = container._toKube();
+
+    expect(spec.envFrom).toEqual([
+      { configMapRef: { name: cm.name }, prefix: 'pref' },
+      { secretRef: { name: secret.name }, prefix: 'pref' },
+    ]);
+
+  });
+
   test('Can mount container to volume', () => {
 
     const container = new kplus.Container({


### PR DESCRIPTION
Fixes cdk8s-team/cdk8s#2295

## What was wrong

When a single `EnvFrom` instance was constructed with both a `ConfigMap` and a `Secret` (e.g. `new kplus.EnvFrom(configMap, undefined, secret)`, used directly in `container.envFrom`), `EnvFrom._toKube()` rendered them into a single `k8s.EnvFromSource` object with both `configMapRef` and `secretRef` set:

```yaml
envFrom:
  - configMapRef:
      name: cmName
    secretRef:
      name: secretName
```

Kubernetes rejects this: an `envFrom` entry may only specify one of `configMapRef` / `secretRef` (`may not have more than one field specified at a time`), so the synthesized manifest was invalid.

## What changed

- `EnvFrom._toKube()` (`src/container.ts`) now returns an array of `k8s.EnvFromSource`, emitting one entry per configured source instead of merging them into a single object.
- `Env._toKube()` was updated to `flatMap` over its sources instead of `map`, since each source can now expand to more than one rendered entry.
- Added a regression test in `test/container.test.ts` asserting that an `EnvFrom` built from both a `ConfigMap` and a `Secret` synthesizes as two separate `envFrom` entries.

The existing test for the recommended usage (`Env.fromConfigMap` / `Env.fromSecret`, each producing its own single-field `EnvFrom`) is unaffected, since each of those sources only ever has one field set.

## How it was verified

- `npx jest test/container.test.ts --coverage=false` — 48/48 passed, including the new regression test.
- `npx jest --coverage=false` (full suite) — 23 suites / 492 tests / 205 snapshots, all passed, no snapshot changes.
- `npx projen build` — compiled cleanly (`jsii`, warnings only, pre-existing/unrelated), full test suite passed with `--updateSnapshot` and produced no snapshot diffs. The `package:java` step fails locally because Maven isn't installed on this machine; that's an unrelated packaging/toolchain step, not something this change touches.
- `ESLINT_USE_FLAT_CONFIG=false npx projen eslint` — no lint errors on the touched files.